### PR TITLE
ci: audit and align CI/pre-commit setup with spec 001

### DIFF
--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -6,18 +6,21 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
-  group: cpp-test-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   cpp-test:
     name: cpp-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # VPP-in-CI image; see specs/001-ci-and-precommit.md §5.
     # NOTE: pin by digest once first green run is recorded.
     container:
-      image: ligato/vpp-base:24.02
+      image: ghcr.io/r12f/infmon-vpp-dev:24.10
       options: --user root
     steps:
       - name: Checkout
@@ -29,6 +32,14 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends \
               cmake ninja-build g++ clang libgtest-dev ccache pkg-config
+
+      - name: Verify build tools present in image
+        run: |
+          set -eux
+          for cmd in cmake ninja g++ clang ccache pkg-config; do
+            command -v "$cmd" || { echo "::error::$cmd not found in container image"; exit 1; }
+          done
+          dpkg -s libgtest-dev >/dev/null 2>&1 || { echo "::error::libgtest-dev not installed"; exit 1; }
 
       - name: Verify VPP dev headers
         run: |

--- a/.github/workflows/cross-build.yml
+++ b/.github/workflows/cross-build.yml
@@ -6,8 +6,11 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
-  group: cross-build-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -17,7 +20,7 @@ env:
 jobs:
   rust-aarch64:
     name: cross-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -59,7 +62,7 @@ jobs:
 
   cpp-aarch64:
     name: cross-build-cpp
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -97,7 +100,7 @@ jobs:
           docker run --rm --platform linux/arm64 \
               -v "$PWD:/work" -w /work \
               -v "$HOME/.ccache:/root/.ccache" \
-              ligato/vpp-base:24.02 \
+              ghcr.io/r12f/infmon-vpp-dev:24.10 \
               bash -euxc '
                   apt-get update
                   apt-get install -y --no-install-recommends \

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -3,11 +3,20 @@ name: dco
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   dco:
     name: dco
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout PR
         uses: actions/checkout@v4
@@ -35,6 +44,30 @@ jobs:
               echo "Add sign-off to existing commits with:"
               echo "    git rebase --signoff ${BASE_SHA}..HEAD"
               echo "    git push --force-with-lease"
+              exit 1
+          fi
+          echo "All commits have a valid Signed-off-by trailer."
+
+      - name: Verify Signed-off-by on push commits
+        if: github.event_name == 'push'
+        run: |
+          set -euo pipefail
+          BEFORE="${{ github.event.before }}"
+          AFTER="${{ github.event.after }}"
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "Initial push — skipping DCO check."
+            exit 0
+          fi
+          missing=0
+          for sha in $(git rev-list --no-merges "${BEFORE}..${AFTER}"); do
+              if ! git log -1 --format=%B "$sha" \
+                      | grep -qE '^Signed-off-by: .+ <.+@.+>[[:space:]]*$'; then
+                  echo "::error::commit $sha is missing a 'Signed-off-by:' trailer."
+                  git log -1 --format='  %h %s%n  author: %an <%ae>' "$sha"
+                  missing=$((missing + 1))
+              fi
+          done
+          if [ "$missing" -gt 0 ]; then
               exit 1
           fi
           echo "All commits have a valid Signed-off-by trailer."

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,14 +6,17 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
-  group: lint-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -6,8 +6,11 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
-  group: rust-test-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -17,7 +20,7 @@ env:
 jobs:
   rust-test:
     name: rust-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,18 @@
 #
 # See specs/001-ci-and-precommit.md for the contract.
 
-.PHONY: help lint test e2e ci-branch-protection install-hooks
+.PHONY: help lint cppcheck-full test e2e build clean ci-branch-protection install-hooks
 
 help:
 	@echo "InFMon — make targets"
 	@echo ""
 	@echo "  make install-hooks         Install pre-commit + commit-msg hooks"
 	@echo "  make lint                  Run all pre-commit hooks across the tree"
+	@echo "  make cppcheck-full         Run cppcheck over the full C/C++ tree"
 	@echo "  make test                  Run unit tests (Rust + C/C++); E2E NOT included"
 	@echo "  make e2e                   Print the manual E2E procedure (run on r12f-bf3)"
+	@echo "  make build                 Build all targets (Rust + C/C++)"
+	@echo "  make clean                 Remove all build artefacts"
 	@echo "  make ci-branch-protection  Apply branch protection to main (admin only)"
 
 install-hooks:
@@ -20,6 +23,18 @@ install-hooks:
 
 lint:
 	pre-commit run --all-files --show-diff-on-failure
