### PR TITLE
specs: align CLI field names with v1 field set in spec 002

### DIFF
--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -5,7 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-cli` v1: verb tree, output contract, exit codes, config layout, privilege model. Verb tree splits `flow-rule {add,rm,list,show}` (configuration) from `flow {list,show}` (live read-only views) — each flow-rule generates one flow per distinct key tuple. SIGPIPE installs an `exit(0)` handler so the documented "exits 0 silently" claim holds (avoids the POSIX 141 path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); multi-positional unquoted keys are rejected with exit 2. |
-| 0.2     | 2026-04-18 | BF-3 (bf3)   | Align CLI field names with spec 002 v1 field set (`src_ip`, `dst_ip`, `ip_proto`, `dscp`, `mirror_src_ip`). Remove L4 port fields (`dport`, `sport`) and protocol name shorthand (`proto`, `src`, `dst`, `mirror_src`) that don't exist in v1. Update `flow-rule list` columns and all examples to use canonical field names. |
+| 0.2     | 2026-04-18 | Riff (r12f)   | Align CLI field names with spec 002 v1 field set (`src_ip`, `dst_ip`, `ip_proto`, `dscp`, `mirror_src_ip`). Remove L4 port fields (`dport`, `sport`) and protocol name shorthand (`proto`, `src`, `dst`, `mirror_src`) that don't exist in v1. Update `flow-rule list` columns and all examples to use canonical field names. |
 
 ---
 

--- a/specs/007-cli.md
+++ b/specs/007-cli.md
@@ -5,6 +5,7 @@
 | Version | Date       | Author       | Changes |
 | ------- | ---------- | ------------ | ------- |
 | 0.1     | 2026-04-18 | Riff (r12f)  | Initial draft of `infmon-cli` v1: verb tree, output contract, exit codes, config layout, privilege model. Verb tree splits `flow-rule {add,rm,list,show}` (configuration) from `flow {list,show}` (live read-only views) — each flow-rule generates one flow per distinct key tuple. SIGPIPE installs an `exit(0)` handler so the documented "exits 0 silently" claim holds (avoids the POSIX 141 path). `flow show <rule> <key>` requires `<key>` as a single argv element (must be shell-quoted); multi-positional unquoted keys are rejected with exit 2. |
+| 0.2     | 2026-04-18 | BF-3 (bf3)   | Align CLI field names with spec 002 v1 field set (`src_ip`, `dst_ip`, `ip_proto`, `dscp`, `mirror_src_ip`). Remove L4 port fields (`dport`, `sport`) and protocol name shorthand (`proto`, `src`, `dst`, `mirror_src`) that don't exist in v1. Update `flow-rule list` columns and all examples to use canonical field names. |
 
 ---
 
@@ -237,7 +238,7 @@ key tuple the rule observes — with their own packet/byte counters. Use
 the live flows that result.
 
 - `flow-rule add <spec>` adds a rule. Spec uses a compact key=value form, e.g.
-  `proto=tcp src=10.0.0.0/8 dst=0.0.0.0/0 dport=443 name=https-egress`.
+  `src_ip=10.0.0.0/8 dst_ip=0.0.0.0/0 ip_proto=6 dscp=0 name=https-egress`.
   Returns the assigned rule ID on stdout. Requires root.
 
   **Parsing grammar (frozen v1):**
@@ -261,9 +262,10 @@ the live flows that result.
   **refuses** by default and exits `6` (conflict) listing the matching
   IDs; pass `--all` to delete every match. ID and name lookups always
   remove exactly one rule or exit `3` (not found). Requires root.
-- `flow-rule list` lists all rules. Columns: `ID`, `NAME`, `PROTO`, `SRC`,
-  `DST`, `SPORT`, `DPORT`, `KEYS`, `FLOWS`, `ACTION`. `KEYS` is the
-  flow-key field set; `FLOWS` is the current count of live flows under
+- `flow-rule list` lists all rules. Columns: `ID`, `NAME`, `FIELDS`,
+  `MAX_KEYS`, `FLOWS`, `EVICTION`. `FIELDS` is the
+  flow-key field set (from spec 002 §3: `src_ip`, `dst_ip`, `ip_proto`,
+  `dscp`, `mirror_src_ip`); `FLOWS` is the current count of live flows under
   the rule. JSON mode emits an array of rule objects.
 - `flow-rule show <id|name>` prints one rule's full detail, including
   configured key-set, packet/byte aggregates across all of its flows,
@@ -277,7 +279,7 @@ the backend as packets are observed.
 
 - `flow list <rule-id|name>` lists the active flows under one flow-rule.
   Columns: `KEY` (the canonical key tuple, e.g.
-  `proto=tcp src=10.0.0.7:51234 dst=10.0.1.4:443 mirror_src=192.0.2.10`),
+  `src_ip=10.0.0.7 dst_ip=10.0.1.4 ip_proto=6 mirror_src_ip=192.0.2.10`),
   `PACKETS`, `BYTES`, `FIRST_SEEN`, `LAST_SEEN`. JSON mode emits an array
   of flow objects. `--top N` and `--sort {bytes,packets,last_seen}` are
   supported (default `--sort bytes --top 50`).
@@ -288,11 +290,11 @@ the backend as packets are observed.
 - `flow show <rule-id|name> <key>` prints one flow's full counters,
   where `<key>` is the canonical key form printed by `flow list`,
   passed as a **single argv element** (i.e. quoted in the shell so the
-  whole `proto=…  src=…  dst=…` string arrives as one positional).
+  whole `src_ip=…  dst_ip=…  ip_proto=…` string arrives as one positional).
   The CLI does **not** concatenate trailing positionals; a multi-token
   unquoted key is rejected with exit `2` (`Usage error`) and an error
   pointing at the second positional. Example:
-  `infmon-cli flow show https-egress 'proto=tcp src=10.0.0.7:51234 dst=10.0.1.4:443'`.
+  `infmon-cli flow show https-egress 'src_ip=10.0.0.7 dst_ip=10.0.1.4 ip_proto=6'`.
 
 #### `stats show` and `stats export`
 


### PR DESCRIPTION
## Summary

Spec 007 (CLI) used field names (`proto`, `src`, `dst`, `dport`, `sport`, `mirror_src`) that don't exist in spec 002's v1 field set (§3). This PR aligns all CLI examples and the `flow-rule list` column set with the canonical v1 fields: `src_ip`, `dst_ip`, `ip_proto`, `dscp`, `mirror_src_ip`.

### Changes
- **`flow-rule add` example**: replaced `proto=tcp src=… dst=… dport=443` with `src_ip=… dst_ip=… ip_proto=6 dscp=0`
- **`flow-rule list` columns**: replaced `PROTO/SRC/DST/SPORT/DPORT/KEYS/ACTION` with `FIELDS/MAX_KEYS/EVICTION` (matches the flow-rule model from spec 002)
- **`flow list` key format**: uses canonical field names, removes L4 port notation
- **`flow show` example**: updated to use canonical field names

L4 port fields (`src_port`, `dst_port`) are explicitly marked as v2/future in spec 002 §9.1.

Fixes DPU-34.