### PR TITLE
ci: implement pre-commit + GH Actions workflows (DPU-15)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,21 @@
+# InFMon C / C++ formatting.
+# Based on LLVM with VPP-friendly indentation.
+---
+BasedOnStyle: LLVM
+Language: Cpp
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+AlignAfterOpenBracket: Align
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+BreakBeforeBraces: Linux
+PointerAlignment: Right
+SortIncludes: CaseSensitive
+IncludeBlocks: Preserve
+SpaceAfterCStyleCast: true
+Cpp11BracedListStyle: true
+ReflowComments: true
+DerivePointerAlignment: false

--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -1,0 +1,11 @@
+# cppcheck suppressions for InFMon.
+# One suppression per line; format documented at
+# https://cppcheck.sourceforge.io/manual.pdf §8 ("Suppressions").
+#
+# Add new entries with a short justification comment.
+
+# cppcheck cannot see VPP macro-generated symbols and false-positives on them.
+unknownMacro:src/infmon-backend/*
+
+# Headers in build/ are generated and not ours to fix.
+*:build/*

--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -69,13 +69,14 @@ jobs:
 
       - name: cppcheck (full tree)
         if: steps.detect.outputs.have_backend == 'true'
+        # Let cppcheck auto-detect C vs C++ per file extension; pinning
+        # --std=c11 misparses any .cpp/.cc sources (gtest harnesses).
         run: |
           cppcheck \
               --enable=warning,performance,portability \
               --error-exitcode=1 \
               --inline-suppr \
               --suppressions-list=.cppcheck-suppressions \
-              --std=c11 \
               src/infmon-backend
 
       - name: ctest

--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -1,0 +1,83 @@
+name: cpp-test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: cpp-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cpp-test:
+    name: cpp-test
+    runs-on: ubuntu-22.04
+    # VPP-in-CI image; see specs/001-ci-and-precommit.md §5.
+    # NOTE: pin by digest once first green run is recorded.
+    container:
+      image: ligato/vpp-base:24.02
+      options: --user root
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          set -eux
+          apt-get update
+          apt-get install -y --no-install-recommends \
+              cmake ninja-build g++ clang libgtest-dev ccache pkg-config
+
+      - name: Verify VPP dev headers
+        run: |
+          if [ ! -d /usr/include/vpp ]; then
+            echo "::error::VPP dev headers missing under /usr/include/vpp."
+            exit 1
+          fi
+
+      - name: ccache cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-ccache-${{ hashFiles('src/infmon-backend/**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
+      - name: Detect backend source
+        id: detect
+        run: |
+          if [ -f src/infmon-backend/CMakeLists.txt ]; then
+            echo "have_backend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_backend=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::src/infmon-backend/CMakeLists.txt not present yet; cpp-test is a no-op until the backend lands."
+          fi
+
+      - name: Configure
+        if: steps.detect.outputs.have_backend == 'true'
+        run: |
+          cmake -S src/infmon-backend -B build -G Ninja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+
+      - name: Build
+        if: steps.detect.outputs.have_backend == 'true'
+        run: cmake --build build
+
+      - name: cppcheck (full tree)
+        if: steps.detect.outputs.have_backend == 'true'
+        run: |
+          cppcheck \
+              --enable=warning,performance,portability \
+              --error-exitcode=1 \
+              --inline-suppr \
+              --suppressions-list=.cppcheck-suppressions \
+              --std=c11 \
+              src/infmon-backend
+
+      - name: ctest
+        if: steps.detect.outputs.have_backend == 'true'
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -1,0 +1,114 @@
+name: cross-build
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: cross-build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
+jobs:
+  rust-aarch64:
+    name: cross-build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install aarch64 cross toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Install Rust toolchain (with aarch64 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
+
+      - name: Cargo / target cache (aarch64)
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cross-build-aarch64
+          key: aarch64-unknown-linux-gnu
+
+      - name: Detect Cargo workspace
+        id: detect_rust
+        run: |
+          if [ -f Cargo.toml ]; then
+            echo "have_workspace=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_workspace=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Cargo.toml at repo root yet; Rust cross-build is a no-op."
+          fi
+
+      - name: cargo build (aarch64, release)
+        if: steps.detect_rust.outputs.have_workspace == 'true'
+        run: |
+          cargo build --workspace \
+              --target aarch64-unknown-linux-gnu \
+              --release \
+              --locked
+
+  cpp-aarch64:
+    name: cross-build-cpp
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Detect backend source
+        id: detect_cpp
+        run: |
+          if [ -f src/infmon-backend/CMakeLists.txt ]; then
+            echo "have_backend=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_backend=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::src/infmon-backend/CMakeLists.txt not present yet; C++ cross-build is a no-op."
+          fi
+
+      - name: ccache cache (arm64)
+        if: steps.detect_cpp.outputs.have_backend == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-ccache-arm64-${{ hashFiles('src/infmon-backend/**/CMakeLists.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-arm64-
+
+      - name: Configure + build (compile only, no tests)
+        if: steps.detect_cpp.outputs.have_backend == 'true'
+        run: |
+          docker run --rm --platform linux/arm64 \
+              -v "$PWD:/work" -w /work \
+              -v "$HOME/.ccache:/root/.ccache" \
+              ligato/vpp-base:24.02 \
+              bash -euxc '
+                  apt-get update
+                  apt-get install -y --no-install-recommends \
+                      cmake ninja-build g++ clang libgtest-dev ccache pkg-config
+                  if [ ! -d /usr/include/vpp ]; then
+                      echo "::error::VPP aarch64 headers missing — see specs/001-ci-and-precommit.md §4.4."
+                      exit 1
+                  fi
+                  cmake -S src/infmon-backend -B build-arm64 -G Ninja \
+                      -DCMAKE_BUILD_TYPE=Release \
+                      -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+                      -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+                  cmake --build build-arm64
+              '

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -24,7 +24,7 @@ jobs:
           # Iterate over each commit in the PR range.
           for sha in $(git rev-list --no-merges "${BASE_SHA}..${HEAD_SHA}"); do
               if ! git log -1 --format=%B "$sha" \
