### PR TITLE
specs: fix exporter format references — OTLP is the only v1 exporter

### DIFF
--- a/specs/000-overview.md
+++ b/specs/000-overview.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author      | Changes |
 | ------- | ---------- | ----------- | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f) | Initial draft. Establishes mission, scope, component map, repo layout, build/release model, glossary (incl. flow / flow-rule), and pointers to the canonical spec template at [`TEMPLATE.md`](TEMPLATE.md). |
-| 0.2     | 2026-04-18 | BF-3 (bf3)  | Fix exporter format references: OTLP is the only v1 exporter (per spec 006). Update cross-references from spec 004 to spec 006, remove IPFIX-first language. |
+| 0.2     | 2026-04-18 | Riff (r12f)  | Fix exporter format references: OTLP is the only v1 exporter (per spec 006). Update cross-references from spec 004 to spec 006, remove IPFIX-first language. |
 
 ---
 

--- a/specs/000-overview.md
+++ b/specs/000-overview.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author      | Changes |
 | ------- | ---------- | ----------- | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f) | Initial draft. Establishes mission, scope, component map, repo layout, build/release model, glossary (incl. flow / flow-rule), and pointers to the canonical spec template at [`TEMPLATE.md`](TEMPLATE.md). |
+| 0.2     | 2026-04-18 | BF-3 (bf3)  | Fix exporter format references: OTLP is the only v1 exporter (per spec 006). Update cross-references from spec 004 to spec 006, remove IPFIX-first language. |
 
 ---
 
@@ -53,8 +54,8 @@ In-scope for v1:
 > of the opaque inner payload, not extracted into the flow key. This will be
 > revisited in spec 002 (parser).
 - Expose a snapshot/aggregate API consumed by `infmon-frontend`.
-- Ship exporters for at least one standard format (IPFIX or OpenTelemetry —
-  decided in spec 004).
+- Ship an OTLP exporter as the only v1 export format (see
+  [spec 006](006-exporter-otlp.md)).
 - A CLI (`infmon-cli`) for inspection, debugging, and admin.
 - Packaging as a `.deb` for **arm64 / aarch64**, single artifact for v1.
 
@@ -90,7 +91,7 @@ packets         |     v                                         |
                 |            v                                  |
                 |  +-------------------+    +---------------+   |
                 |  | infmon-frontend   |--->| exporters     |---+--> collectors
-                |  | (Rust)            |    | (IPFIX/OTel)  |   |     (off-DPU)
+                |  | (Rust)            |    | (OTLP)        |   |     (off-DPU)
                 |  | - aggregate       |    +---------------+   |
                 |  | - serve API       |                        |
                 |  +---------+---------+                        |
@@ -290,7 +291,7 @@ running Ubuntu 22.04 / DOCA-supported distro).
 - **Aggregate** — Frontend-side reduction of snapshots over a window (e.g.
   top-N talkers, per-VRF totals).
 - **Exporter** — Component that pushes flow records to an external collector
-  in a standard format (IPFIX, OpenTelemetry metrics/logs, etc.).
+  in a standard format (OTLP for v1; see [spec 006](006-exporter-otlp.md)).
 - **Collector** — Off-DPU consumer of exported records.
 - **Frontend** — `infmon-frontend`, the Rust user-space service that owns
   aggregation, exporters, and the API surface for the CLI.
@@ -327,9 +328,8 @@ explanations of each rule.
 
 ## Open Questions
 
-1. **Exporter format for v1** — IPFIX, OpenTelemetry, or both? Decided in
-   spec 004. *Default:* IPFIX first (broadest collector support); OTel as a
-   fast follow.
+1. **Exporter format for v1** — OTLP is the only v1 exporter. Decided in
+   [spec 006](006-exporter-otlp.md).
 2. **Snapshot transport** — shared memory ring vs. local Unix-domain socket
    vs. gRPC. Decided in spec 002. *Default:* shared-memory ring (lowest
    overhead on DPU).

