### PR TITLE
ci: remove container dependency, install VPP dev deps via apt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,15 @@ jobs:
           set -eux
           curl -fsSL https://packagecloud.io/fdio/release/gpgkey \
             | sudo gpg --dearmor -o /usr/share/keyrings/fdio-archive-keyring.gpg
+          expected="59A8E0DB0B611CA471C9FBDE9E9FE7A46C37F7CD"
+          actual=$(gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/fdio-archive-keyring.gpg \
+            --list-keys --with-colons 2>/dev/null \
+            | awk -F: '/^fpr/{print $10; exit}')
+          [[ "$actual" == "$expected" ]] || { echo "GPG key mismatch: got $actual"; exit 1; }
           echo "deb [signed-by=/usr/share/keyrings/fdio-archive-keyring.gpg] \
-            https://packagecloud.io/fdio/release/ubuntu $(lsb_release -cs) main" \
+            https://packagecloud.io/fdio/release/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") main" \
             | sudo tee /etc/apt/sources.list.d/fdio.list
 
       - name: Install build deps
@@ -68,7 +75,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
               cmake ninja-build g++ ccache pkg-config \
-              vpp-dev libvppinfra-dev
+              vpp-dev=24.06* libvppinfra-dev=24.06*
 
       - name: Detect backend source
         id: detect_cpp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,12 +49,26 @@ jobs:
   cpp-build:
     name: build-cpp
     runs-on: ubuntu-24.04
-    container:
-      image: ligato/vpp-base:24.06
-      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Add fd.io apt repo
+        run: |
+          set -eux
+          curl -fsSL https://packagecloud.io/fdio/release/gpgkey \
+            | sudo gpg --dearmor -o /usr/share/keyrings/fdio-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/fdio-archive-keyring.gpg] \
+            https://packagecloud.io/fdio/release/ubuntu $(lsb_release -cs) main" \
+            | sudo tee /etc/apt/sources.list.d/fdio.list
+
+      - name: Install build deps
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              cmake ninja-build g++ ccache pkg-config \
+              vpp-dev libvppinfra-dev
 
       - name: Detect backend source
         id: detect_cpp
@@ -69,10 +83,8 @@ jobs:
       - name: Configure + build
         if: steps.detect_cpp.outputs.have_backend == 'true'
         run: |
-          cmake_launchers=""
-          if command -v ccache >/dev/null 2>&1; then
-            cmake_launchers="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
-          fi
           cmake -S src/backend -B build -G Ninja \
-              -DCMAKE_BUILD_TYPE=Release $cmake_launchers
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
               cmake ninja-build g++ ccache pkg-config \
-              vpp-dev=24.06* libvppinfra-dev=24.06*
+              vpp-dev=24.10* libvppinfra-dev=24.10*
 
       - name: Detect backend source
         id: detect_cpp

--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -26,8 +26,15 @@ jobs:
           set -eux
           curl -fsSL https://packagecloud.io/fdio/release/gpgkey \
             | sudo gpg --dearmor -o /usr/share/keyrings/fdio-archive-keyring.gpg
+          expected="59A8E0DB0B611CA471C9FBDE9E9FE7A46C37F7CD"
+          actual=$(gpg --no-default-keyring \
+            --keyring /usr/share/keyrings/fdio-archive-keyring.gpg \
+            --list-keys --with-colons 2>/dev/null \
+            | awk -F: '/^fpr/{print $10; exit}')
+          [[ "$actual" == "$expected" ]] || { echo "GPG key mismatch: got $actual"; exit 1; }
           echo "deb [signed-by=/usr/share/keyrings/fdio-archive-keyring.gpg] \
-            https://packagecloud.io/fdio/release/ubuntu $(lsb_release -cs) main" \
+            https://packagecloud.io/fdio/release/ubuntu \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") main" \
             | sudo tee /etc/apt/sources.list.d/fdio.list
 
       - name: Install build deps
@@ -36,7 +43,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
               cmake ninja-build g++ clang libgtest-dev ccache pkg-config \
-              cppcheck vpp-dev libvppinfra-dev
+              cppcheck vpp-dev=24.06* libvppinfra-dev=24.06*
 
       - name: ccache cache
         uses: actions/cache@v4

--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
               cmake ninja-build g++ clang libgtest-dev ccache pkg-config \
-              cppcheck vpp-dev=24.06* libvppinfra-dev=24.06*
+              cppcheck vpp-dev=24.10* libvppinfra-dev=24.10*
 
       - name: ccache cache
         uses: actions/cache@v4

--- a/.github/workflows/cpp-test.yml
+++ b/.github/workflows/cpp-test.yml
@@ -17,28 +17,26 @@ jobs:
   cpp-test:
     name: cpp-test
     runs-on: ubuntu-24.04
-    # VPP-in-CI image; see specs/001-ci-and-precommit.md §5.
-    # Consumed from the ghcr.io mirror to avoid Docker Hub rate-limits.
-    container:
-      image: ligato/vpp-base:24.06
-      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Add fd.io apt repo
+        run: |
+          set -eux
+          curl -fsSL https://packagecloud.io/fdio/release/gpgkey \
+            | sudo gpg --dearmor -o /usr/share/keyrings/fdio-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/fdio-archive-keyring.gpg] \
+            https://packagecloud.io/fdio/release/ubuntu $(lsb_release -cs) main" \
+            | sudo tee /etc/apt/sources.list.d/fdio.list
+
       - name: Install build deps
         run: |
           set -eux
-          apt-get update
-          apt-get install -y --no-install-recommends \
-              cmake ninja-build g++ clang libgtest-dev ccache pkg-config
-
-      - name: Verify VPP dev headers
-        run: |
-          if [ ! -d /usr/include/vpp ]; then
-            echo "::error::VPP dev headers missing under /usr/include/vpp."
-            exit 1
-          fi
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+              cmake ninja-build g++ clang libgtest-dev ccache pkg-config \
+              cppcheck vpp-dev libvppinfra-dev
 
       - name: ccache cache
         uses: actions/cache@v4
@@ -72,8 +70,6 @@ jobs:
 
       - name: cppcheck (full tree)
         if: steps.detect.outputs.have_backend == 'true'
-        # Let cppcheck auto-detect C vs C++ per file extension; pinning
-        # --std=c11 misparses any .cpp/.cc sources (gtest harnesses).
         run: |
           cppcheck \
               --enable=warning,performance,portability \


### PR DESCRIPTION
## Summary

Remove `ligato/vpp-base` container from `build-cpp` and `cpp-test` CI jobs. Install VPP dev headers and build tools directly from the fd.io apt repository.

**Why:** The container image was never published to GHCR, and pulling from Docker Hub causes rate-limiting. Installing via apt is simpler, works on native runners, and avoids Docker entirely.

**Changes:**
- `build.yml`: Remove container block from `cpp-build`, add fd.io apt repo + apt-get install steps
- `cpp-test.yml`: Same — remove container, install deps via apt

Closes #35