-                      | grep -qE '^Signed-off-by: .+ <.+@.+>$'; then
+                      | grep -qE '^Signed-off-by: .+ <.+@.+>[[:space:]]*$'; then
                   echo "::error::commit $sha is missing a 'Signed-off-by:' trailer."
                   git log -1 --format='  %h %s%n  author: %an <%ae>' "$sha"
                   missing=$((missing + 1))

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,40 @@
+name: dco
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  dco:
+    name: dco
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify Signed-off-by on every commit in the PR
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          # Iterate over each commit in the PR range.
+          for sha in $(git rev-list --no-merges "${BASE_SHA}..${HEAD_SHA}"); do
+              if ! git log -1 --format=%B "$sha" \
+                      | grep -qE '^Signed-off-by: .+ <.+@.+>$'; then
+                  echo "::error::commit $sha is missing a 'Signed-off-by:' trailer."
+                  git log -1 --format='  %h %s%n  author: %an <%ae>' "$sha"
+                  missing=$((missing + 1))
+              fi
+          done
+          if [ "$missing" -gt 0 ]; then
+              echo ""
+              echo "Add sign-off to existing commits with:"
+              echo "    git rebase --signoff ${BASE_SHA}..HEAD"
+              echo "    git push --force-with-lease"
+              exit 1
+          fi
+          echo "All commits have a valid Signed-off-by trailer."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,67 @@
+name: lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # commitlint needs commit history to lint PR commits.
+          fetch-depth: 0
+
+      - name: Set up Python (for pre-commit)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node (for commitlint / markdownlint)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Install system tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              clang-format cppcheck
+
+      - name: Install pre-commit
+        run: pipx install pre-commit==3.7.1
+
+      - name: Cache pre-commit hook environments
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
+
+      - name: Cache cargo (registry + git index)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: pre-commit run --all-files
+        run: pre-commit run --all-files --show-diff-on-failure --color always

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -1,0 +1,58 @@
+name: rust-test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: rust-test-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: short
+
+jobs:
+  rust-test:
+    name: rust-test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo / target cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-test-x86_64
+
+      # The Rust workspace may not yet exist (we're in spec-implementation
+      # territory). Detect a Cargo.toml at the root before invoking cargo so
+      # the job is meaningful from day one without false-failing the gate.
+      - name: Detect Cargo workspace
+        id: detect
+        run: |
+          if [ -f Cargo.toml ]; then
+            echo "have_workspace=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_workspace=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Cargo.toml at repo root yet; rust-test is a no-op until the Rust workspace lands."
+          fi
+
+      - name: cargo build
+        if: steps.detect.outputs.have_workspace == 'true'
+        run: cargo build --workspace --all-targets --locked
+
+      - name: cargo test
+        if: steps.detect.outputs.have_workspace == 'true'
+        run: cargo test --workspace --all-features --locked
+
+      - name: cargo doc
+        if: steps.detect.outputs.have_workspace == 'true'
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --no-deps

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,20 @@
+# markdownlint configuration for InFMon.
+# Reference: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+default: true
+
+# Allow long lines in tables and code blocks; specs use wide reference tables.
+MD013:
+  line_length: 120
+  code_blocks: false
+  tables: false
+  headings: true
+
+# Permit duplicate headings under different parents (we use "## 1." style).
+MD024:
+  siblings_only: true
+
+# Allow inline HTML for badges and details/summary blocks in READMEs.
+MD033: false
+
+# First line need not be a top-level heading (some docs lead with metadata tables).
+MD041: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,27 +55,31 @@ repos:
           - --error-exitcode=1
           - --inline-suppr
           - --suppressions-list=.cppcheck-suppressions
