### PR TITLE
specs: standardize CLI binary name to infmonctl

### DIFF
--- a/specs/000-overview.md
+++ b/specs/000-overview.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author      | Changes |
 | ------- | ---------- | ----------- | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f) | Initial draft. Establishes mission, scope, component map, repo layout, build/release model, glossary (incl. flow / flow-rule), and pointers to the canonical spec template at [`TEMPLATE.md`](TEMPLATE.md). |
+| 0.2     | 2026-04-18 | Riff (r12f) | Rename CLI binary references from `infmon-cli` to `infmonctl`; `infmon-cli` retained only as Cargo crate / Debian package name. |
 
 ---
 
@@ -55,7 +56,7 @@ In-scope for v1:
 - Expose a snapshot/aggregate API consumed by `infmon-frontend`.
 - Ship exporters for at least one standard format (IPFIX or OpenTelemetry —
   decided in spec 004).
-- A CLI (`infmon-cli`) for inspection, debugging, and admin.
+- A CLI (`infmonctl`) for inspection, debugging, and admin.
 - Packaging as a `.deb` for **arm64 / aarch64**, single artifact for v1.
 
 Out-of-scope for v1 (non-goals):
@@ -98,7 +99,7 @@ packets         |     v                                         |
                 +------------|----------------------------------+
                              |  local UDS, loopback only
                        +-----+------+