--- a/specs/004-backend-architecture.md
+++ b/specs/004-backend-architecture.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-backend` (VPP plugin). Linear-probing flow table with offset-based descriptors, memory ordering, epoch-based RCU, scratch cap, alloc-failed recovery; internal identifiers use `flow_rule*` per Spec 002 mental model; per-worker scratch-triple and §6 emit format use `flow_rule_index` (u32 handle), keeping the 24 B/entry estimate. |
-| 0.2     | 2026-04-18 | BF-3 (bf3)  | Remove IPFIX from out-of-scope bullet — OTLP is the only v1 exporter. |
+| 0.2     | 2026-04-18 | Riff (r12f)  | Remove IPFIX from out-of-scope bullet — OTLP is the only v1 exporter. |
 
 - **Depends on:** [`000-overview`](000-overview.md), [`002-flow-tracking-model`](002-flow-tracking-model.md), [`003-erspan-and-packet-parsing`](003-erspan-and-packet-parsing.md)
 

--- a/specs/004-backend-architecture.md
+++ b/specs/004-backend-architecture.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-backend` (VPP plugin). Linear-probing flow table with offset-based descriptors, memory ordering, epoch-based RCU, scratch cap, alloc-failed recovery; internal identifiers use `flow_rule*` per Spec 002 mental model; per-worker scratch-triple and §6 emit format use `flow_rule_index` (u32 handle), keeping the 24 B/entry estimate. |
+| 0.2     | 2026-04-18 | BF-3 (bf3)  | Remove IPFIX from out-of-scope bullet — OTLP is the only v1 exporter. |
 
 - **Depends on:** [`000-overview`](000-overview.md), [`002-flow-tracking-model`](002-flow-tracking-model.md), [`003-erspan-and-packet-parsing`](003-erspan-and-packet-parsing.md)
 
@@ -46,7 +47,7 @@ In-scope:
 
 Out of scope (deferred to later specs):
 
-- Wire format of OTLP / IPFIX exports — spec 006.
+- Wire format of OTLP exports — spec 006.
 - Frontend aggregation logic, REST surface, auth — spec 005.
 - CLI UX — spec 007.
 - Persistence of flow definitions across reboots — v2.

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-cli` v1: verb tree, output contract, exit codes, config layout, privilege model. Verb tree splits `flow-rule {add,rm,list,show}` (configuration) from `flow {list,show}` (live read-only views) — each flow-rule generates one flow per distinct key tuple. SIGPIPE installs an `exit(0)` handler so the documented "exits 0 silently" claim holds (avoids the POSIX 141 path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); multi-positional unquoted keys are rejected with exit 2. |
+| 0.2     | 2026-04-18 | BF-3 (bf3)  | Update config example from `exporter.ipfix.collector` to `exporter.otlp.endpoint` — OTLP is the only v1 exporter. |
 
 ---
 
@@ -205,7 +206,7 @@ an object:
 - `config show` prints the effective merged config (defaults + file +
   environment overrides) as TOML (table mode) or JSON (json mode).
 - `config get <key>` prints just that key's value. Dotted keys index into
-  tables: `config get exporter.ipfix.collector`.
+  tables: `config get exporter.otlp.endpoint`.
 - `config set <key> <value>` rewrites `/etc/infmon/infmon.toml` atomically
   with the new value. Type is inferred from the existing value's type
   (string, int, bool, float, array). `--type <t>` can force the type when

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-cli` v1: verb tree, output contract, exit codes, config layout, privilege model. Verb tree splits `flow-rule {add,rm,list,show}` (configuration) from `flow {list,show}` (live read-only views) — each flow-rule generates one flow per distinct key tuple. SIGPIPE installs an `exit(0)` handler so the documented "exits 0 silently" claim holds (avoids the POSIX 141 path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); multi-positional unquoted keys are rejected with exit 2. |
-| 0.2     | 2026-04-18 | BF-3 (bf3)  | Update config example from `exporter.ipfix.collector` to `exporter.otlp.endpoint` — OTLP is the only v1 exporter. |
+| 0.2     | 2026-04-18 | Riff (r12f)  | Update config example from `exporter.ipfix.collector` to `exporter.otlp.endpoint` — OTLP is the only v1 exporter. |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes inconsistent exporter format references across specs. Per spec 006 §1, OTLP is the only v1 exporter.

### Changes

- **Spec 000 (overview):** Update cross-references from spec 004 → spec 006, replace "IPFIX first; OTel fast follow" with "OTLP only for v1", update ASCII diagram label and glossary entry.
- **Spec 004 (backend):** Remove IPFIX from out-of-scope bullet (was "OTLP / IPFIX", now "OTLP").
- **Spec 007 (CLI):** Update config example from `exporter.ipfix.collector` to `exporter.otlp.endpoint`.

Contextual IPFIX references (existing-tool mentions in §Context, timeout conventions, historical bug patterns) are left intact — they are not exporter-format claims.

Closes DPU-26.