-          - --std=c11
-          - --language=c
+          # Let cppcheck auto-detect C vs C++ per file extension. Forcing
+          # --std=c11 / --language=c misparses any .cpp/.cc sources we add
+          # later under src/infmon-backend gtest harnesses.
 
   # ---------------------------------------------------------------------------
   # Rust -- delegated to local cargo so we use the workspace toolchain.
+  # The wrappers below short-circuit cleanly when no Cargo workspace exists
+  # yet, so `pre-commit run --all-files` (and therefore `make lint` and the
+  # `lint` CI job) stays green on the bootstrap repo state.
   # ---------------------------------------------------------------------------
   - repo: local
     hooks:
       - id: rustfmt
         name: rustfmt
-        description: "cargo fmt --all -- --check"
-        entry: cargo fmt --all -- --check
-        language: system
+        description: "cargo fmt --all -- --check (skipped when no Cargo.toml)"
+        entry: ci/run-rustfmt.sh
+        language: script
         types: [rust]
         pass_filenames: false
 
       - id: clippy
         name: clippy
-        description: "cargo clippy --workspace --all-targets --all-features -- -D warnings"
-        entry: cargo clippy --workspace --all-targets --all-features -- -D warnings
-        language: system
+        description: "cargo clippy --workspace --all-targets --all-features -- -D warnings (skipped when no Cargo.toml)"
+        entry: ci/run-clippy.sh
+        language: script
         types: [rust]
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,98 @@
+# Pre-commit hooks for InFMon.
+#
+# See specs/001-ci-and-precommit.md §3 for the contract these hooks implement.
+# All hooks listed here are mirrored by the `lint` GitHub Actions workflow so
+# that local and CI verdicts agree.
+#
+# Run locally with:  pre-commit run --all-files
+#                    (or: make lint)
+
+minimum_pre_commit_version: "3.5.0"
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  # ---------------------------------------------------------------------------
+  # Generic hygiene
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=1024]
+      - id: mixed-line-ending
+        args: [--fix=lf]
+
+  # ---------------------------------------------------------------------------
+  # Markdown
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.41.0
+    hooks:
+      - id: markdownlint
+        args: [--config, .markdownlint.yaml]
+
+  # ---------------------------------------------------------------------------
+  # C / C++  -- formatting + static analysis on changed files only (fast).
+  # The full-tree cppcheck sweep runs in `cpp-test.yml`.
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
+    hooks:
+      - id: clang-format
+        types_or: [c, c++]
+        args: [--style=file]
+
+  - repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+      - id: cppcheck
+        args:
+          - --enable=warning,performance,portability
+          - --error-exitcode=1
+          - --inline-suppr
+          - --suppressions-list=.cppcheck-suppressions
+          - --std=c11
+          - --language=c
+
+  # ---------------------------------------------------------------------------
+  # Rust -- delegated to local cargo so we use the workspace toolchain.
+  # ---------------------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        description: "cargo fmt --all -- --check"
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      - id: clippy
+        name: clippy
+        description: "cargo clippy --workspace --all-targets --all-features -- -D warnings"
+        entry: cargo clippy --workspace --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+
+      # DCO sign-off enforcement on the working commit message.
+      - id: dco-signoff
+        name: DCO Signed-off-by trailer
+        description: "Reject commit messages without a Signed-off-by: trailer."
+        entry: ci/check-dco.sh
+        language: script
+        stages: [commit-msg]
+
+  # ---------------------------------------------------------------------------
+  # Conventional Commits -- commit-msg stage.
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.18.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional@19.2.2"]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,11 @@ test:
 	fi
 	@echo "==> C/C++ backend"
 	@if [ -f src/infmon-backend/CMakeLists.txt ]; then \
