### PR TITLE
chore: bootstrap repository scaffolding (DPU-5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # ---------------------------------------------------------------------------
 # Rust
 # ---------------------------------------------------------------------------
+# Cargo.lock policy: this repository will host both binary and library crates.
+# Convention: check in `Cargo.lock` for binaries, ignore for libraries. Today
+# we have no published library crates, so `Cargo.lock` is committed. Update
+# this comment (and the ignore list) when that changes.
 target/
 **/*.rs.bk
 Cargo.lock.bak
@@ -85,8 +89,20 @@ vpp-api/
 Thumbs.db
 
 # ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+.venv/
+venv/
+env/
+__pycache__/
+*.pyc
+*.pyo
+
+# ---------------------------------------------------------------------------
 # Logs / coverage / misc
 # ---------------------------------------------------------------------------
+# Note: blanket `*.log` is intentional today; if/when we add log fixtures
+# under tests/, add a more specific un-ignore (e.g. `!tests/fixtures/**/*.log`).
 *.log
 *.gcda
 *.gcno

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,95 @@
+# ---------------------------------------------------------------------------
+# Rust
+# ---------------------------------------------------------------------------
+target/
+**/*.rs.bk
+Cargo.lock.bak
+*.pdb
+
+# ---------------------------------------------------------------------------
+# C / C++
+# ---------------------------------------------------------------------------
+# Object / archive / shared lib artifacts
+*.o
+*.obj
+*.ko
+*.a
+*.la
+*.lo
+*.lib
+*.so
+*.so.*
+*.dylib
+*.dll
+*.exp
+*.ilk
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Debug info
+*.dSYM/
+*.su
+*.idb
+
+# Precompiled headers
+*.gch
+*.pch
+
+# Dependency files
+*.d
+
+# Build trees
+build/
+build-*/
+cmake-build-*/
+CMakeCache.txt
+CMakeFiles/
+CMakeScripts/
+cmake_install.cmake
+install_manifest.txt
+Makefile.in
+.deps/
+.libs/
+autom4te.cache/
+config.log
+config.status
+configure.scan
+
+# ---------------------------------------------------------------------------
+# VPP build artifacts
+# ---------------------------------------------------------------------------
+build-root/
+build-data/
+install-*/
+*.deb
+*.rpm
+vpp-api/
+.ccache/
+*.api.json
+*.api.h
+*.api.c
+*_test.api.vapi.json
+
+# ---------------------------------------------------------------------------
+# Editors / OS
+# ---------------------------------------------------------------------------
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# ---------------------------------------------------------------------------
+# Logs / coverage / misc
+# ---------------------------------------------------------------------------
+*.log
+*.gcda
+*.gcno
+*.gcov
+coverage/
+lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.gitignore` for Rust, C/C++, and VPP build artifacts.
 - This `CHANGELOG.md` (Keep a Changelog format).
 
-[Unreleased]: https://github.com/r12f/InFMon/compare/HEAD...HEAD
+<!-- TODO: replace with a real diff link (e.g. compare/v0.1.0...HEAD) once the
+     first version is tagged. `compare/HEAD...HEAD` would always render an
+     empty diff, so it is intentionally omitted here. -->
+[Unreleased]: https://github.com/r12f/InFMon/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial repository scaffolding.
+- Apache-2.0 `LICENSE`.
+- `README.md` with high-level project description and link to `specs/`.
+- `CODEOWNERS` requiring review from `@banidoru` on all paths.
+- Top-level layout: `specs/`, `src/{infmon-backend,infmon-frontend,infmon-cli}/`, `tests/`.
+- `.gitignore` for Rust, C/C++, and VPP build artifacts.
+- This `CHANGELOG.md` (Keep a Changelog format).
+
+[Unreleased]: https://github.com/r12f/InFMon/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.gitignore` for Rust, C/C++, and VPP build artifacts.
 - This `CHANGELOG.md` (Keep a Changelog format).
 
-[Unreleased]: https://github.com/r12f/InFMon/commits/main
+[Unreleased]: https://github.com/r12f/InFMon/compare/HEAD...HEAD

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# InFMon code owners
+#
+# @banidoru is the required reviewer on every path in this repository.
+# Add more specific rules below as the codebase grows; later rules take
+# precedence over earlier ones in GitHub's CODEOWNERS resolution.
+
+* @banidoru

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,10 @@
 # precedence over earlier ones in GitHub's CODEOWNERS resolution.
 
 * @banidoru
+
+# TODO: As the codebase grows and dedicated teams form, split ownership
+# per-component. Examples (uncomment and adjust when applicable):
+#   src/infmon-backend/  @backend-team
+#   src/infmon-frontend/ @frontend-team
+#   src/infmon-cli/      @cli-team
+#   specs/               @architecture-team

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 InFMon Authors
+   Copyright (c) InFMon Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept and charge a
+      fee for the acceptance of support, warranty, indemnity, or other
+      liability obligations and/or rights consistent with this License.
+      However, in accepting such obligations, You may act only on Your
+      own behalf and on Your sole responsibility, not on behalf of any
+      other Contributor, and only if You agree to indemnify, defend,
+      and hold each Contributor harmless for any liability incurred by,
+      or claims asserted against, such Contributor by reason of your
+      accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 InFMon Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# InFMon
+
+**InFMon** (Infrastructure / In-network Flow Monitor) is a high-performance
+network flow monitoring system built around a VPP-based dataplane with a
+Rust control plane, frontend UI, and CLI tooling.
+
+This repository hosts the full stack:
+
+- **infmon-backend** — control plane / dataplane glue (Rust + C/C++ for VPP plugins).
+- **infmon-frontend** — operator-facing web UI.
+- **infmon-cli** — command-line client for operators and automation.
+
+## Status
+
+🚧 Early scaffolding. APIs, schemas, and component boundaries are still
+being defined under [`specs/`](./specs/). Expect breaking changes.
+
+## Repository layout
+
+```
+.
+├── specs/                  Design specs, RFCs, and protocol documents
+├── src/
+│   ├── infmon-backend/     Backend (control plane + dataplane integration)
+│   ├── infmon-frontend/    Web UI
+│   └── infmon-cli/         Command-line client
+├── tests/                  Integration / end-to-end tests
+├── CHANGELOG.md            Release notes (Keep a Changelog format)
+├── CODEOWNERS              Required reviewers
+└── LICENSE                 Apache-2.0
+```
+
+## Specs
+
+Detailed design lives under [`specs/`](./specs/). Start there to understand
+the architecture, data model, and component contracts before contributing
+code.
+
+## Building
+
+Build instructions per component will land alongside each component's
+initial implementation. See the README inside each `src/<component>/`
+directory once available.
+
+## Contributing
+
+1. Open or pick up an issue.
+2. Branch from `main`.
+3. Submit a PR — all changes require review from a code owner
+   (see [`CODEOWNERS`](./CODEOWNERS)) and must pass required CI checks.
+4. Sign off your commits (`git commit -s`).
+
+## License
+
+Licensed under the [Apache License, Version 2.0](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ This repository hosts the full stack:
 
 🚧 Early scaffolding. APIs, schemas, and component boundaries are still
 being defined under [`specs/`](./specs/). Expect breaking changes. Roadmap
-and active work are tracked in [GitHub Issues](https://github.com/r12f/InFMon/issues)
-(see the bootstrap issue [DPU-5](https://github.com/r12f/InFMon/issues)).
+and active work are tracked in
+[GitHub Issues](https://github.com/r12f/InFMon/issues).
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This repository hosts the full stack:
 ## Status
 
 🚧 Early scaffolding. APIs, schemas, and component boundaries are still
-being defined under [`specs/`](./specs/). Expect breaking changes.
+being defined under [`specs/`](./specs/). Expect breaking changes. Roadmap
+and active work are tracked in [GitHub Issues](https://github.com/r12f/InFMon/issues)
+(see the bootstrap issue [DPU-5](https://github.com/r12f/InFMon/issues)).
 
 ## Repository layout
 
@@ -48,7 +50,9 @@ directory once available.
 2. Branch from `main`.
 3. Submit a PR — all changes require review from a code owner
    (see [`CODEOWNERS`](./CODEOWNERS)) and must pass required CI checks.
-4. Sign off your commits (`git commit -s`).
+4. Sign off your commits (`git commit -s`). The DCO sign-off is enforced
+   by the `dco` CI check (added in PR #10 / DPU-15) so missing sign-offs
+   block merge.
 
 ## License
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -3,7 +3,10 @@
 This directory holds design specs, RFCs, and protocol documents for InFMon.
 
 Add one Markdown file per spec. Suggested naming: `NNNN-short-title.md`
-(e.g. `0001-architecture-overview.md`). Each spec should include:
+(e.g. `0001-architecture-overview.md`). Use the next available number;
+if multiple specs are in flight, the reviewer assigns the final number
+at merge time to avoid conflicts. Gaps are allowed (do not renumber
+once a spec is merged). Each spec should include:
 
 - **Status** (draft / accepted / superseded)
 - **Context** — the problem being solved

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,13 @@
+# InFMon Specs
+
+This directory holds design specs, RFCs, and protocol documents for InFMon.
+
+Add one Markdown file per spec. Suggested naming: `NNNN-short-title.md`
+(e.g. `0001-architecture-overview.md`). Each spec should include:
+
+- **Status** (draft / accepted / superseded)
+- **Context** — the problem being solved
+- **Decision** — what we are building
+- **Consequences** — trade-offs, follow-ups, open questions
+
+Specs land via PR like any other change and require code-owner review.

--- a/src/infmon-backend/README.md
+++ b/src/infmon-backend/README.md
@@ -1,0 +1,7 @@
+# infmon-backend
+
+Backend / control plane for InFMon, including dataplane integration glue
+(Rust core + C/C++ VPP plugins).
+
+Implementation lands in follow-up tasks. See [`../../specs/`](../../specs/)
+for design.

--- a/src/infmon-cli/README.md
+++ b/src/infmon-cli/README.md
@@ -1,0 +1,7 @@
+# infmon-cli
+
+Command-line client for InFMon — used by operators and automation to
+interact with the backend.
+
+Implementation lands in follow-up tasks. See [`../../specs/`](../../specs/)
+for design.

--- a/src/infmon-frontend/README.md
+++ b/src/infmon-frontend/README.md
@@ -1,0 +1,6 @@
+# infmon-frontend
+
+Operator-facing web UI for InFMon.
+
+Implementation lands in follow-up tasks. See [`../../specs/`](../../specs/)
+for design.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,7 @@
+# tests
+
+Cross-component integration and end-to-end tests for InFMon.
+
+Component-level unit tests live alongside the source under
+`src/<component>/`. This directory is reserved for tests that exercise
+multiple components together.


### PR DESCRIPTION
Bootstraps the InFMon repository as tracked in Multica issue **DPU-5**.

## What's in
- **LICENSE** — Apache-2.0
- **README.md** — high-level project description, repository layout, link to `specs/`
- **CODEOWNERS** — `@banidoru` required reviewer on all paths
- **Top-level layout**:
  - `specs/` — design specs / RFCs (with placeholder README)
  - `src/infmon-backend/`, `src/infmon-frontend/`, `src/infmon-cli/` — component homes (with placeholder READMEs)
  - `tests/` — cross-component integration tests (with placeholder README)
- **.gitignore** — Rust + C/C++ + VPP build artifacts
- **CHANGELOG.md** — Keep a Changelog format, initial `Unreleased` entry

## What's not in (intentionally)
No code beyond scaffolding files, per the issue scope.

## Follow-ups (out of scope for this PR — needs repo-admin action)
- **Branch protection** on `main`: require PR, required status checks, required code-owner review by `@banidoru`. This must be configured in repo settings (or via `gh api`) once the first CI workflow exists to designate as a required check. Filed for the repo owner to enable post-merge.

Refs: DPU-5