### PR TITLE
specs: fix IPC/wire protocol — gRPC for frontend↔CLI (DPU-28)

### DIFF
--- a/specs/005-frontend-architecture.md
+++ b/specs/005-frontend-architecture.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Consolidated from v0.1–v0.6. Initial draft of `infmon-frontend` (Rust). Task model, `interval_ns` defined on tick 1, single-reader enforcement, reload-rollback failure handling, stop exit code, complete tracker→flow-rule rename (`FlowRuleStats`/`FlowRuleCounters`/`FlowRuleDef`/`FlowStatsSnapshot`), metric prefix cleanup, YAML config, `polling_interval_ms`, `InFMonStatsClient`/`InFMonControlClient`, control-plane `flow_rule_*` methods, and §3.0 mental-model paragraph. |
+| 0.2     | 2026-04-18 | BF-3 (bf3)   | §8.2: replace length-prefixed protobuf framing with gRPC server on Unix-domain socket (DPU-28). |
 
 - **Parent epic:** `DPU-4` (EPIC: InFMon — flow telemetry service on BF-3)
 - **Depends on:** [`000-overview`](000-overview.md), [`002-flow-tracking-model`](002-flow-tracking-model.md), [`004-backend-architecture`](004-backend-architecture.md)
@@ -375,8 +376,8 @@ race the poller on the clear half of the operation.
 
 ### 8.2 Control API (request/response)
 