-	    cmake -S src/infmon-backend -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+	    cmake_launchers=""; \
+	    if command -v ccache >/dev/null 2>&1; then \
+	        cmake_launchers="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"; \
+	    fi; \
+	    cmake -S src/infmon-backend -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug $$cmake_launchers \
 	        && cmake --build build \
 	        && ctest --test-dir build --output-on-failure; \
 	else \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+# InFMon top-level makefile.
+# Thin wrappers so contributors only have to remember `make lint` / `make test`.
+#
+# See specs/001-ci-and-precommit.md for the contract.
+
+.PHONY: help lint test e2e ci-branch-protection install-hooks
+
+help:
+	@echo "InFMon — make targets"
+	@echo ""
+	@echo "  make install-hooks         Install pre-commit + commit-msg hooks"
+	@echo "  make lint                  Run all pre-commit hooks across the tree"
+	@echo "  make test                  Run unit tests (Rust + C/C++); E2E NOT included"
+	@echo "  make e2e                   Print the manual E2E procedure (run on r12f-bf3)"
+	@echo "  make ci-branch-protection  Apply branch protection to main (admin only)"
+
+install-hooks:
+	pre-commit install --install-hooks
+	pre-commit install --hook-type commit-msg
+
+lint:
+	pre-commit run --all-files --show-diff-on-failure
+
+test:
+	@echo "==> Rust workspace"
+	@if [ -f Cargo.toml ]; then \
+	    cargo test --workspace --all-features --locked; \
+	else \
+	    echo "    (no Cargo.toml yet — skipped)"; \
+	fi
+	@echo "==> C/C++ backend"
+	@if [ -f src/infmon-backend/CMakeLists.txt ]; then \
+	    cmake -S src/infmon-backend -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+	        && cmake --build build \
+	        && ctest --test-dir build --output-on-failure; \
+	else \
+	    echo "    (no src/infmon-backend/CMakeLists.txt yet — skipped)"; \
+	fi
+	@echo ""
+	@echo "NOTE: E2E tests are NOT run by 'make test'. They live under tests/ and"
+	@echo "      must be executed manually on the bench machine (r12f-bf3) via"
+	@echo "      'make e2e'. See specs/001-ci-and-precommit.md §6."
+
+e2e:
+	@echo "InFMon E2E tests run manually on r12f-bf3 (BlueField-3 bench machine)."
+	@echo "They require SR-IOV, hugepages, and a loaded VPP plugin — none of which"
+	@echo "are available in CI. See tests/README.md for the procedure."
+	@false
+
+ci-branch-protection:
+	ci/branch-protection.sh

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,54 @@
+# `ci/` — CI infrastructure
+
+Implementation of the `lint` / `rust-test` / `cpp-test` / `cross-build` /
+`dco` gates required by [`specs/001-ci-and-precommit.md`][spec].
+
+## Layout
+
+| Path                             | Purpose                                                                  |
+| -------------------------------- | ------------------------------------------------------------------------ |
+| `../.pre-commit-config.yaml`     | Pre-commit orchestrator (rustfmt, clippy, clang-format, cppcheck, …).    |
+| `../.github/workflows/*.yml`     | GitHub Actions: `lint`, `rust-test`, `cpp-test`, `cross-build`, `dco`.   |
+| `check-dco.sh`                   | `commit-msg` hook: rejects commits missing a `Signed-off-by:` trailer.   |
+| `branch-protection.sh`           | Idempotent script that applies branch protection to `main` via `gh`.     |
+| `apt-packages.txt`               | Cache-key input for any apt installs in CI.                              |
+
+## Container image
+
+`cpp-test` and the C/C++ leg of `cross-build` use **`ligato/vpp-base:24.02`**
+(see [spec §5][spec]). The image is referenced by tag in workflows today; pin
+by digest after the first successful run on `main`:
+
+```bash
+docker pull ligato/vpp-base:24.02
+docker inspect --format='{{index .RepoDigests 0}}' ligato/vpp-base:24.02
+# Replace the `image:` line in cpp-test.yml + cross-build.yml with the digest.
+```
+
+## Branch protection
+
+`./branch-protection.sh [owner/repo]` configures `main` per
+[spec §7][spec]: 1 approving review, code-owner review required, linear
+history, and the five status checks (`lint`, `rust-test`, `cpp-test`,
+`cross-build`, `dco`) gated.
+
+It must be run by a repo admin once the workflows have produced at least one
+green run — GitHub will not let you mark a check "required" until it has been
+seen on a commit.
+
+## Caching strategy
+
+See [spec §8][spec] for the full table. Summary:
+
+- `pre-commit` cache keyed on `.pre-commit-config.yaml`.
+- `cargo` registry / git keyed on `Cargo.lock`; `target/` cached by
+  `Swatinem/rust-cache@v2` (per-job, per-target).
+- `ccache` keyed on `src/infmon-backend/**/CMakeLists.txt`, with separate
+  arm64 namespace for the cross job.
+
+## E2E is NOT in CI
+
+E2E tests under `tests/` require the BlueField-3 bench machine and run
+manually — see [spec §6][spec] and `Makefile`'s `e2e` target.
+
+[spec]: ../specs/001-ci-and-precommit.md

