### PR TITLE
feat(env): DPDK development environment + helloworld sanity check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# InFMon
+
+In-network monitoring tooling running on NVIDIA BlueField DPUs.
+
+## Status
+
+Early bootstrap. See [`docs/dev-environment.md`](docs/dev-environment.md) for the
+DPDK development environment setup.

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -1,0 +1,135 @@
+# DPDK Development Environment
+
+This document describes the DPDK toolchain InFMon targets, how to set it up on
+an NVIDIA BlueField-3 DPU running Ubuntu 24.04 with DOCA installed, and how to
+verify the environment with the `examples/dpdk-helloworld` sanity check.
+
+## Target platform
+
+| Component | Version (verified) |
+|-----------|--------------------|
+| DPU       | NVIDIA BlueField-3 (`MT43244` ConnectX-7) |
+| OS        | Ubuntu 24.04 LTS (`aarch64`) |
+| Kernel    | 6.8.0-1016-bluefield |
+| DOCA      | 3.3 (`doca-devel` 1-3.3.0109-1) |
+| DPDK      | 25.11.0+doca2601.2 (shipped via `/opt/mellanox/dpdk`) |
+| GCC       | 13.3.0 |
+
+DPDK is installed by the DOCA stack. Headers, libraries and the `dpdk-*`
+helper binaries live under `/opt/mellanox/dpdk/`. Build flags are exposed via
+pkg-config:
+
+```
+/opt/mellanox/dpdk/lib/aarch64-linux-gnu/pkgconfig/libdpdk.pc
+```
+
+## Host packages
+
+DOCA does not pull in the toolchain itself. Install the build essentials once
+per machine:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    pkg-config \
+    meson ninja-build \
+    python3-pyelftools \
+    libnuma-dev
+```
+
+`meson` / `ninja` are only required if you plan to build DPDK itself or any
+DPDK-based project that uses meson. The `examples/dpdk-helloworld` sanity check
+uses plain `make` + `pkg-config` and works without them.
+
+## Hugepages
+
+DPDK requires hugepages. The BlueField kernel exposes three sizes
+(`/sys/kernel/mm/hugepages/hugepages-{2048,524288,16777216}kB`). For
+development we use 2 MiB pages because they are easy to reserve at runtime
+without a reboot.
+
+Reserve 1024 × 2 MiB pages (2 GiB) and mount a hugetlbfs that DPDK can target:
+
+```bash
+echo 1024 | sudo tee /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
+sudo mkdir -p /mnt/huge-2M
+sudo mount -t hugetlbfs -o pagesize=2M nodev /mnt/huge-2M
+```
+
+> The default `/dev/hugepages` mount on this image uses 512 MiB pages and has
+> zero pages reserved, so DPDK falls back to `--no-huge` or fails. Always
+> point DPDK at `/mnt/huge-2M` with `--huge-dir /mnt/huge-2M` until persistent
+> reservations are configured (`/etc/fstab` + kernel cmdline).
+
+To make the reservation persist across reboots, add to `/etc/fstab`:
+
+```
+nodev  /mnt/huge-2M  hugetlbfs  pagesize=2M  0 0
+```
+
+and add `default_hugepagesz=2M hugepagesz=2M hugepages=1024` to the kernel
+cmdline.
+
+## NIC inventory
+
+Confirm the DPU NICs are visible to DPDK tooling:
+
+```bash
+/opt/mellanox/dpdk/bin/dpdk-devbind.py --status-dev net
+```
+
+Expected on a BlueField-3 (both ports bound to `mlx5_core`, which is what
+DPDK's `mlx5` PMD wants — no `vfio-pci` rebind needed):
+
+```
+0000:03:00.0 'BlueField-3 ... ConnectX-7' drv=mlx5_core
+0000:03:00.1 'BlueField-3 ... ConnectX-7' drv=mlx5_core
+```
+
+## Sanity check
+
+A minimal helloworld lives under [`examples/dpdk-helloworld`](../examples/dpdk-helloworld).
+It links against DPDK via `pkg-config`, initialises the EAL on two lcores and
+prints the runtime version.
+
+```bash
+cd examples/dpdk-helloworld
+make
+make run        # uses sudo + /mnt/huge-2M + --no-pci
+```
+
+Expected output (abridged):
+
+```
+EAL: Detected CPU lcores: 16
+EAL: Detected NUMA nodes: 1
+EAL: Selected IOVA mode 'VA'
+DPDK 25.11.0+doca2601 — EAL initialised, 2 lcore(s) enabled
+  lcore 1 alive on socket 0
+  lcore 0 alive on socket 0
+```
+
+If you see this, the development environment is ready.
+
+## Build flag cheat sheet
+
+For projects that aren't bundled with InFMon, the canonical way to consume
+DOCA-shipped DPDK is:
+
+```bash
+export PKG_CONFIG_PATH=/opt/mellanox/dpdk/lib/aarch64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
+pkg-config --cflags libdpdk
+pkg-config --libs   libdpdk
+```
+
+Drop those into `CFLAGS` / `LDFLAGS` and you're done.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `EAL: Cannot get hugepage information` | No hugepages reserved or wrong dir | Reserve pages, pass `--huge-dir /mnt/huge-2M` |
+| `cannot find -lrte_*` at link time | Wrong pkg-config path | `export PKG_CONFIG_PATH=/opt/mellanox/dpdk/lib/aarch64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH` |
+| `undefined reference to rte_panic` | Missing `<rte_debug.h>` include | Include `<rte_debug.h>` (and `<rte_launch.h>` for `rte_eal_remote_launch`) |
+| Permission denied on `/dev/hugepages` | DPDK launched as non-root | Run with `sudo` or grant your user `CAP_SYS_NICE` + hugetlbfs group |

--- a/examples/dpdk-helloworld/.gitignore
+++ b/examples/dpdk-helloworld/.gitignore
@@ -1,0 +1,2 @@
+dpdk-helloworld
+*.o

--- a/examples/dpdk-helloworld/Makefile
+++ b/examples/dpdk-helloworld/Makefile
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Minimal DPDK helloworld build.
+# Uses pkg-config to pull DPDK CFLAGS/LDFLAGS from the DOCA-installed libdpdk.pc.
+#
+# Usage:
+#   make            # build ./dpdk-helloworld
+#   make run        # run the sanity check (needs hugepages + sudo)
+#   make clean
+
+PKG_CONFIG ?= pkg-config
+DPDK_PC_PATH ?= /opt/mellanox/dpdk/lib/aarch64-linux-gnu/pkgconfig
+export PKG_CONFIG_PATH := $(DPDK_PC_PATH):$(PKG_CONFIG_PATH)
+
+APP := dpdk-helloworld
+SRCS := main.c
+
+CFLAGS  += -O2 -Wall -Wextra
+CFLAGS  += $(shell $(PKG_CONFIG) --cflags libdpdk)
+LDFLAGS += $(shell $(PKG_CONFIG) --libs   libdpdk)
+
+$(APP): $(SRCS)
+	$(CC) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+
+.PHONY: run clean
+run: $(APP)
+	sudo ./$(APP) -l 0-1 --huge-dir /mnt/huge-2M --no-pci
+
+clean:
+	rm -f $(APP)

--- a/examples/dpdk-helloworld/README.md
+++ b/examples/dpdk-helloworld/README.md
@@ -1,0 +1,15 @@
+# DPDK helloworld
+
+Minimal DPDK sanity check used to verify the DPU development environment.
+
+See [`docs/dev-environment.md`](../../docs/dev-environment.md) for the full
+setup. Quickstart:
+
+```bash
+make            # build ./dpdk-helloworld
+make run        # sudo + /mnt/huge-2M + --no-pci
+make clean
+```
+
+Expected output: EAL initialises, two lcores print "alive on socket 0", and
+the DPDK version is logged.

--- a/examples/dpdk-helloworld/main.c
+++ b/examples/dpdk-helloworld/main.c
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Minimal DPDK environment sanity check.
+ * Initialises EAL, prints version + lcore layout, then exits cleanly.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <rte_eal.h>
+#include <rte_debug.h>
+#include <rte_lcore.h>
+#include <rte_launch.h>
+#include <rte_version.h>
+
+static int
+lcore_hello(void *arg)
+{
+	(void)arg;
+	printf("  lcore %u alive on socket %u\n",
+	       rte_lcore_id(), rte_socket_id());
+	return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+	int ret = rte_eal_init(argc, argv);
+	if (ret < 0)
+		rte_panic("Cannot init EAL\n");
+
+	printf("DPDK %s — EAL initialised, %u lcore(s) enabled\n",
+	       rte_version(), rte_lcore_count());
+
+	unsigned lcore_id;
+	RTE_LCORE_FOREACH_WORKER(lcore_id)
+		rte_eal_remote_launch(lcore_hello, NULL, lcore_id);
+
+	lcore_hello(NULL);
+	rte_eal_mp_wait_lcore();
+
+	rte_eal_cleanup();
+	return 0;
+}


### PR DESCRIPTION
## Summary

Bootstraps the InFMon repo for DPU development on top of NVIDIA BlueField-3 +
DOCA-shipped DPDK 25.11.

- **`docs/dev-environment.md`** — full setup guide: target platform table,
  required apt packages, hugepage reservation, hugetlbfs mount workaround
  (the default mount uses 512 MiB pages with zero reservations), NIC
  inventory check, pkg-config wiring against `/opt/mellanox/dpdk`, and a
  troubleshooting table covering the gotchas hit during validation.
- **`examples/dpdk-helloworld/`** — minimal C program that initialises EAL on
  two lcores and prints DPDK version + lcore layout. Built with plain
  `make` + `pkg-config` (no meson dependency). Doubles as the canonical
  smoke test: if `make run` works, the env is good.
- **`README.md`** — top-level pointer.

## Verification

Ran on `bf3` (BlueField-3, Ubuntu 24.04, DOCA 3.3):

```
$ cd examples/dpdk-helloworld && make && make run
...
DPDK 25.11.0+doca2601 — EAL initialised, 2 lcore(s) enabled
  lcore 1 alive on socket 0
  lcore 0 alive on socket 0
```

Closes DPU-1.