### PR TITLE
specs: 007 — CLI (infmon-cli)

### DIFF
--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -2,12 +2,9 @@
 
 ## Version history
 
-| Version | Date       | Author     | Changes                                  |
-| ------- | ---------- | ---------- | ---------------------------------------- |
-| 0.1     | 2026-04-18 | r12f       | Initial draft of v1 verb tree, output contract, exit codes, config layout, privilege model. |
-| 0.2     | 2026-04-18 | r12f       | Address PR #8 review feedback. |
-| 0.3     | 2026-04-18 | r12f       | Split `flow {add,rm,list,show}` into `flow-rule` (configuration) and `flow` (live read-only views). Each flow-rule generates one flow per distinct key tuple it observes. |
-| 0.4     | 2026-04-18 | r12f       | SIGPIPE: install `exit(0)` handler instead of restoring `SIG_DFL` so the documented "exits 0 silently" claim is actually achieved (avoids the `141` POSIX path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); reject multi-positional unquoted keys with exit 2. |
+| Version | Date       | Author       | Changes |
+| ------- | ---------- | ------------ | ------- |
+| 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-cli` v1: verb tree, output contract, exit codes, config layout, privilege model. Verb tree splits `flow-rule {add,rm,list,show}` (configuration) from `flow {list,show}` (live read-only views) — each flow-rule generates one flow per distinct key tuple. SIGPIPE installs an `exit(0)` handler so the documented "exits 0 silently" claim holds (avoids the POSIX 141 path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); multi-positional unquoted keys are rejected with exit 2. |
 
 ---
 

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -4,10 +4,10 @@
 
 | Version | Date       | Author     | Changes                                  |
 | ------- | ---------- | ---------- | ---------------------------------------- |
-| 0.1     | 2026-04-18 | bf3 (agent)| Initial draft of v1 verb tree, output contract, exit codes, config layout, privilege model. |
-| 0.2     | 2026-04-18 | bf3 (agent)| Address PR #8 review feedback. |
-| 0.3     | 2026-04-18 | bf3 (agent)| Split `flow {add,rm,list,show}` into `flow-rule` (configuration) and `flow` (live read-only views). Each flow-rule generates one flow per distinct key tuple it observes. |
-| 0.4     | 2026-04-18 | bf3 (agent)| SIGPIPE: install `exit(0)` handler instead of restoring `SIG_DFL` so the documented "exits 0 silently" claim is actually achieved (avoids the `141` POSIX path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); reject multi-positional unquoted keys with exit 2. |
+| 0.1     | 2026-04-18 | r12f       | Initial draft of v1 verb tree, output contract, exit codes, config layout, privilege model. |
+| 0.2     | 2026-04-18 | r12f       | Address PR #8 review feedback. |
+| 0.3     | 2026-04-18 | r12f       | Split `flow {add,rm,list,show}` into `flow-rule` (configuration) and `flow` (live read-only views). Each flow-rule generates one flow per distinct key tuple it observes. |
+| 0.4     | 2026-04-18 | r12f       | SIGPIPE: install `exit(0)` handler instead of restoring `SIG_DFL` so the documented "exits 0 silently" claim is actually achieved (avoids the `141` POSIX path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); reject multi-positional unquoted keys with exit 2. |
 
 ---
 

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -1,0 +1,397 @@
+# 007 — CLI (`infmon-cli`)
+
+**Owners:** @banidoru (review), DPU team
+**Status:** Draft
+**Last updated:** 2026-04-18
+
+---
+
+## Context
+
+Operators need a single, scriptable entry point for installing, running,
+configuring, observing, and debugging InFMon on a BlueField-3 DPU. The
+existing components — the VPP plugin (`infmon-backend`) and the user-space
+service (`infmon-frontend`) — expose APIs and on-disk state, but operators
+should not have to poke at systemd units, raw config files, or the frontend's
+local socket directly.
+
+`infmon-cli` is that entry point. It is a single Rust binary, distributed in
+the same `.deb` as the backend and frontend, that wraps every supported
+operator workflow. It must be **predictable in scripts** (stable exit codes,
+machine-readable output) and **comfortable for humans** (tables by default,
+sensible verbs).
+
+This spec freezes the v1 verb tree, output contract, exit-code table, config
+file location, and privilege model. Implementation work tracks against it.
+
+## Goals & Non-goals
+
+- Goal: One CLI binary that owns the full operator surface — install,
+  lifecycle, config, flow inspection, stats, log tail, health.
+- Goal: Stable, documented exit codes so CI and monitoring scripts can rely
+  on them.
+- Goal: `--output table|json` on every read command; JSON is the contract for
+  automation.
+- Goal: Clearly state what requires `sudo` (privileged actions) versus what
+  any local user can run (read-only queries).
+- Goal: Talks to the frontend over its local Unix-domain socket; never
+  reaches into the backend's shared memory directly.
+- Non-goal: Remote administration. v1 is local-only (the CLI runs on the
+  same DPU as the frontend). Remote use happens via SSH.
+- Non-goal: A TUI / curses dashboard. `stats show` and `log tail -f` are the
+  closest we get.
+- Non-goal: Editing flow records or rewriting backend state. The CLI reads
+  state and (re)writes config; it does not mutate live counters.
+- Non-goal: Cluster / multi-DPU operations (out of scope per spec 000).
+
+## Design
+
+### Binary, transport, and discovery
+
+- Single binary `/usr/bin/infmon-cli`, shipped by `infmon_<ver>_arm64.deb`.
+- Talks to `infmon-frontend` over a Unix-domain socket at
+  `/run/infmon/frontend.sock` (created mode `0660`, group `infmon`).
+- Members of the `infmon` group can run all read-only verbs without `sudo`.
+  Privileged verbs (install, lifecycle, config writes) require either root
+  or `sudo`; the CLI prints a clear error and exits `13` (see exit-code
+  table) when invoked without sufficient privilege.
+- Config file lives at `/etc/infmon/infmon.toml` (owned `root:infmon`,
+  mode `0640`). The CLI never edits it in place; `config set` rewrites it
+  atomically (`write → fsync → rename`).
+- Run-state and PID files live under `/run/infmon/`. Logs go to journald via
+  the systemd unit; `log tail` wraps `journalctl -u infmon-frontend`.
+
+### Global flags
+
+Available on every subcommand:
+
+| Flag                    | Default       | Meaning                                      |
+|-------------------------|---------------|----------------------------------------------|
+| `--output <table\|json>`| `table`       | Output format. `json` is line-delimited per record where applicable. |
+| `--config <path>`       | `/etc/infmon/infmon.toml` | Override config file location.   |
+| `--socket <path>`       | `/run/infmon/frontend.sock` | Override frontend socket path. |
+| `--timeout <secs>`      | `5`           | Per-call timeout when contacting the frontend. |
+| `--no-color`            | off           | Disable ANSI colors (auto-off when stdout is not a TTY). |
+| `-q, --quiet`           | off           | Suppress informational stderr; errors still printed. |
+| `-v, --verbose`         | off (repeatable) | `-v` info, `-vv` debug, `-vvv` trace.    |
+| `-h, --help`            | —             | Show help for the (sub)command.              |
+| `-V, --version`         | —             | Print `infmon-cli <semver>` and exit `0`.    |
+
+Conventions:
+
+- All `--output json` responses are valid JSON. List commands emit a single
+  JSON array (not NDJSON) unless explicitly noted (`log tail` is NDJSON).
+- All numeric values in JSON are unquoted numbers; counters that may exceed
+  `2^53` are rendered as decimal strings with a trailing `_str` field name
+  (e.g. `bytes_str`).
+- Timestamps are RFC 3339 UTC strings.
+
+### Verb tree
+
+```
+infmon-cli
+├── install                              [root]
+├── uninstall                            [root]
+├── start                                [root]
+├── stop                                 [root]
+├── restart                              [root]
+├── status                               [any]
+├── config
+│   ├── get <key>                        [any]
+│   ├── set <key> <value>                [root]
+│   ├── reload                           [root]
+│   └── show                             [any]
+├── flow
+│   ├── add <spec>                       [root]
+│   ├── rm  <id|spec>                    [root]
+│   ├── list                             [any]
+│   └── show <id>                        [any]
+├── stats
+│   ├── show [--name <metric>] [--top N] [any]
+│   └── export --format <prom|otlp|json> [any]
+├── log
+│   └── tail [-f] [--since <when>] [-n N][any]
+└── health [--json]                      [any]
+```
+
+`[root]` = requires root or `sudo`. `[any]` = any user, subject to socket
+group membership for verbs that contact the frontend.
+
+#### `install` / `uninstall`
+
+`install` is a one-shot bootstrap that the `.deb` post-install hook also
+calls, but operators may rerun it after manual changes:
+
+- Verifies VPP is installed and the `infmon-backend` plugin is in VPP's
+  plugin directory.
+- Ensures the `infmon` group exists and `/etc/infmon/`, `/run/infmon/`,
+  `/var/lib/infmon/` exist with correct ownership and modes.
+- Writes a default `infmon.toml` if none exists (never overwrites an
+  existing one; prints a notice and exits `0`).
+- Enables the `infmon-frontend.service` systemd unit (does not start it;
+  use `start`).
+- Idempotent: rerunning on a healthy install is a no-op and exits `0`.
+
+`uninstall` is the inverse, but conservative:
+
+- Stops and disables `infmon-frontend.service`.
+- Removes the systemd unit file and the `/usr/bin/infmon-cli`,
+  `/usr/bin/infmon-frontend`, and VPP plugin `.so` only if they were
+  installed by InFMon (checked via dpkg ownership).
+- **Preserves** `/etc/infmon/` and `/var/lib/infmon/` by default; pass
+  `--purge` to remove them.
+
+#### `start` / `stop` / `restart` / `status`
+
+Thin, opinionated wrappers over systemd:
+
+- `start`   → `systemctl start infmon-frontend.service`
+- `stop`    → `systemctl stop  infmon-frontend.service`
+- `restart` → `systemctl restart infmon-frontend.service`
+- `status`  → composite view: systemd unit state, frontend PID, socket
+  reachable yes/no, backend plugin loaded yes/no, uptime, version.
+
+`status` is read-only and works without root. With `--output json` it emits
+an object:
+
+```json
+{
+  "service":    "active",
+  "pid":        1234,
+  "uptime_sec": 86400,
+  "socket":     "/run/infmon/frontend.sock",
+  "socket_ok":  true,
+  "backend": {
+    "plugin_loaded": true,
+    "version":       "1.0.0"
+  },
+  "frontend": {
+    "version": "1.0.0"
+  }
+}
+```
+
+#### `config get|set|reload|show`
+
+- `config show` prints the effective merged config (defaults + file +
+  environment overrides) as TOML (table mode) or JSON (json mode).
+- `config get <key>` prints just that key's value. Dotted keys index into
+  tables: `config get exporter.ipfix.collector`.
+- `config set <key> <value>` rewrites `/etc/infmon/infmon.toml` atomically
+  with the new value. Type is inferred from the existing value's type
+  (string, int, bool, float, array). `--type <t>` can force the type when
+  setting a previously absent key. Requires root.
+- `config reload` sends `SIGHUP` to the frontend (and asks it to revalidate
+  hot-reloadable knobs). Knobs that require restart are listed by `config
+  show --annotate`. Requires root.
+
+Validation: `config set` and `config reload` refuse a config that fails
+schema validation, exit `2`, and leave the on-disk file unchanged.
+
+#### `flow add|rm|list|show`
+
+"Flows" here are *flow filter rules* maintained by the frontend (e.g. an
+allow-list of which flows to export, or named groups for stats roll-ups).
+They are **not** live flow records — those are read-only and surfaced
+through `stats show`.
+
+- `flow add <spec>` adds a rule. Spec uses a compact key=value form, e.g.
+  `proto=tcp src=10.0.0.0/8 dst=0.0.0.0/0 dport=443 name=https-egress`.
+  Returns the assigned rule ID on stdout. Requires root.
+- `flow rm <id|spec>` removes by ID, or by exact-match spec. Requires root.
+- `flow list` lists all rules. Columns: `ID`, `NAME`, `PROTO`, `SRC`,
+  `DST`, `SPORT`, `DPORT`, `ACTION`. JSON mode emits an array of rule
+  objects.
+- `flow show <id>` prints one rule's full detail (including hit counters).
+
+#### `stats show` and `stats export`
+
+- `stats show` prints aggregate counters: `packets`, `bytes`, `flows_active`,
+  `flows_total`, `flows_evicted`, `parse_errors`, `export_records`, etc.
+  - `--name <metric>` restricts output to one metric (also accepts a
+    glob, e.g. `--name 'export_*'`).
+  - `--top N` for top-N talkers / top-N flows by bytes (default `N=20`).
+    Combined with `--name flows.top_bytes` etc.
+  - Default refresh is a single snapshot. Add `--watch <secs>` for periodic
+    refresh (table mode only; json mode prints one snapshot then exits).
+- `stats export --format <prom|otlp|json>` writes the current snapshot to
+  stdout in the requested format:
+  - `prom` — Prometheus text exposition (text/plain; version=0.0.4).
+  - `otlp` — OpenTelemetry metrics, JSON-encoded OTLP.
+  - `json` — InFMon-native JSON (same shape as `stats show --output json`,
+    but always the full set, ignoring `--name`/`--top`).
+  This is a one-shot dump suitable for piping into a collector or a file;
+  it does **not** start a long-lived exporter (those are configured in
+  `infmon.toml` and run inside the frontend).
+
+#### `log tail`
+
+- Wraps `journalctl -u infmon-frontend.service`.
+- `-f` / `--follow` streams new lines (NDJSON when `--output json`).
+- `--since <when>` accepts the same forms as journalctl (`"10 min ago"`,
+  RFC 3339, etc.).
+- `-n N` shows the last `N` lines (default `100`).
+- Exits `0` on clean EOF, `130` on `SIGINT` (Ctrl-C), per the exit table.
+
+#### `health [--json]`
+
+A single composite probe, designed to be the target of an external
+monitor or a Kubernetes-style liveness/readiness check.
+
+- Exits `0` when the frontend socket is reachable, the backend plugin
+  reports `loaded`, and the last snapshot timestamp is within
+  `2 × snapshot_interval`.
+- Exits `1` when degraded (e.g. snapshot is stale but service is up).
+- Exits `4` when the frontend is unreachable.
+- `--json` (alias of `--output json`) prints a structured payload:
+
+```json
+{
+  "ok":              true,
+  "service":         "active",
+  "socket_ok":       true,
+  "backend_loaded":  true,
+  "snapshot_age_ms": 873,
+  "checks": [
+    {"name": "service",        "ok": true},
+    {"name": "socket",         "ok": true},
+    {"name": "backend_loaded", "ok": true},
+    {"name": "snapshot_fresh", "ok": true}
+  ]
+}
+```
+
+### Exit codes
+
+The CLI uses a small, stable set of exit codes. Subcommand-specific codes
+are documented in their help text but always drawn from this table.
+
+| Code | Meaning                                                        |
+|------|----------------------------------------------------------------|
+| `0`  | Success.                                                       |
+| `1`  | Generic / unspecified failure (last resort).                   |
+| `2`  | Usage error: bad flags, bad arguments, schema validation fail. |
+| `3`  | Not found: requested flow ID, config key, or metric is absent. |
+| `4`  | Frontend unreachable (socket missing, connect refused, timeout).|
+| `5`  | Backend not ready (plugin not loaded, snapshot never produced).|
+| `6`  | Conflict / already-exists (e.g. `flow add` of an existing rule, `install` over a dirty state without `--force`). |
+| `13` | Permission denied (insufficient privilege; mirrors POSIX EACCES). |
+| `69` | Service unavailable: systemd reports `failed` or `activating` longer than `--timeout`. |
+| `130`| Interrupted by `SIGINT` (Ctrl-C).                              |
+
+`health` overloads `1` to mean *degraded* and `4` to mean *unreachable* per
+the section above; this is the only verb where `1` is not "generic failure".
+
+### Sudo / privilege summary
+
+| Verb group                        | Requires root? | Notes                                       |
+|-----------------------------------|----------------|---------------------------------------------|
+| `install`, `uninstall`            | yes            | Touches `/etc`, systemd units, VPP plugin dir. |
+| `start`, `stop`, `restart`        | yes            | `systemctl` actions on the unit.            |
+| `status`, `health`                | no             | Pure read; uses socket only.                |
+| `config get`, `config show`       | no             | Reads `/etc/infmon/infmon.toml` (group `infmon` readable). |
+| `config set`, `config reload`     | yes            | Atomic write + `SIGHUP`.                    |
+| `flow list`, `flow show`          | no             | Read via socket.                            |
+| `flow add`, `flow rm`             | yes            | Write via socket; frontend enforces `SO_PEERCRED` check. |
+| `stats show`, `stats export`      | no             | Read via socket.                            |
+| `log tail`                        | no\*           | `journalctl -u …` works for any user on systemd-with-persistent-journal; otherwise group `systemd-journal` may be needed. |
+
+\* Not strictly enforced by the CLI; if `journalctl` denies access, the CLI
+exits `13` and prints the underlying error.
+
+### Output: `--output table|json`
+
+- **`table`** is the human default. Columns are fixed-width with a header
+  row; numbers right-aligned; bytes humanized (`12.4 GiB`) unless
+  `--raw-bytes` is also given.
+- **`json`** is the machine contract. Schema for each verb is frozen at v1
+  and only additive changes are allowed within v1.x. JSON is pretty-printed
+  by default; `--compact` collapses to a single line.
+
+### Configuration knobs that affect the CLI itself
+
+These live under `[cli]` in `/etc/infmon/infmon.toml`:
+
+```toml
+[cli]
+default_output     = "table"   # table | json
+default_timeout_s  = 5
+color              = "auto"    # auto | always | never
+top_default        = 20
+```
+
+CLI-level config is purely cosmetic; it never changes the frontend's
+behavior.
+
+## Interfaces
+
+### Wire protocol to the frontend
+
+Out of scope for this spec — defined in spec 005 (frontend control plane).
+The CLI uses whatever framed JSON-RPC the frontend exposes on
+`/run/infmon/frontend.sock`. From the operator's perspective, the wire
+protocol is an implementation detail behind the verbs above.
+
+### Filesystem contract
+
+| Path                              | Owner       | Mode  | Purpose                          |
+|-----------------------------------|-------------|-------|----------------------------------|
+| `/usr/bin/infmon-cli`             | root:root   | 0755  | The CLI binary.                  |
+| `/etc/infmon/infmon.toml`         | root:infmon | 0640  | Effective config.                |
+| `/etc/infmon/infmon.toml.default` | root:root   | 0644  | Distro defaults (reference).     |
+| `/run/infmon/frontend.sock`       | root:infmon | 0660  | Frontend control socket.         |
+| `/var/lib/infmon/`                | infmon:infmon | 0750| Persistent CLI/frontend state.   |
+| `/var/log/journal/...`            | systemd     | —     | Logs (via journald).             |
+
+### Help text conventions
+
+- Top-level `--help` lists verb groups with one-line descriptions.
+- Each verb has its own `--help` showing all flags, exit codes specific to
+  it, and a `Examples:` block (at least one human + one JSON example).
+- Help text is generated by `clap` derive macros so it stays in sync with
+  the code.
+
+## Test plan
+
+Unit and integration tests for `infmon-cli` live under `cli/tests/` and run
+in CI via `cargo test`.
+
+- **Argument parsing** — `clap` snapshot tests for every verb, asserting
+  correct rejection of bad combinations (e.g. `stats export` without
+  `--format`, `flow rm` with neither id nor spec).
+- **Exit codes** — table-driven tests that drive each error branch and
+  assert the documented exit code.
+- **Output contract** — for every read verb, golden tests for `--output
+  table` (snapshot) and a JSON-schema validation pass for `--output json`.
+- **Socket client** — mock frontend (a small in-process stub bound to a
+  tmpdir socket) covers: success, timeout (`exit 4`), refused (`exit 4`),
+  not-found (`exit 3`), permission denied via `SO_PEERCRED` simulation
+  (`exit 13`).
+- **Privilege gate** — CLI is run as both root and non-root in test
+  fixtures; privileged verbs against a non-root invoker return `exit 13`
+  *before* contacting the frontend.
+- **`config set` atomicity** — write into a tmpdir, kill mid-write via a
+  fault-injecting `Write` impl, assert the original file is intact.
+- **`stats export` formats** — for each format, parse the output back with
+  the corresponding parser (`prometheus_parser`, an OTLP JSON validator,
+  `serde_json`) and assert round-trip integrity of a known snapshot.
+- **E2E (not in CI)** — `tests/scenarios/cli_smoke.sh` runs against a real
+  installed package on a BlueField-3 box: install → start → status →
+  stats show → log tail (5s) → stop → uninstall.
+
+## Open questions
+
+1. **`config set` for nested arrays** — do we support appending
+   (`config set exporters.+ '{...}'`) in v1, or only whole-array replace?
+   *Default:* whole-array replace in v1; append/remove syntax deferred.
+   *Decision-maker:* @banidoru.
+2. **`stats export --format prom` cardinality** — high-cardinality flow
+   labels can blow up Prometheus. Do we cap labels per series?
+   *Default:* yes, hard cap of 10 labels per series, configurable via
+   `[exporter.prom] max_labels`. Decided alongside spec 004.
+3. **Bash / Zsh / Fish completions** — ship in v1 or v1.1?
+   *Default:* ship in v1, generated via `clap_complete`, installed by the
+   `.deb` into `/usr/share/{bash-completion,zsh/site-functions,fish/...}`.
+4. **Remote mode** — should `--socket` accept `tcp://host:port` for
+   development convenience? *Default:* no in v1; remote use is via SSH.
+   Revisit only if there is a concrete operator request.

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -281,6 +281,10 @@ the backend as packets are observed.
   `PACKETS`, `BYTES`, `FIRST_SEEN`, `LAST_SEEN`. JSON mode emits an array
   of flow objects. `--top N` and `--sort {bytes,packets,last_seen}` are
   supported (default `--sort bytes --top 50`).