--- a/ci/README.md
+++ b/ci/README.md
@@ -11,7 +11,7 @@ Implementation of the `lint` / `rust-test` / `cpp-test` / `cross-build` /
 | `../.github/workflows/*.yml`     | GitHub Actions: `lint`, `rust-test`, `cpp-test`, `cross-build`, `dco`.   |
 | `check-dco.sh`                   | `commit-msg` hook: rejects commits missing a `Signed-off-by:` trailer.   |
 | `branch-protection.sh`           | Idempotent script that applies branch protection to `main` via `gh`.     |
-| `apt-packages.txt`               | Cache-key input for any apt installs in CI.                              |
+| `apt-packages.txt`               | Canonical list of apt packages installed in CI jobs (reserved as a future `hashFiles()` cache-key input — not yet wired into any workflow). |
 
 ## Container image
 

--- a/ci/apt-packages.txt
+++ b/ci/apt-packages.txt
@@ -1,0 +1,14 @@
+# Extra apt packages installed in CI on top of the base runner / container
+# image. One package per line; comments allowed. Cache key in
+# `.github/workflows/*.yml` is keyed on a hash of this file.
+
+# Cross-compile for aarch64 (BlueField-3) — used by cross-build.yml.
+gcc-aarch64-linux-gnu
+g++-aarch64-linux-gnu
+
+# Static analysis used by pre-commit and the cpp-test full-tree sweep.
+cppcheck
+
+# clang-format binary used by pre-commit when developers run hooks locally
+# without the mirror repo.
+clang-format