-A Unix-domain socket at `frontend.backend_socket`, length-prefixed
-protobuf (transport owned by Spec 004). The client crate exposes:
+A gRPC server on a Unix-domain socket at `/run/infmon/frontend.sock`
+(transport owned by Spec 004). The client crate exposes:
 
 ```rust
 pub struct InFMonControlClient { /* ... */ }

--- a/specs/005-frontend-architecture.md
+++ b/specs/005-frontend-architecture.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Consolidated from v0.1–v0.6. Initial draft of `infmon-frontend` (Rust). Task model, `interval_ns` defined on tick 1, single-reader enforcement, reload-rollback failure handling, stop exit code, complete tracker→flow-rule rename (`FlowRuleStats`/`FlowRuleCounters`/`FlowRuleDef`/`FlowStatsSnapshot`), metric prefix cleanup, YAML config, `polling_interval_ms`, `InFMonStatsClient`/`InFMonControlClient`, control-plane `flow_rule_*` methods, and §3.0 mental-model paragraph. |
-| 0.2     | 2026-04-18 | BF-3 (bf3)   | §8.2: replace length-prefixed protobuf framing with gRPC server on Unix-domain socket (DPU-28). |
+| 0.2     | 2026-04-18 | Riff (r12f)   | §8.2: replace length-prefixed protobuf framing with gRPC server on Unix-domain socket (DPU-28). |
 
 - **Parent epic:** `DPU-4` (EPIC: InFMon — flow telemetry service on BF-3)
 - **Depends on:** [`000-overview`](000-overview.md), [`002-flow-tracking-model`](002-flow-tracking-model.md), [`004-backend-architecture`](004-backend-architecture.md)

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-cli` v1: verb tree, output contract, exit codes, config layout, privilege model. Verb tree splits `flow-rule {add,rm,list,show}` (configuration) from `flow {list,show}` (live read-only views) — each flow-rule generates one flow per distinct key tuple. SIGPIPE installs an `exit(0)` handler so the documented "exits 0 silently" claim holds (avoids the POSIX 141 path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); multi-positional unquoted keys are rejected with exit 2. |
-| 0.2     | 2026-04-18 | BF-3 (bf3)   | §Interfaces: replace JSON-RPC with gRPC for frontend↔CLI wire protocol (DPU-28). |
+| 0.2     | 2026-04-18 | Riff (r12f)   | §Interfaces: replace JSON-RPC with gRPC for frontend↔CLI wire protocol (DPU-28). |
 
 ---
 

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-cli` v1: verb tree, output contract, exit codes, config layout, privilege model. Verb tree splits `flow-rule {add,rm,list,show}` (configuration) from `flow {list,show}` (live read-only views) — each flow-rule generates one flow per distinct key tuple. SIGPIPE installs an `exit(0)` handler so the documented "exits 0 silently" claim holds (avoids the POSIX 141 path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); multi-positional unquoted keys are rejected with exit 2. |
+| 0.2     | 2026-04-18 | BF-3 (bf3)   | §Interfaces: replace JSON-RPC with gRPC for frontend↔CLI wire protocol (DPU-28). |
 
 ---
 
@@ -435,13 +436,13 @@ behavior.
 ### Wire protocol to the frontend
 
 Out of scope for this spec — defined in spec 005 (frontend control plane).
-The CLI uses whatever framed JSON-RPC the frontend exposes on
+The CLI uses the gRPC service the frontend exposes on
 `/run/infmon/frontend.sock`. From the operator's perspective, the wire
 protocol is an implementation detail behind the verbs above.
 
 **Version compatibility (operator-facing guarantee).** `infmon-cli vX.Y` is
 guaranteed to work with any `infmon-frontend vX.*` (same major). The
-JSON-RPC handshake (defined in spec 005) carries each side's semver; on
+gRPC handshake (defined in spec 005) carries each side's semver; on
 any *major* mismatch the CLI exits `4` ("frontend unreachable") with a
 clear error explaining the mismatch and the supported range. On a
 *minor*-only skew where the CLI is newer than the frontend, the CLI

--- a/specs/008-packaging-install.md
+++ b/specs/008-packaging-install.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of the `.deb` packaging contract for Ubuntu aarch64 on BlueField-3. Version-locked deps, source/format declared, postrm cross-package fix, equivs preferred over `--force-depends`, GPG verification note, version-skew check, CLI stability marking, explicit cmake + cargo rules; PartOf and compat file dropped per PR #9 review. |
-| 0.2     | 2026-04-18 | BF-3 (bf3)   | §3, §5.3, §9.1: replace REST references with gRPC for CLI↔frontend communication (DPU-28). |
+| 0.2     | 2026-04-18 | Riff (r12f)   | §3, §5.3, §9.1: replace REST references with gRPC for CLI↔frontend communication (DPU-28). |
 
 - **Depends on:** [`000-overview`](000-overview.md), [`004-backend-architecture`](004-backend-architecture.md)
 - **Affects:** [`005-frontend-architecture`](005-frontend-architecture.md), [`007-cli`](007-cli.md), [`001-ci-and-precommit`](001-ci-and-precommit.md) (build job produces the `.deb`)

--- a/specs/008-packaging-install.md
+++ b/specs/008-packaging-install.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of the `.deb` packaging contract for Ubuntu aarch64 on BlueField-3. Version-locked deps, source/format declared, postrm cross-package fix, equivs preferred over `--force-depends`, GPG verification note, version-skew check, CLI stability marking, explicit cmake + cargo rules; PartOf and compat file dropped per PR #9 review. |
+| 0.2     | 2026-04-18 | BF-3 (bf3)   | §3, §5.3, §9.1: replace REST references with gRPC for CLI↔frontend communication (DPU-28). |
 
 - **Depends on:** [`000-overview`](000-overview.md), [`004-backend-architecture`](004-backend-architecture.md)
 - **Affects:** [`005-frontend-architecture`](005-frontend-architecture.md), [`007-cli`](007-cli.md), [`001-ci-and-precommit`](001-ci-and-precommit.md) (build job produces the `.deb`)
@@ -72,7 +73,7 @@ upgrades from producing skewed deployments:
 - `infmon-frontend` declares `Depends: infmon-backend (= ${binary:Version})`
   so a co-installed pair always shares the same source release. (CLI
   remains independent — it is allowed to talk to an older frontend over
-  the REST surface; cross-version compatibility there is handled in
+  the gRPC surface; cross-version compatibility there is handled in
   spec 005.)
 
 Splitting the three lets operators run the CLI from a jump host without
@@ -196,8 +197,8 @@ not orphan log files.
 | `/usr/share/man/man1/infmonctl.1.gz`                | root  | 0644 | Generated from clap by `clap_mangen`.  |
 | `/usr/share/doc/infmon-cli/changelog.gz`            | root  | 0644 |                                        |
 
-The CLI does not require VPP locally; it talks to the frontend's REST
-surface (spec 005) over TCP or a Unix socket. `infmon-cli` therefore
+The CLI does not require VPP locally; it talks to the frontend's gRPC
+service (spec 005) over a Unix socket. `infmon-cli` therefore
 declares no dependency on VPP.
 
 ## 6. systemd unit
@@ -489,7 +490,7 @@ InFMon uses **SemVer 2.0.0** (`MAJOR.MINOR.PATCH`) on the source release.
 
 - `MAJOR` bumps on incompatible changes to the binary-API messages
   (spec 004 §7.1), the stats-segment descriptor layout (spec 004 §6),
-  the frontend REST contract (spec 005), or the CLI argument grammar
+  the frontend gRPC contract (spec 005), or the CLI argument grammar
   marked as stable. Stable CLI arguments are those whose `clap`
   definition does **not** carry the `#[arg(hide = true)]` attribute or
   a doc-comment line starting with `UNSTABLE:`; the help text rendered


### PR DESCRIPTION
## Summary

Fixes the protocol inconsistency across specs (DPU-28). Four different protocols were described for the same communication paths.

**Decision applied:**
- Backend ↔ Frontend: VPP binary API (unchanged, spec 004 remains authoritative)
- Frontend ↔ CLI: **gRPC** (was variously described as protobuf framing, JSON-RPC, and REST)

## Changes

| Spec | Section | Before | After |
|------|---------|--------|-------|
| 005 | §8.2 Control API | length-prefixed protobuf on Unix socket | gRPC server on Unix socket |
| 007 | §Interfaces | JSON-RPC | gRPC |
| 008 | §3, §5.3, §9.1 | REST surface | gRPC service |

No changes to spec 004 (VPP binary API for backend↔frontend).