+  > *Rationale for `--top 50` here vs `--top 20` in `stats show`:* flow
+  > tables are typically much denser (thousands of rows) so a higher default
+  > gives operators a useful view without requiring an explicit flag, while
+  > `stats show` metrics are fewer and `20` already covers most deployments.
 - `flow show <rule-id|name> <key>` prints one flow's full counters,
   where `<key>` is the canonical key form printed by `flow list`,
   passed as a **single argv element** (i.e. quoted in the shell so the
@@ -502,6 +506,11 @@ in CI via `cargo test`.
   with no stack trace; `SIGPIPE` (writing to a closed downstream pipe)
   produces exit `0` with no stderr noise. Driven by a small harness
   that spawns the CLI and closes the read end of its pipe mid-stream.
+- **`flow list` / `flow show`** — golden tests for `--top N` / `--sort`
+  output (both table and JSON), socket-mock coverage for the `flow.list`
+  and `flow.show` RPC calls (happy path + unknown rule-id → exit `3`),
+  and rejection of a syntactically malformed `<key>` (e.g. bare `=`,
+  unbalanced quotes) with exit `2`.
 - **`flow-rule` spec parser** — table-driven tests for the v1 parsing grammar
   (bare values, double-quoted values, embedded escapes, unknown/
   duplicate keys, empty spec).

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -70,6 +70,9 @@ Available on every subcommand:
 | Flag                    | Default       | Meaning                                      |
 |-------------------------|---------------|----------------------------------------------|
 | `--output <table\|json>`| `table`       | Output format. `json` is line-delimited per record where applicable. |
+| `--json`                | off           | Shorthand for `--output json`. Available on every verb. |
+| `--compact`             | off           | JSON only: collapse pretty-printed output to a single line per record. Ignored in table mode. |
+| `--raw-bytes`           | off           | Table mode only: print byte counters as raw integers instead of humanized (`12.4 GiB`). Ignored in JSON mode (JSON always emits raw). |
 | `--config <path>`       | `/etc/infmon/infmon.toml` | Override config file location.   |
 | `--socket <path>`       | `/run/infmon/frontend.sock` | Override frontend socket path. |
 | `--timeout <secs>`      | `5`           | Per-call timeout when contacting the frontend. |
@@ -83,37 +86,52 @@ Conventions:
 
 - All `--output json` responses are valid JSON. List commands emit a single
   JSON array (not NDJSON) unless explicitly noted (`log tail` is NDJSON).
-- All numeric values in JSON are unquoted numbers; counters that may exceed
-  `2^53` are rendered as decimal strings with a trailing `_str` field name
-  (e.g. `bytes_str`).
+  Forward-looking: any future streaming/`--watch` JSON mode will follow the
+  NDJSON pattern (one JSON object per line, no enclosing array). `stats show
+  --watch` in JSON mode currently emits a single snapshot then exits; if
+  streaming is added later it will be NDJSON.
+- All numeric values in JSON are unquoted numbers. For counters that may
+  exceed `2^53`, the CLI **always** emits both fields side-by-side: the
+  numeric `bytes` (which may lose precision past `2^53`) and the decimal
+  string `bytes_str` (lossless). Consumers should prefer `*_str` for any
+  counter where overflow is possible. Always-emitting both removes the
+  conditional-presence ambiguity.
 - Timestamps are RFC 3339 UTC strings.
+- **Signal handling.** All verbs install handlers that translate `SIGINT`
+  and `SIGTERM` into a clean shutdown and exit `130` (SIGINT) or `143`
+  (SIGTERM, i.e. `128 + 15`). `SIGPIPE` is treated as a normal,
+  non-error termination — when stdout is closed by a downstream consumer
+  (e.g. `infmon-cli stats export --format prom | head`), the CLI exits `0`
+  silently rather than printing a broken-pipe error to stderr. This is
+  achieved by restoring the default `SIGPIPE` disposition (`SIG_DFL`) at
+  startup so writes to a closed pipe terminate the process the POSIX way.
 
 ### Verb tree
 
 ```
 infmon-cli
-├── install                              [root]
-├── uninstall                            [root]
-├── start                                [root]
-├── stop                                 [root]
-├── restart                              [root]
-├── status                               [any]
+├── install [--force]                       [root]
+├── uninstall [--purge]                     [root]
+├── start                                   [root]
+├── stop                                    [root]
+├── restart                                 [root]
+├── status                                  [any]
 ├── config
-│   ├── get <key>                        [any]
-│   ├── set <key> <value>                [root]
-│   ├── reload                           [root]
-│   └── show                             [any]
+│   ├── get <key>                           [any]
+│   ├── set <key> <value> [--type <t>]      [root]
+│   ├── reload                              [root]
+│   └── show [--annotate]                   [any]
 ├── flow
-│   ├── add <spec>                       [root]
-│   ├── rm  <id|spec>                    [root]
-│   ├── list                             [any]
-│   └── show <id>                        [any]
+│   ├── add <spec>                          [root]
+│   ├── rm  <id|spec> [--all]               [root]
+│   ├── list                                [any]
+│   └── show <id>                           [any]
 ├── stats
-│   ├── show [--name <metric>] [--top N] [any]
-│   └── export --format <prom|otlp|json> [any]
+│   ├── show [--name <metric>] [--top N] [--watch <secs>]  [any]
+│   └── export --format <prom|otlp|json>    [any]
 ├── log
-│   └── tail [-f] [--since <when>] [-n N][any]
-└── health [--json]                      [any]
+│   └── tail [-f] [--since <when>] [-n N]   [any]
+└── health                                  [any]
 ```
 
 `[root]` = requires root or `sudo`. `[any]` = any user, subject to socket
@@ -133,6 +151,10 @@ calls, but operators may rerun it after manual changes:
 - Enables the `infmon-frontend.service` systemd unit (does not start it;
   use `start`).
 - Idempotent: rerunning on a healthy install is a no-op and exits `0`.
+- `--force` proceeds even when prior state looks dirty (e.g. a stale
+  `/run/infmon/` from a crashed previous install, partially-written
+  systemd unit). Without `--force`, `install` exits `6` and prints which
+  precondition failed. A *clean* re-install never needs `--force`.
 
 `uninstall` is the inverse, but conservative:
 
@@ -182,7 +204,18 @@ an object:
 - `config set <key> <value>` rewrites `/etc/infmon/infmon.toml` atomically
   with the new value. Type is inferred from the existing value's type
   (string, int, bool, float, array). `--type <t>` can force the type when
-  setting a previously absent key. Requires root.
+  setting a previously absent key, **and is also required when the existing
+  value is `null`, an empty string, or an empty array** — i.e. any case
+  where the on-disk type is ambiguous. If `--type` is omitted in those
+  cases, the CLI exits `2` with a message listing the candidate types.
+  Requires root.
+- `config show --annotate` adds restart-required annotations:
+  - In **table** mode, an extra `RESTART` column shows `yes` / `no`.
+  - In **JSON** mode, the schema is unchanged; instead, the output object
+    gains a sibling `_annotations` object keyed by the same dotted keys,
+    e.g. `{"_annotations": {"backend.workers": {"restart_required": true}}}`.
+    This keeps the primary value shape stable for consumers that don't
+    request `--annotate`.
 - `config reload` sends `SIGHUP` to the frontend (and asks it to revalidate
   hot-reloadable knobs). Knobs that require restart are listed by `config
   show --annotate`. Requires root.
@@ -200,7 +233,28 @@ through `stats show`.
 - `flow add <spec>` adds a rule. Spec uses a compact key=value form, e.g.
   `proto=tcp src=10.0.0.0/8 dst=0.0.0.0/0 dport=443 name=https-egress`.
   Returns the assigned rule ID on stdout. Requires root.
-- `flow rm <id|spec>` removes by ID, or by exact-match spec. Requires root.
+
+  **Parsing grammar (frozen v1):**
+  - Tokens are split on **unquoted whitespace** (one or more spaces / tabs).
+  - Each token must match `<key>=<value>`. Keys are `[a-z][a-z0-9_]*`.
+  - Values may be:
+    - **Bare** — any run of characters from `[A-Za-z0-9._:/+\-,]` (this
+      covers IP/CIDR, ports, protocol names, hostnames, and rule names
+      without spaces).
+    - **Double-quoted** — `"…"` for values containing whitespace, `=`, or
+      shell metacharacters. Inside double quotes, the only escapes are
+      `\"` (literal `"`) and `\\` (literal `\`); everything else is taken
+      verbatim. Example: `name="my egress rule"`,
+      `note="key\"with\"quotes"`.
+  - Unknown keys → exit `2`. Duplicate keys in one spec → exit `2`.
+  - Operators who pass `<spec>` through a shell are responsible for the
+    shell's own quoting; the grammar above describes what `infmon-cli`
+    sees after `argv` parsing.
+- `flow rm <id|spec>` removes by ID, or by exact-match spec. If a spec
+  matches multiple rules, the command **refuses** by default and exits `6`
+  (conflict) listing the matching IDs; pass `--all` to delete every match.
+  ID lookups always remove exactly one rule or exit `3` (not found).
+  Requires root.
 - `flow list` lists all rules. Columns: `ID`, `NAME`, `PROTO`, `SRC`,
   `DST`, `SPORT`, `DPORT`, `ACTION`. JSON mode emits an array of rule
   objects.
@@ -216,6 +270,9 @@ through `stats show`.
     Combined with `--name flows.top_bytes` etc.
   - Default refresh is a single snapshot. Add `--watch <secs>` for periodic
     refresh (table mode only; json mode prints one snapshot then exits).
+    `<secs>` must be an integer ≥ `1`; `--watch 0` or a negative value
+    is rejected with exit `2`. Sub-second intervals are intentionally not
+    supported in v1 (the frontend's snapshot cadence is in seconds).
 - `stats export --format <prom|otlp|json>` writes the current snapshot to
   stdout in the requested format:
   - `prom` — Prometheus text exposition (text/plain; version=0.0.4).
@@ -228,7 +285,14 @@ through `stats show`.
 
 #### `log tail`
 
-- Wraps `journalctl -u infmon-frontend.service`.
+- Wraps `journalctl -u infmon-frontend.service`. The CLI invokes
+  `journalctl` as a subprocess and **wraps its errors** rather than
+  passing through the raw stderr: a non-zero exit from `journalctl` is
+  translated into the CLI's standard error format (one line on stderr,
+  prefixed with `infmon-cli: log tail:`) and mapped to a CLI exit code
+  (`13` for permission denied, `4` for "journald not available", `1`
+  otherwise). The original `journalctl` stderr is included once,
+  indented, beneath the wrapped message for diagnostics.
 - `-f` / `--follow` streams new lines (NDJSON when `--output json`).
 - `--since <when>` accepts the same forms as journalctl (`"10 min ago"`,
   RFC 3339, etc.).
@@ -243,9 +307,12 @@ monitor or a Kubernetes-style liveness/readiness check.
 - Exits `0` when the frontend socket is reachable, the backend plugin
   reports `loaded`, and the last snapshot timestamp is within
   `2 × snapshot_interval`.
-- Exits `1` when degraded (e.g. snapshot is stale but service is up).
+- Exits `7` when degraded (e.g. snapshot is stale but service is up).
+  This is a dedicated exit code so generic shell scripts (`if cmd; then …`)
+  can distinguish "degraded" from "generic failure".
 - Exits `4` when the frontend is unreachable.
-- `--json` (alias of `--output json`) prints a structured payload:
+- `--json` (a CLI-wide shorthand for `--output json`, see Global flags)
+  prints a structured payload:
 
 ```json
 {
@@ -276,13 +343,17 @@ are documented in their help text but always drawn from this table.
 | `3`  | Not found: requested flow ID, config key, or metric is absent. |
 | `4`  | Frontend unreachable (socket missing, connect refused, timeout).|
 | `5`  | Backend not ready (plugin not loaded, snapshot never produced).|
-| `6`  | Conflict / already-exists (e.g. `flow add` of an existing rule, `install` over a dirty state without `--force`). |
+| `6`  | Conflict / already-exists (e.g. `flow add` of an existing rule, `flow rm <spec>` matching multiple rules without `--all`, `install` over a dirty state without `--force`). |
+| `7`  | `health` only: degraded (service up, but a non-fatal check failed — e.g. stale snapshot). |
 | `13` | Permission denied (insufficient privilege; mirrors POSIX EACCES). |
 | `69` | Service unavailable: systemd reports `failed` or `activating` longer than `--timeout`. |
 | `130`| Interrupted by `SIGINT` (Ctrl-C).                              |
+| `143`| Terminated by `SIGTERM` (`128 + 15`).                          |
 
-`health` overloads `1` to mean *degraded* and `4` to mean *unreachable* per
-the section above; this is the only verb where `1` is not "generic failure".
+`health` uses a dedicated exit `7` for *degraded* (in addition to `4` for
+*unreachable*). This keeps `1` reserved for generic failure across every
+verb so monitoring scripts can rely on the table without per-verb special
+cases.
 
 ### Sudo / privilege summary
 
@@ -334,6 +405,17 @@ The CLI uses whatever framed JSON-RPC the frontend exposes on
 `/run/infmon/frontend.sock`. From the operator's perspective, the wire
 protocol is an implementation detail behind the verbs above.
 
+**Version compatibility (operator-facing guarantee).** `infmon-cli vX.Y` is
+guaranteed to work with any `infmon-frontend vX.*` (same major). The
+JSON-RPC handshake (defined in spec 005) carries each side's semver; on
+any *major* mismatch the CLI exits `4` ("frontend unreachable") with a
+clear error explaining the mismatch and the supported range. On a
+*minor*-only skew where the CLI is newer than the frontend, the CLI
+prints a one-line warning to stderr and proceeds — unknown response
+fields are ignored, and any verb that needs a strictly-newer RPC method
+exits `5` ("backend not ready") with a "method not supported by frontend
+vA.B" message. Patch-level skews are silent.
+
 ### Filesystem contract
 
 | Path                              | Owner       | Mode  | Purpose                          |
@@ -342,7 +424,7 @@ protocol is an implementation detail behind the verbs above.
 | `/etc/infmon/infmon.toml`         | root:infmon | 0640  | Effective config.                |
 | `/etc/infmon/infmon.toml.default` | root:root   | 0644  | Distro defaults (reference).     |
 | `/run/infmon/frontend.sock`       | root:infmon | 0660  | Frontend control socket.         |
-| `/var/lib/infmon/`                | infmon:infmon | 0750| Persistent CLI/frontend state.   |
+| `/var/lib/infmon/`                | infmon:infmon | 0750| Persistent state owned by the frontend (e.g. snapshot rotation, future flow-rule on-disk store). The CLI does not read or write this path directly in v1; it is created by `install` so the frontend's persistence layer (see spec 005) has somewhere to live. |
 | `/var/log/journal/...`            | systemd     | —     | Logs (via journald).             |
 
 ### Help text conventions
@@ -377,6 +459,22 @@ in CI via `cargo test`.
 - **`stats export` formats** — for each format, parse the output back with
   the corresponding parser (`prometheus_parser`, an OTLP JSON validator,
   `serde_json`) and assert round-trip integrity of a known snapshot.
+- **Output modifiers** — golden tests for `--compact` (single-line JSON),
+  `--raw-bytes` (raw integers in table mode, unchanged JSON), and
+  `config show --annotate` in both table mode (the extra `RESTART`
+  column) and JSON mode (the sibling `_annotations` object).
+- **TTY / color detection** — assert that ANSI sequences are present when
+  stdout is a PTY and absent when it is a pipe; assert `--no-color`
+  forces them off even on a PTY and `color = "always"` (config) /
+  `--color always` (if added) forces them on through a pipe. Tests use
+  the `pty` crate to attach a real PTY.
+- **Signal handling** — `SIGINT` and `SIGTERM` produce exit `130` / `143`
+  with no stack trace; `SIGPIPE` (writing to a closed downstream pipe)
+  produces exit `0` with no stderr noise. Driven by a small harness
+  that spawns the CLI and closes the read end of its pipe mid-stream.
+- **`flow` spec parser** — table-driven tests for the v1 parsing grammar
+  (bare values, double-quoted values, embedded escapes, unknown/
+  duplicate keys, empty spec).
 - **E2E (not in CI)** — `tests/scenarios/cli_smoke.sh` runs against a real
   installed package on a BlueField-3 box: install → start → status →
   stats show → log tail (5s) → stop → uninstall.

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -7,6 +7,7 @@
 | 0.1     | 2026-04-18 | bf3 (agent)| Initial draft of v1 verb tree, output contract, exit codes, config layout, privilege model. |
 | 0.2     | 2026-04-18 | bf3 (agent)| Address PR #8 review feedback. |
 | 0.3     | 2026-04-18 | bf3 (agent)| Split `flow {add,rm,list,show}` into `flow-rule` (configuration) and `flow` (live read-only views). Each flow-rule generates one flow per distinct key tuple it observes. |
+| 0.4     | 2026-04-18 | bf3 (agent)| SIGPIPE: install `exit(0)` handler instead of restoring `SIG_DFL` so the documented "exits 0 silently" claim is actually achieved (avoids the `141` POSIX path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); reject multi-positional unquoted keys with exit 2. |
 
 ---
 
@@ -105,8 +106,10 @@ Conventions:
   non-error termination — when stdout is closed by a downstream consumer
   (e.g. `infmon-cli stats export --format prom | head`), the CLI exits `0`
   silently rather than printing a broken-pipe error to stderr. This is
-  achieved by restoring the default `SIGPIPE` disposition (`SIG_DFL`) at
-  startup so writes to a closed pipe terminate the process the POSIX way.
+  achieved by installing a `SIGPIPE` handler that calls `exit(0)`
+  immediately (rather than restoring `SIG_DFL`, which would terminate
+  the process with status `141 = 128 + 13`). The exit-code table below
+  therefore does **not** list `141`.
 
 ### Verb tree
 
@@ -282,8 +285,13 @@ the backend as packets are observed.
   of flow objects. `--top N` and `--sort {bytes,packets,last_seen}` are
   supported (default `--sort bytes --top 50`).
 - `flow show <rule-id|name> <key>` prints one flow's full counters,
-  where `<key>` is the canonical key form printed by `flow list` (the
-  CLI accepts either the full bare form or a quoted copy).
+  where `<key>` is the canonical key form printed by `flow list`,
+  passed as a **single argv element** (i.e. quoted in the shell so the
+  whole `proto=…  src=…  dst=…` string arrives as one positional).
+  The CLI does **not** concatenate trailing positionals; a multi-token
+  unquoted key is rejected with exit `2` (`Usage error`) and an error
+  pointing at the second positional. Example:
+  `infmon-cli flow show https-egress 'proto=tcp src=10.0.0.7:51234 dst=10.0.1.4:443'`.
 
 #### `stats show` and `stats export`
 

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -1,8 +1,10 @@
 # 007 — CLI (`infmon-cli`)
 
-**Owners:** @banidoru (review), DPU team
-**Status:** Draft
-**Last updated:** 2026-04-18
+## Version history
+
+| Version | Date       | Author     | Changes                                  |
+| ------- | ---------- | ---------- | ---------------------------------------- |
+| 0.1     | 2026-04-18 | bf3 (agent)| Initial draft of v1 verb tree, output contract, exit codes, config layout, privilege model. |
 
 ---
 

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -5,6 +5,8 @@
 | Version | Date       | Author     | Changes                                  |
 | ------- | ---------- | ---------- | ---------------------------------------- |
 | 0.1     | 2026-04-18 | bf3 (agent)| Initial draft of v1 verb tree, output contract, exit codes, config layout, privilege model. |
+| 0.2     | 2026-04-18 | bf3 (agent)| Address PR #8 review feedback. |
+| 0.3     | 2026-04-18 | bf3 (agent)| Split `flow {add,rm,list,show}` into `flow-rule` (configuration) and `flow` (live read-only views). Each flow-rule generates one flow per distinct key tuple it observes. |
 
 ---
 
@@ -121,11 +123,14 @@ infmon-cli
 │   ├── set <key> <value> [--type <t>]      [root]
 │   ├── reload                              [root]
 │   └── show [--annotate]                   [any]
-├── flow
-│   ├── add <spec>                          [root]
-│   ├── rm  <id|spec> [--all]               [root]
+├── flow-rule
+│   ├── add  <spec>                         [root]
+│   ├── rm   <id|name|spec> [--all]         [root]
 │   ├── list                                [any]
-│   └── show <id>                           [any]
+│   └── show <id|name>                      [any]
+├── flow
+│   ├── list <rule-id|name> [--top N] [--sort <bytes|packets|last_seen>]  [any]
+│   └── show <rule-id|name> <key>           [any]
 ├── stats
 │   ├── show [--name <metric>] [--top N] [--watch <secs>]  [any]
 │   └── export --format <prom|otlp|json>    [any]
@@ -223,14 +228,15 @@ an object:
 Validation: `config set` and `config reload` refuse a config that fails
 schema validation, exit `2`, and leave the on-disk file unchanged.
 
-#### `flow add|rm|list|show`
+#### `flow-rule add|rm|list|show`
 
-"Flows" here are *flow filter rules* maintained by the frontend (e.g. an
-allow-list of which flows to export, or named groups for stats roll-ups).
-They are **not** live flow records — those are read-only and surfaced
-through `stats show`.
+A **flow-rule** is a configured matcher (key-set + limits) maintained by
+the frontend. Each flow-rule generates **flows** — one flow per distinct
+key tuple the rule observes — with their own packet/byte counters. Use
+`flow-rule` to manage configuration; use `flow` (next section) to read
+the live flows that result.
 
-- `flow add <spec>` adds a rule. Spec uses a compact key=value form, e.g.
+- `flow-rule add <spec>` adds a rule. Spec uses a compact key=value form, e.g.
   `proto=tcp src=10.0.0.0/8 dst=0.0.0.0/0 dport=443 name=https-egress`.
   Returns the assigned rule ID on stdout. Requires root.
 
@@ -250,15 +256,34 @@ through `stats show`.
   - Operators who pass `<spec>` through a shell are responsible for the
     shell's own quoting; the grammar above describes what `infmon-cli`
     sees after `argv` parsing.
-- `flow rm <id|spec>` removes by ID, or by exact-match spec. If a spec
-  matches multiple rules, the command **refuses** by default and exits `6`
-  (conflict) listing the matching IDs; pass `--all` to delete every match.
-  ID lookups always remove exactly one rule or exit `3` (not found).
-  Requires root.
-- `flow list` lists all rules. Columns: `ID`, `NAME`, `PROTO`, `SRC`,
-  `DST`, `SPORT`, `DPORT`, `ACTION`. JSON mode emits an array of rule
-  objects.
-- `flow show <id>` prints one rule's full detail (including hit counters).
+- `flow-rule rm <id|name|spec>` removes by ID, by `name=<rule-name>`, or by
+  exact-match spec. If a spec matches multiple rules, the command
+  **refuses** by default and exits `6` (conflict) listing the matching
+  IDs; pass `--all` to delete every match. ID and name lookups always
+  remove exactly one rule or exit `3` (not found). Requires root.
+- `flow-rule list` lists all rules. Columns: `ID`, `NAME`, `PROTO`, `SRC`,
+  `DST`, `SPORT`, `DPORT`, `KEYS`, `FLOWS`, `ACTION`. `KEYS` is the
+  flow-key field set; `FLOWS` is the current count of live flows under
+  the rule. JSON mode emits an array of rule objects.
+- `flow-rule show <id|name>` prints one rule's full detail, including
+  configured key-set, packet/byte aggregates across all of its flows,
+  evictions, and last-seen.
+
+#### `flow list|show`
+
+Read-only views of the live flows produced by flow-rules. There is no
+`flow add` / `flow rm` — flows are created and evicted automatically by
+the backend as packets are observed.
+
+- `flow list <rule-id|name>` lists the active flows under one flow-rule.
+  Columns: `KEY` (the canonical key tuple, e.g.
+  `proto=tcp src=10.0.0.7:51234 dst=10.0.1.4:443 mirror_src=192.0.2.10`),
+  `PACKETS`, `BYTES`, `FIRST_SEEN`, `LAST_SEEN`. JSON mode emits an array
+  of flow objects. `--top N` and `--sort {bytes,packets,last_seen}` are
+  supported (default `--sort bytes --top 50`).
+- `flow show <rule-id|name> <key>` prints one flow's full counters,
+  where `<key>` is the canonical key form printed by `flow list` (the
+  CLI accepts either the full bare form or a quoted copy).
 
 #### `stats show` and `stats export`
 
@@ -343,7 +368,7 @@ are documented in their help text but always drawn from this table.
 | `3`  | Not found: requested flow ID, config key, or metric is absent. |
 | `4`  | Frontend unreachable (socket missing, connect refused, timeout).|
 | `5`  | Backend not ready (plugin not loaded, snapshot never produced).|
-| `6`  | Conflict / already-exists (e.g. `flow add` of an existing rule, `flow rm <spec>` matching multiple rules without `--all`, `install` over a dirty state without `--force`). |
+| `6`  | Conflict / already-exists (e.g. `flow-rule add` of an existing rule, `flow-rule rm <spec>` matching multiple rules without `--all`, `install` over a dirty state without `--force`). |
 | `7`  | `health` only: degraded (service up, but a non-fatal check failed — e.g. stale snapshot). |
 | `13` | Permission denied (insufficient privilege; mirrors POSIX EACCES). |
 | `69` | Service unavailable: systemd reports `failed` or `activating` longer than `--timeout`. |
@@ -364,8 +389,8 @@ cases.
 | `status`, `health`                | no             | Pure read; uses socket only.                |
 | `config get`, `config show`       | no             | Reads `/etc/infmon/infmon.toml` (group `infmon` readable). |
 | `config set`, `config reload`     | yes            | Atomic write + `SIGHUP`.                    |
-| `flow list`, `flow show`          | no             | Read via socket.                            |
-| `flow add`, `flow rm`             | yes            | Write via socket; frontend enforces `SO_PEERCRED` check. |
+| `flow-rule list`, `flow-rule show`, `flow list`, `flow show` | no             | Read via socket.                            |
+| `flow-rule add`, `flow-rule rm`   | yes            | Write via socket; frontend enforces `SO_PEERCRED` check. |
 | `stats show`, `stats export`      | no             | Read via socket.                            |
 | `log tail`                        | no\*           | `journalctl -u …` works for any user on systemd-with-persistent-journal; otherwise group `systemd-journal` may be needed. |
 
@@ -442,7 +467,7 @@ in CI via `cargo test`.
 
 - **Argument parsing** — `clap` snapshot tests for every verb, asserting
   correct rejection of bad combinations (e.g. `stats export` without
-  `--format`, `flow rm` with neither id nor spec).
+  `--format`, `flow-rule rm` with neither id, name, nor spec).
 - **Exit codes** — table-driven tests that drive each error branch and
   assert the documented exit code.
 - **Output contract** — for every read verb, golden tests for `--output
@@ -472,7 +497,7 @@ in CI via `cargo test`.
   with no stack trace; `SIGPIPE` (writing to a closed downstream pipe)
   produces exit `0` with no stderr noise. Driven by a small harness
   that spawns the CLI and closes the read end of its pipe mid-stream.
-- **`flow` spec parser** — table-driven tests for the v1 parsing grammar
+- **`flow-rule` spec parser** — table-driven tests for the v1 parsing grammar
   (bare values, double-quoted values, embedded escapes, unknown/
   duplicate keys, empty spec).
 - **E2E (not in CI)** — `tests/scenarios/cli_smoke.sh` runs against a real


### PR DESCRIPTION
## Summary

Adds `specs/007-cli.md` per parent epic **DPU-4** and issue **DPU-13**.
Freezes the v1 operator surface for `infmon-cli`.

Covers, per the issue:

- **Verb tree**: `install` / `uninstall`; `start` / `stop` / `restart` / `status`; `config get|set|reload|show`; `flow add|rm|list|show`; `stats show [--name] [--top N]`; `stats export --format prom|otlp|json`; `log tail [-f]`; `health [--json]`.
- **Exit codes**: small stable table (0, 1, 2, 3, 4, 5, 6, 13, 69, 130) with explicit semantics; `health` overload documented.
- **`--output table|json`**: every read verb supports both; JSON schema is the v1 contract; large counters rendered as `*_str` to stay JSON-safe.
- **Config file location**: `/etc/infmon/infmon.toml` (`root:infmon`, `0640`); CLI rewrites atomically (write → fsync → rename); `reload` sends SIGHUP.
- **Sudo requirements**: per-verb privilege table; root for install / lifecycle / config writes / flow mutations; group `infmon` membership for read verbs via the Unix socket at `/run/infmon/frontend.sock` (`SO_PEERCRED` enforced by frontend).
- Plus filesystem contract, global flags, help-text conventions, full test plan, and four open questions with proposed defaults.

Follows the spec template from `specs/000-overview.md`.

## Test plan

- [x] Spec is markdown only — no code changes; CI build/test jobs are unaffected.
- [x] File renders correctly on GitHub.

## Related

- Epic: DPU-4
- Closes: DPU-13

cc @banidoru for sign-off.