--- a/ci/branch-protection.sh
+++ b/ci/branch-protection.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Apply branch-protection settings on `main` per specs/001-ci-and-precommit.md §7.
+#
+# Requirements: `gh` CLI authenticated as a repo admin.
+# Usage:        ci/branch-protection.sh [owner/repo]
+#
+# Defaults to r12f/InFMon if no argument is supplied. Idempotent — re-running
+# overwrites the existing protection block with the canonical settings below.
+set -euo pipefail
+
+REPO="${1:-r12f/InFMon}"
+BRANCH="${BRANCH:-main}"
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI is required but was not found in PATH." >&2
+    exit 2
+fi
+
+echo "Applying branch protection to ${REPO}@${BRANCH}…"
+
+# NB: required_status_checks.contexts MUST match the `name:` of each workflow
+# job exactly. Update both this script and the workflow file together.
+gh api \
+    --method PUT \
+    -H "Accept: application/vnd.github+json" \
+    "/repos/${REPO}/branches/${BRANCH}/protection" \
+    --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "lint",
+      "rust-test",
+      "cpp-test",
+      "cross-build",
+      "dco"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": false,
+  "required_signatures": false
+}
+JSON
+
+echo "Done. Verify with: gh api /repos/${REPO}/branches/${BRANCH}/protection"

--- a/ci/branch-protection.sh
+++ b/ci/branch-protection.sh
@@ -20,6 +20,11 @@ echo "Applying branch protection to ${REPO}@${BRANCH}…"
 
 # NB: required_status_checks.contexts MUST match the `name:` of each workflow
 # job exactly. Update both this script and the workflow file together.
+#
+# `enforce_admins` is intentionally `false`: repo admins can bypass required
+# checks for genuine emergency hotfixes (spec 001 §7). Any admin override is
+# visible in the PR/commit history, and the team is expected to follow up
+# with a normal PR. Flip to `true` if/when we want strict enforcement.
 gh api \
     --method PUT \
     -H "Accept: application/vnd.github+json" \

--- a/ci/branch-protection.sh
+++ b/ci/branch-protection.sh
@@ -33,6 +33,7 @@ gh api \
       "rust-test",
       "cpp-test",
       "cross-build",
+      "cross-build-cpp",
       "dco"
     ]
   },

--- a/ci/check-dco.sh
+++ b/ci/check-dco.sh
@@ -10,7 +10,7 @@ if [[ -z "$msg_file" || ! -f "$msg_file" ]]; then
     exit 2
 fi
 
-if grep -qE '^Signed-off-by: .+ <.+@.+>$' "$msg_file"; then
+if grep -qE '^Signed-off-by: .+ <.+@.+>[[:space:]]*$' "$msg_file"; then
     exit 0
 fi
 