-                       | infmon-cli |
+                       | infmonctl |
                        |  (Rust)    |
                        +------------+
 ```
@@ -107,7 +108,7 @@ packets         |     v                                         |
 |-------------------|----------|----------------|----------------------------------------------|
 | `infmon-backend`  | C/C++    | gtest          | VPP plugin: ERSPAN decap, parse, flow table  |
 | `infmon-frontend` | Rust     | cargo test     | Snapshot/aggregate, exporter drivers, API    |
-| `infmon-cli`      | Rust     | cargo test     | Operator/admin CLI over the frontend API     |
+| `infmon-cli`     | Rust     | cargo test     | Operator/admin CLI over the frontend API     |
 | `tests/`          | mixed    | pytest + pcap  | E2E real-packet replay (see *E2E execution* below) |
 
 > **Backend language note.** "C/C++" here means: production VPP plugin code
@@ -155,7 +156,7 @@ packets         |     v                                         |
 6. **Snapshot.** Frontend periodically reads the backend's exposed snapshot
    (lock-free / RCU-style; details in spec 002) and builds an aggregate view.
 7. **Export.** Frontend pushes records to configured exporters and serves
-   `infmon-cli` queries against the aggregate.
+   `infmonctl` queries against the aggregate.
 
 ## Repo Layout
 
@@ -224,7 +225,7 @@ running Ubuntu 22.04 / DOCA-supported distro).
 - Artifact:
   - `infmon_<version>_arm64.deb` — installs the VPP plugin (`.so` into VPP's
     plugin dir), the `infmon-frontend` daemon (systemd unit), and the
-    `infmon-cli` binary into `/usr/bin`.
+    `infmonctl` binary into `/usr/bin`.
   - The package ships its plugin under VPP's standard plugin directory but
     **does not** force-enable it. VPP's default behavior is to auto-load
     every `.so` in the plugin dir; to keep InFMon opt-in on shared DPUs
@@ -281,8 +282,8 @@ running Ubuntu 22.04 / DOCA-supported distro).
   key tuple it sees, with its own packet/byte counters.
 - **Flow-rule** — A configured matcher (key-set + limits) that selects
   packets and emits flows. One flow-rule yields many flows (one per unique
-  key tuple). Flow-rules are managed via `infmon-cli flow-rule {add,rm,list,show}`;
-  the resulting flows are read with `infmon-cli flow {list,show}`.
+  key tuple). Flow-rules are managed via `infmonctl flow-rule {add,rm,list,show}`;
+  the resulting flows are read with `infmonctl flow {list,show}`.
 - **Flow table** — In-memory data structure that maps a flow key to its
   current counters and metadata; the backend's core state.
 - **Snapshot** — A point-in-time, read-only view of the flow table that the
@@ -294,7 +295,7 @@ running Ubuntu 22.04 / DOCA-supported distro).
 - **Collector** — Off-DPU consumer of exported records.
 - **Frontend** — `infmon-frontend`, the Rust user-space service that owns
   aggregation, exporters, and the API surface for the CLI.
-- **CLI** — `infmon-cli`, operator/admin tool that talks to the frontend.
+- **CLI** — `infmonctl`, operator/admin tool that talks to the frontend.
 - **DCO / Signed-off-by** — Developer Certificate of Origin attestation
   required on every commit (`git commit -s`).
 

--- a/specs/002-flow-tracking-model.md
+++ b/specs/002-flow-tracking-model.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of the flow-rule data model and lifecycle. Establishes flow-rule (matcher) vs flow (one per distinct key tuple), `mirror_src_ip` as the only outer-header field allowed in a key, name regex / `max_keys` / 64-byte caps, LRU recency on insert, file-load vs per-`add` budget enforcement, drop-reason set, `infmon_flow_rule_*` metric names, and §2.4 mental-model section. CLI examples align with the `flow-rule` / `flow` verb split (Spec 007). |
+| 0.2     | 2026-04-18 | Riff (r12f)  | Rename CLI binary references from `infmon-cli` to `infmonctl`. |
 
 - **Parent epic:** `DPU-4` (EPIC: InFMon — flow telemetry service on BF-3)
 - **Depends on:** [`000-overview`](000-overview.md), [`003-erspan-and-packet-parsing`](003-erspan-and-packet-parsing.md)
@@ -255,17 +256,17 @@ operators can size `max_keys` against observed eviction rate.
 
 ## 7. CRUD API surface
 
-The backend exposes a small management API consumed by `infmon-cli`
+The backend exposes a small management API consumed by `infmonctl`
 (Spec 007) and by the config loader. Transport is owned by Spec 004
 (likely a Unix socket carrying length-prefixed protobuf or JSON); this
 spec defines only the operations and their semantics.
 
 | Op       | CLI                              | Input                                     | Output                              | Notes |
 |----------|----------------------------------|-------------------------------------------|-------------------------------------|-------|
-| `add`    | `infmon-cli flow-rule add <spec>`     | full flow-rule definition (name, fields, max_keys, eviction_policy) | created flow-rule, or error           | Fails if name exists. |
-| `rm`     | `infmon-cli flow-rule rm <name>`      | flow-rule name                              | ok / `not_found`                    | Drops all flows for that flow-rule. |
-| `list`   | `infmon-cli flow-rule list`           | —                                         | array of flow-rule definitions        | Cheap; no flow data. |
-| `show`   | `infmon-cli flow-rule show <name>`    | flow-rule name                              | flow-rule definition + live stats: `flow_count`, `evictions_total`, `drops_total`, `last_seen_ns` (the maximum `last_seen_ns` across this flow-rule's resident flows; absent if there are none) | Stats are best-effort snapshots. |
+| `add`    | `infmonctl flow-rule add <spec>`     | full flow-rule definition (name, fields, max_keys, eviction_policy) | created flow-rule, or error           | Fails if name exists. |
+| `rm`     | `infmonctl flow-rule rm <name>`      | flow-rule name                              | ok / `not_found`                    | Drops all flows for that flow-rule. |
+| `list`   | `infmonctl flow-rule list`           | —                                         | array of flow-rule definitions        | Cheap; no flow data. |
+| `show`   | `infmonctl flow-rule show <name>`    | flow-rule name                              | flow-rule definition + live stats: `flow_count`, `evictions_total`, `drops_total`, `last_seen_ns` (the maximum `last_seen_ns` across this flow-rule's resident flows; absent if there are none) | Stats are best-effort snapshots. |
 
 ### 7.1 Semantics
 

--- a/specs/005-frontend-architecture.md
+++ b/specs/005-frontend-architecture.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Consolidated from v0.1–v0.6. Initial draft of `infmon-frontend` (Rust). Task model, `interval_ns` defined on tick 1, single-reader enforcement, reload-rollback failure handling, stop exit code, complete tracker→flow-rule rename (`FlowRuleStats`/`FlowRuleCounters`/`FlowRuleDef`/`FlowStatsSnapshot`), metric prefix cleanup, YAML config, `polling_interval_ms`, `InFMonStatsClient`/`InFMonControlClient`, control-plane `flow_rule_*` methods, and §3.0 mental-model paragraph. |
+| 0.2     | 2026-04-18 | Riff (r12f)  | Rename CLI binary references from `infmon-cli` to `infmonctl`. |
 
 - **Parent epic:** `DPU-4` (EPIC: InFMon — flow telemetry service on BF-3)
 - **Depends on:** [`000-overview`](000-overview.md), [`002-flow-tracking-model`](002-flow-tracking-model.md), [`004-backend-architecture`](004-backend-architecture.md)
@@ -322,7 +323,7 @@ Per tick, per exporter, the dispatcher records exactly one of:
   closed). Bumps `frontend_export_disabled_total`.
 
 A permanent error never crashes the process. Operators see it as
-a `permanent` status in `infmon-cli exporter list`.
+a `permanent` status in `infmonctl exporter list`.
 
 ## 8. IPC to the backend
 
@@ -397,7 +398,7 @@ impl InFMonControlClient {
 }
 ```
 
