### PR TITLE
specs: fix eviction policy contradiction — adopt lru_drop for v1

### DIFF
--- a/specs/000-overview.md
+++ b/specs/000-overview.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author      | Changes |
 | ------- | ---------- | ----------- | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f) | Initial draft. Establishes mission, scope, component map, repo layout, build/release model, glossary (incl. flow / flow-rule), and pointers to the canonical spec template at [`TEMPLATE.md`](TEMPLATE.md). |
+| 0.2     | 2026-04-18 | BF-3 (bf3)  | Fix eviction policy references: §5 step 5 now points to spec 002 (not 003); §open-questions item 3 updated to reflect `lru_drop` decision. |
 
 ---
 
@@ -151,7 +152,7 @@ packets         |     v                                         |
 4. **Match & key.** L2–L4 parser produces a flow key (5-tuple + VRF/VNI when
    available) and per-packet metadata (length, TCP flags, timestamp).
 5. **Update.** Flow table lookup; on hit, update counters in place; on miss,
-   insert a new flow record (with eviction policy per spec 003 to be written).
+   insert a new flow record (with eviction policy per spec 002).
 6. **Snapshot.** Frontend periodically reads the backend's exposed snapshot
    (lock-free / RCU-style; details in spec 002) and builds an aggregate view.
 7. **Export.** Frontend pushes records to configured exporters and serves
@@ -333,8 +334,7 @@ explanations of each rule.
 2. **Snapshot transport** — shared memory ring vs. local Unix-domain socket
    vs. gRPC. Decided in spec 002. *Default:* shared-memory ring (lowest
    overhead on DPU).
-3. **Flow table eviction policy** — LRU, time-based, or hybrid. Decided in
-   spec 003. *Default:* time-based with active/idle timeouts (IPFIX-aligned).
+3. **Flow table eviction policy** — `lru_drop` (decided in spec 002 §6).
 4. **Distro target** — Ubuntu 22.04 only, or also DOCA's recommended base?
    Decided in spec 005. *Default:* Ubuntu 22.04 arm64.
 5. **Frontend API authn/authz** — v1 ships with UNIX-group-based access on a

--- a/specs/000-overview.md
+++ b/specs/000-overview.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author      | Changes |
 | ------- | ---------- | ----------- | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f) | Initial draft. Establishes mission, scope, component map, repo layout, build/release model, glossary (incl. flow / flow-rule), and pointers to the canonical spec template at [`TEMPLATE.md`](TEMPLATE.md). |
-| 0.2     | 2026-04-18 | BF-3 (bf3)  | Fix eviction policy references: §5 step 5 now points to spec 002 (not 003); §open-questions item 3 updated to reflect `lru_drop` decision. |
+| 0.2     | 2026-04-18 | Riff (r12f)  | Fix eviction policy references: §5 step 5 now points to spec 002 (not 003); §open-questions item 3 updated to reflect `lru_drop` decision. |
 
 ---
 

--- a/specs/004-backend-architecture.md
+++ b/specs/004-backend-architecture.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-backend` (VPP plugin). Linear-probing flow table with offset-based descriptors, memory ordering, epoch-based RCU, scratch cap, alloc-failed recovery; internal identifiers use `flow_rule*` per Spec 002 mental model; per-worker scratch-triple and §6 emit format use `flow_rule_index` (u32 handle), keeping the 24 B/entry estimate. |
-| 0.2     | 2026-04-18 | BF-3 (bf3)   | Fix eviction policy contradiction: §5.2 now adopts `lru_drop` (spec 002 §6) instead of deferring eviction to v2. Updated §11 `counter_table_full` description accordingly. |
+| 0.2     | 2026-04-18 | Riff (r12f)   | Fix eviction policy contradiction: §5.2 now adopts `lru_drop` (spec 002 §6) instead of deferring eviction to v2. Updated §11 `counter_table_full` description accordingly. |
 
 - **Depends on:** [`000-overview`](000-overview.md), [`002-flow-tracking-model`](002-flow-tracking-model.md), [`003-erspan-and-packet-parsing`](003-erspan-and-packet-parsing.md)
 

--- a/specs/004-backend-architecture.md
+++ b/specs/004-backend-architecture.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-backend` (VPP plugin). Linear-probing flow table with offset-based descriptors, memory ordering, epoch-based RCU, scratch cap, alloc-failed recovery; internal identifiers use `flow_rule*` per Spec 002 mental model; per-worker scratch-triple and §6 emit format use `flow_rule_index` (u32 handle), keeping the 24 B/entry estimate. |
+| 0.2     | 2026-04-18 | BF-3 (bf3)   | Fix eviction policy contradiction: §5.2 now adopts `lru_drop` (spec 002 §6) instead of deferring eviction to v2. Updated §11 `counter_table_full` description accordingly. |
 
 - **Depends on:** [`000-overview`](000-overview.md), [`002-flow-tracking-model`](002-flow-tracking-model.md), [`003-erspan-and-packet-parsing`](003-erspan-and-packet-parsing.md)
 
@@ -158,8 +159,11 @@ struct infmon_slot {
   exhaustion we increment a per-table `insert_failed` counter and drop
   the contribution from this packet (the packet itself still goes to
   `drop`, like every other packet — InFMon never forwards).
-- Table full → contribution dropped, `table_full` counter incremented.
-  We deliberately do not evict; eviction policy is a v2 conversation.
+- Table full → the `lru_drop` eviction policy (spec 002 §6) applies:
+  evict the least-recently-updated key, drop its residual counters,
+  increment `infmon_flow_rule_evictions_total`, and insert the new key.
+  If eviction itself fails, the contribution is dropped and
+  `counter_insert_retry_exhausted` is incremented.
 
 ### 5.3 Width
 
@@ -373,7 +377,7 @@ The plugin exposes the following error counters via the standard VPP
 | `inner_parse_failed`          | Inner L2/L3/L4 parse error after decap.              |
 | `flow_rule_no_match`           | Packet matched zero flow_rules (informational).       |
 | `counter_insert_retry_exhausted` | CAS retries exceeded `INFMON_INSERT_RETRY`.        |
-| `counter_table_full`          | Table reached `max_keys_per_flow_rule`.               |
+| `counter_table_full`          | Table reached `max_keys_per_flow_rule`; `lru_drop` eviction triggered (spec 002 §6). |
 | `snapshot_alloc_failed`       | Could not allocate replacement table (OOM in stats segment). |
 
 **`snapshot_alloc_failed` recovery contract.** If step 2 of §7.2 fails,


### PR DESCRIPTION
## Summary

Spec 004 §5.2 stated *"We deliberately do not evict; eviction policy is a v2 conversation"* which directly contradicts spec 002 §6 that defines `lru_drop` as the v1 eviction policy.

**Decision (per DPU-25):** spec 002 is correct — `lru_drop` is the v1 policy.

## Changes

### Spec 004 (backend architecture)
- **§5.2**: Replaced the no-eviction statement with a reference to spec 002 §6's `lru_drop` policy
- **§11**: Updated `counter_table_full` error counter description to note that eviction is triggered

### Spec 000 (overview)
- **§5 step 5**: Fixed cross-reference from "spec 003 to be written" → "spec 002" 
- **Open questions item 3**: Replaced open question about eviction policy with the decided answer (`lru_drop`)

## Verification
- Searched all specs for eviction/lru references — no other contradictions found
- Specs 002, 005, 006, 007 already correctly reference `lru_drop` / eviction from spec 002

Resolves: DPU-25