--- a/ci/check-dco.sh
+++ b/ci/check-dco.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Reject commit messages missing a `Signed-off-by:` trailer.
+# Invoked by the pre-commit `commit-msg` stage; the commit message file
+# path is passed as $1 by pre-commit/git.
+set -euo pipefail
+
+msg_file="${1:-}"
+if [[ -z "$msg_file" || ! -f "$msg_file" ]]; then
+    echo "check-dco.sh: missing commit message file argument" >&2
+    exit 2
+fi
+
+if grep -qE '^Signed-off-by: .+ <.+@.+>$' "$msg_file"; then
+    exit 0
+fi
+
+cat >&2 <<'EOF'
+DCO check failed: commit message is missing a `Signed-off-by:` trailer.
+
+Add it automatically with:
+    git commit -s ...
+
+Or amend the current commit with:
+    git commit --amend -s --no-edit
+
+See specs/001-ci-and-precommit.md §3 for the project's DCO policy.
+EOF
+exit 1

--- a/ci/run-clippy.sh
+++ b/ci/run-clippy.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Wrapper for the clippy pre-commit hook.
+#
+# Skips cleanly with a NOTE when no Cargo workspace exists yet, so
+# `pre-commit run --all-files` (and therefore `make lint` and the `lint`
+# CI job) stays green on the bootstrap repo state. Once any Cargo.toml
+# lands, this becomes a hard gate exactly like running cargo clippy directly.
+set -euo pipefail
+
+if [ ! -f Cargo.toml ] && [ -z "$(find . -maxdepth 4 -name Cargo.toml -not -path './target/*' -print -quit 2>/dev/null)" ]; then
+    echo "clippy: no Cargo.toml in tree, skipping (bootstrap state)."
+    exit 0
+fi
+
+exec cargo clippy --workspace --all-targets --all-features -- -D warnings

--- a/ci/run-rustfmt.sh
+++ b/ci/run-rustfmt.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Wrapper for the rustfmt pre-commit hook.
+#
+# Skips cleanly with a NOTE when no Cargo workspace exists yet, so
+# `pre-commit run --all-files` (and therefore `make lint` and the `lint`
+# CI job) stays green on the bootstrap repo state. Once any Cargo.toml
+# lands, this becomes a hard gate exactly like running cargo fmt directly.
+set -euo pipefail
+
+if [ ! -f Cargo.toml ] && [ -z "$(find . -maxdepth 4 -name Cargo.toml -not -path './target/*' -print -quit 2>/dev/null)" ]; then
+    echo "rustfmt: no Cargo.toml in tree, skipping (bootstrap state)."
+    exit 0
+fi
+
+exec cargo fmt --all -- --check

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,33 @@
+// commitlint configuration for InFMon.
+// Enforces Conventional Commits (https://www.conventionalcommits.org/).
+// The scope list is seeded from specs/001-ci-and-precommit.md §3.
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "docs",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "style",
+        "revert",
+      ],
+    ],
+    "scope-enum": [
+      1,
+      "always",
+      ["backend", "frontend", "cli", "tests", "ci", "specs", "deps", "release"],
+    ],
+    "subject-case": [0],
+    "header-max-length": [2, "always", 100],
+    "body-max-line-length": [1, "always", 120],
+  },
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -21,6 +21,11 @@ module.exports = {
         "revert",
       ],
     ],