-`infmon-cli` (Spec 007) is a thin wrapper over `InFMonControlClient`;
+`infmonctl` (Spec 007) is a thin wrapper over `InFMonControlClient`;
 keeping the client in `frontend-ipc` means the CLI and frontend
 cannot drift on the wire format.
 

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -1,10 +1,11 @@
-# 007 — CLI (`infmon-cli`)
+# 007 — CLI (`infmonctl`)
 
 ## Version history
 
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-cli` v1: verb tree, output contract, exit codes, config layout, privilege model. Verb tree splits `flow-rule {add,rm,list,show}` (configuration) from `flow {list,show}` (live read-only views) — each flow-rule generates one flow per distinct key tuple. SIGPIPE installs an `exit(0)` handler so the documented "exits 0 silently" claim holds (avoids the POSIX 141 path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); multi-positional unquoted keys are rejected with exit 2. |
+| 0.2     | 2026-04-18 | Riff (r12f)  | Rename CLI binary from `infmon-cli` to `infmonctl` throughout. |
 
 ---
 
@@ -17,7 +18,7 @@ service (`infmon-frontend`) — expose APIs and on-disk state, but operators
 should not have to poke at systemd units, raw config files, or the frontend's
 local socket directly.
 
-`infmon-cli` is that entry point. It is a single Rust binary, distributed in
+`infmonctl` is that entry point. It is a single Rust binary, distributed in
 the same `.deb` as the backend and frontend, that wraps every supported
 operator workflow. It must be **predictable in scripts** (stable exit codes,
 machine-readable output) and **comfortable for humans** (tables by default,
@@ -50,7 +51,7 @@ file location, and privilege model. Implementation work tracks against it.
 
 ### Binary, transport, and discovery
 
-- Single binary `/usr/bin/infmon-cli`, shipped by `infmon_<ver>_arm64.deb`.
+- Single binary `/usr/bin/infmonctl`, shipped by `infmon_<ver>_arm64.deb`.
 - Talks to `infmon-frontend` over a Unix-domain socket at
   `/run/infmon/frontend.sock` (created mode `0660`, group `infmon`).
 - Members of the `infmon` group can run all read-only verbs without `sudo`.
@@ -80,7 +81,7 @@ Available on every subcommand:
 | `-q, --quiet`           | off           | Suppress informational stderr; errors still printed. |
 | `-v, --verbose`         | off (repeatable) | `-v` info, `-vv` debug, `-vvv` trace.    |
 | `-h, --help`            | —             | Show help for the (sub)command.              |
-| `-V, --version`         | —             | Print `infmon-cli <semver>` and exit `0`.    |
+| `-V, --version`         | —             | Print `infmonctl <semver>` and exit `0`.    |
 
 Conventions:
 
@@ -101,7 +102,7 @@ Conventions:
   and `SIGTERM` into a clean shutdown and exit `130` (SIGINT) or `143`
   (SIGTERM, i.e. `128 + 15`). `SIGPIPE` is treated as a normal,
   non-error termination — when stdout is closed by a downstream consumer
-  (e.g. `infmon-cli stats export --format prom | head`), the CLI exits `0`
+  (e.g. `infmonctl stats export --format prom | head`), the CLI exits `0`
   silently rather than printing a broken-pipe error to stderr. This is
   achieved by installing a `SIGPIPE` handler that calls `exit(0)`
   immediately (rather than restoring `SIG_DFL`, which would terminate
@@ -111,7 +112,7 @@ Conventions:
 ### Verb tree
 
 ```
-infmon-cli
+infmonctl
 ├── install [--force]                       [root]
 ├── uninstall [--purge]                     [root]
 ├── start                                   [root]
@@ -164,7 +165,7 @@ calls, but operators may rerun it after manual changes:
 `uninstall` is the inverse, but conservative:
 
 - Stops and disables `infmon-frontend.service`.