+
+cppcheck-full:
+	@if [ -d src/backend ]; then \
+	    cppcheck \
+	        --enable=warning,performance,portability \
+	        --error-exitcode=1 \
+	        --inline-suppr \
+	        --suppressions-list=.cppcheck-suppressions \
+	        src/backend; \
+	else \
+	    echo "src/backend/ not present yet — nothing to check."; \
+	fi
 
 test:
 	@echo "==> Rust workspace"
@@ -50,6 +65,29 @@ e2e:
 	@echo "They require SR-IOV, hugepages, and a loaded VPP plugin — none of which"
 	@echo "are available in CI. See tests/README.md for the procedure."
 	@false
+
+build:
+	@echo "==> Rust workspace"
+	@if [ -f Cargo.toml ]; then \
+	    cargo build --workspace --all-targets --locked; \
+	else \
+	    echo "    (no Cargo.toml yet — skipped)"; \
+	fi
+	@echo "==> C/C++ backend"
+	@if [ -f src/backend/CMakeLists.txt ]; then \
+	    cmake_launchers=""; \
+	    if command -v ccache >/dev/null 2>&1; then \
+	        cmake_launchers="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"; \
+	    fi; \
+	    cmake -S src/backend -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug $$cmake_launchers \
+	        && cmake --build build; \
+	else \
+	    echo "    (no src/backend/CMakeLists.txt yet — skipped)"; \
+	fi
+
+clean:
+	rm -rf target/ build/ build-arm64/
+	@echo "Cleaned target/, build/, build-arm64/"
 
 ci-branch-protection:
 	ci/branch-protection.sh

--- a/ci/mirror-image.sh
+++ b/ci/mirror-image.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Mirror ligato/vpp-base:24.10 to ghcr.io/r12f/infmon-vpp-dev:24.10.
+#
+# See specs/001-ci-and-precommit.md §5.
+#
+# CI consumes the ghcr.io mirror so Docker Hub outages / rate-limits
+# don't hard-block PRs. Run this periodically (weekly cron or manual)
+# to keep the mirror fresh.
+#
+# Requirements:
+#   - docker CLI
+#   - Authenticated to ghcr.io:
+#       echo "$GHCR_TOKEN" | docker login ghcr.io -u <user> --password-stdin
+#
+# Usage: ci/mirror-image.sh [source_tag] [dest_tag]
+set -euo pipefail
+
+SOURCE="${1:-docker.io/ligato/vpp-base:24.10}"
+DEST="${2:-ghcr.io/r12f/infmon-vpp-dev:24.10}"
+
+echo "Mirroring ${SOURCE} → ${DEST}"
+
+# Pull the source image
+docker pull "${SOURCE}"
+
+# Re-tag and push to ghcr.io
+docker tag "${SOURCE}" "${DEST}"
+docker push "${DEST}"
+
+echo "Done. Verify with: docker manifest inspect ${DEST}"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Audits the existing CI and pre-commit configuration against [spec 001](specs/001-ci-and-precommit.md) and fills all identified gaps.

### Gaps found and fixed

**Workflows (all 5):**
- Add `permissions: { contents: read }` (spec §4 cross-cutting contract)
- Upgrade `runs-on` from `ubuntu-22.04` to `ubuntu-24.04` (spec §4)
- Normalize concurrency group to use `github.workflow` variable

**cpp-test.yml:**
- Update container image from `ligato/vpp-base:24.02` → `ghcr.io/r12f/infmon-vpp-dev:24.10` (spec §4.3, §5)
- Add explicit build-tool verification step using `command -v` and `dpkg -s` (spec §4.3 step 2)

**cross-build.yml:**
- Update container image from `ligato/vpp-base:24.02` → `ghcr.io/r12f/infmon-vpp-dev:24.10` (spec §4.4)

**dco.yml:**
- Add `push` trigger on `main` (spec §4 — all workflows trigger on both PR and push)
- Add `concurrency` block with `cancel-in-progress` (spec §4)
- Add push-event commit verification step

**Makefile:**
- Add missing `build` target (spec §3.1)
- Add missing `clean` target (spec §3.1)
- Add missing `cppcheck-full` target (spec §3.1)

**New files:**
- `rust-toolchain.toml`: pin stable channel with rustfmt+clippy (spec §4.2)
- `ci/mirror-image.sh`: mirror `ligato/vpp-base` to `ghcr.io` (spec §5)

### Already conformant (no changes needed)
- `.pre-commit-config.yaml`: all required hooks present
- `lint.yml`: pre-commit with correct cache and Rust toolchain
- `rust-test.yml`: cargo build/test/doc with Swatinem/rust-cache@v2
- `ci/branch-protection.sh`: correct settings
- Config files: `rustfmt.toml`, `.clang-format`, `.markdownlint.yaml`, `commitlint.config.js`

Closes #35