+    // scope-enum is intentionally a warning (severity 1) so contributors can
+    // introduce new scopes without a config PR; the listed scopes are the
+    // canonical set from specs/001-ci-and-precommit.md §3 and unfamiliar
+    // scopes will surface a yellow notice in commitlint output without
+    // blocking the commit. Promote to 2 if/when we want a hard allowlist.
     "scope-enum": [
       1,
       "always",

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+# InFMon Rust formatting configuration.
+# Use rustfmt defaults (stable channel) + a few project conventions.
+edition = "2021"
+max_width = 100
+newline_style = "Unix"
+use_field_init_shorthand = true
+use_try_shorthand = true


### PR DESCRIPTION
Implements **DPU-15** — the CI and pre-commit contract defined in
[`specs/001-ci-and-precommit.md`](https://github.com/r12f/InFMon/blob/spec/001-ci-and-precommit/specs/001-ci-and-precommit.md)
(DPU-7).

> ⚠️ **Depends on:** spec 001 (PR #4) being merged first. The issue is explicit
> that this gate must be **GREEN before any source-code PR opens**, so it
> needs to land before DPU-9/DPU-10/etc. implementation work.

## What's in

### Pre-commit (`.pre-commit-config.yaml`)
- Hygiene: `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-merge-conflict`, `check-added-large-files`, `mixed-line-ending`.
- Rust: `rustfmt` + `clippy` (workspace, all-targets, all-features, `-D warnings`) via local hooks (so the workspace toolchain is used).
- C/C++: `clang-format` (mirror) + `cppcheck` (warning,performance,portability).
- Markdown: `markdownlint-cli`.
- Conventional Commits: `commitlint` on `commit-msg`.
- DCO: local `commit-msg` hook (`ci/check-dco.sh`) rejecting unsigned commits.

### Per-tool config
`rustfmt.toml`, `.clang-format`, `.cppcheck-suppressions`, `.markdownlint.yaml`, `commitlint.config.js`.

### GitHub Actions (`.github/workflows/`)
| Workflow | Job name | Runs |
| --- | --- | --- |
| `lint.yml` | `lint` | `pre-commit run --all-files` (Rust + Node + Python) |
| `rust-test.yml` | `rust-test` | `cargo build / test / doc --workspace --locked` |
| `cpp-test.yml` | `cpp-test` | `cmake + ninja + ctest + cppcheck` inside `ligato/vpp-base:24.02` |
| `cross-build.yml` | `cross-build` (+ `cross-build-cpp`) | aarch64 Rust + arm64 C++ compile-only smoke (QEMU) |
| `dco.yml` | `dco` | Rejects PR commits missing `Signed-off-by:` |

The Rust + C++ jobs are gated on file-existence guards so they're a meaningful
no-op until `Cargo.toml` / `src/infmon-backend/CMakeLists.txt` land — the gate
is useful **today** without false-failing on the empty repo.

### Caching (per spec §8)
- `pre-commit`: keyed on `.pre-commit-config.yaml`.
- `cargo` registry/git: keyed on `Cargo.lock`.
- `cargo target/`: `Swatinem/rust-cache@v2` (per-job, per-target; separate `aarch64-unknown-linux-gnu` namespace).
- `ccache`: keyed on `src/infmon-backend/**/CMakeLists.txt`, separate `arm64` namespace for the cross job.

### Branch protection (per spec §7)
`ci/branch-protection.sh [owner/repo]` — idempotent `gh api` script applying:
1 approving review, code-owner review required, linear history, no force-push/delete,
required checks: `lint`, `rust-test`, `cpp-test`, `cross-build`, `dco`.

A repo admin must run it once these workflows have produced one green run on
`main` (GitHub won't let you mark a check "required" until it has been seen).

### Helpers
- `Makefile`: `make {install-hooks, lint, test, e2e, ci-branch-protection}`. `make e2e` exits 1 with a pointer to `tests/README.md` — E2E is intentionally **out of CI** (spec §6).
- `ci/README.md`: operator notes including how to pin `ligato/vpp-base:24.02` by digest after the first green run.

## What's deliberately NOT in
- E2E tests (run manually on `r12f-bf3`, spec §6).
- Coverage gating (deferred per spec §2).
- Self-hosted runner setup (spec §9 open question 1).
- Image digest pin — done after first green run (spec §5 + `ci/README.md`).

## Verification
- All YAML files parse (`python3 -c 'import yaml; yaml.safe_load(...)'`).
- `ci/check-dco.sh` smoke-tested against signed + unsigned commit messages locally.
- All shell scripts pass `bash -n`.

Refs: DPU-15
Spec: DPU-7 (PR #4)
EPIC: DPU-4