-- Removes the systemd unit file and the `/usr/bin/infmon-cli`,
+- Removes the systemd unit file and the `/usr/bin/infmonctl`,
   `/usr/bin/infmon-frontend`, and VPP plugin `.so` only if they were
   installed by InFMon (checked via dpkg ownership).
 - **Preserves** `/etc/infmon/` and `/var/lib/infmon/` by default; pass
@@ -254,7 +255,7 @@ the live flows that result.
       `note="key\"with\"quotes"`.
   - Unknown keys → exit `2`. Duplicate keys in one spec → exit `2`.
   - Operators who pass `<spec>` through a shell are responsible for the
-    shell's own quoting; the grammar above describes what `infmon-cli`
+    shell's own quoting; the grammar above describes what `infmonctl`
     sees after `argv` parsing.
 - `flow-rule rm <id|name|spec>` removes by ID, by `name=<rule-name>`, or by
   exact-match spec. If a spec matches multiple rules, the command
@@ -292,7 +293,7 @@ the backend as packets are observed.
   The CLI does **not** concatenate trailing positionals; a multi-token
   unquoted key is rejected with exit `2` (`Usage error`) and an error
   pointing at the second positional. Example:
-  `infmon-cli flow show https-egress 'proto=tcp src=10.0.0.7:51234 dst=10.0.1.4:443'`.
+  `infmonctl flow show https-egress 'proto=tcp src=10.0.0.7:51234 dst=10.0.1.4:443'`.
 
 #### `stats show` and `stats export`
 
@@ -323,7 +324,7 @@ the backend as packets are observed.
   `journalctl` as a subprocess and **wraps its errors** rather than
   passing through the raw stderr: a non-zero exit from `journalctl` is
   translated into the CLI's standard error format (one line on stderr,
-  prefixed with `infmon-cli: log tail:`) and mapped to a CLI exit code
+  prefixed with `infmonctl: log tail:`) and mapped to a CLI exit code
   (`13` for permission denied, `4` for "journald not available", `1`
   otherwise). The original `journalctl` stderr is included once,
   indented, beneath the wrapped message for diagnostics.
@@ -439,7 +440,7 @@ The CLI uses whatever framed JSON-RPC the frontend exposes on
 `/run/infmon/frontend.sock`. From the operator's perspective, the wire
 protocol is an implementation detail behind the verbs above.
 
-**Version compatibility (operator-facing guarantee).** `infmon-cli vX.Y` is
+**Version compatibility (operator-facing guarantee).** `infmonctl vX.Y` is
 guaranteed to work with any `infmon-frontend vX.*` (same major). The
 JSON-RPC handshake (defined in spec 005) carries each side's semver; on
 any *major* mismatch the CLI exits `4` ("frontend unreachable") with a
@@ -454,7 +455,7 @@ vA.B" message. Patch-level skews are silent.
 
 | Path                              | Owner       | Mode  | Purpose                          |
 |-----------------------------------|-------------|-------|----------------------------------|
-| `/usr/bin/infmon-cli`             | root:root   | 0755  | The CLI binary.                  |
+| `/usr/bin/infmonctl`             | root:root   | 0755  | The CLI binary.                  |
 | `/etc/infmon/infmon.toml`         | root:infmon | 0640  | Effective config.                |
 | `/etc/infmon/infmon.toml.default` | root:root   | 0644  | Distro defaults (reference).     |
 | `/run/infmon/frontend.sock`       | root:infmon | 0660  | Frontend control socket.         |
@@ -471,7 +472,7 @@ vA.B" message. Patch-level skews are silent.
 
 ## Test plan
 
-Unit and integration tests for `infmon-cli` live under `cli/tests/` and run
+Unit and integration tests for `infmonctl` live under `cli/tests/` and run
 in CI via `cargo test`.
 
 - **Argument parsing** — `clap` snapshot tests for every verb, asserting


### PR DESCRIPTION
## Summary

Standardize all CLI binary references from `infmon-cli` to `infmonctl` across specs 000, 002, 005, and 007.

- **Binary/command name:** `infmonctl` (everywhere)
- **Cargo crate / Debian package name:** `infmon-cli` (unchanged)

### Files changed
- `specs/000-overview.md` — component diagram, glossary, repo layout, CI scope
- `specs/002-flow-tracking-model.md` — flow-rule management API table
- `specs/005-frontend-architecture.md` — IPC crate references vs command references
- `specs/007-cli.md` — all binary/command mentions

Resolves DPU-30.