### PR TITLE
feat: implement ERSPAN III / GRE parser (W2)

### DIFF
--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -8,4 +8,5 @@
 unknownMacro:src/infmon-backend/*
 
 # Headers in build/ are generated and not ours to fix.
-*:build/*
+# Use specific suppression IDs since wildcard '*' is not supported as an ID.
+unmatchedSuppression:build/*

--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -1,7 +1,6 @@
 # cppcheck suppressions for InFMon.
 # One suppression per line; format documented at
-# https://cppcheck.sourceforge.io/manual.pdf §8 ("Suppressions").
-#
+# https://cppcheck.sourceforge.io/manual.pdf section 8 ("Suppressions").
 # Add new entries with a short justification comment.
 
 # cppcheck cannot see VPP macro-generated symbols and false-positives on them.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,13 @@ jobs:
             echo "::notice::src/backend/CMakeLists.txt not present yet; C++ build is a no-op."
           fi
 
+      - name: Install build deps
+        if: steps.detect_cpp.outputs.have_backend == 'true'
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends \
+              cmake ninja-build g++ libgtest-dev ccache pkg-config
+
       - name: Configure + build
         if: steps.detect_cpp.outputs.have_backend == 'true'
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,11 +87,11 @@ jobs:
             echo "::notice::src/backend/CMakeLists.txt not present yet; C++ build is a no-op."
           fi
 
-      - name: Install build deps
+      - name: Install test deps
         if: steps.detect_cpp.outputs.have_backend == 'true'
         run: |
-          apt-get update -qq
-          apt-get install -y --no-install-recommends \
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
               cmake ninja-build g++ libgtest-dev ccache pkg-config
 
       - name: Configure + build

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.16)
+project(infmon-backend C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# --- Compiler flags ---
+add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+
+# --- ERSPAN parser library (pure C, no VPP dependency) ---
+add_library(infmon_parser STATIC
+    src/erspan_parser.c
+)
+target_include_directories(infmon_parser PUBLIC include)
+
+# --- Tests ---
+find_package(GTest REQUIRED)
+enable_testing()
+
+add_executable(test_erspan_parser
+    test/test_erspan_parser.cc
+)
+target_link_libraries(test_erspan_parser PRIVATE infmon_parser GTest::gtest GTest::gtest_main)
+target_include_directories(test_erspan_parser PRIVATE include)
+add_test(NAME erspan_parser COMMAND test_erspan_parser)

--- a/src/backend/include/infmon/erspan_parser.h
+++ b/src/backend/include/infmon/erspan_parser.h
@@ -22,13 +22,13 @@ extern "C" {
 /* ── Error / counter reason codes ─────────────────────────────────── */
 
 typedef enum {
-    INFMON_PARSE_OK = 0,              /* full inner packet present          */
-    INFMON_PARSE_INNER_TRUNCATED_OK,  /* inner truncated but usable         */
+    INFMON_PARSE_OK = 0,             /* full inner packet present          */
+    INFMON_PARSE_INNER_TRUNCATED_OK, /* inner truncated but usable         */
     INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED,
     INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED,
     INFMON_PARSE_ERR_OUTER_V6_EXT_UNSUPPORTED,
     INFMON_PARSE_ERR_OUTER_TRUNCATED,
-    INFMON_PARSE_ERR_MBUF_NOT_CONTIGUOUS,  /* reserved for VPP integration */
+    INFMON_PARSE_ERR_MBUF_NOT_CONTIGUOUS, /* reserved for VPP integration */
     INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS,
     INFMON_PARSE_ERR_GRE_BAD_VERSION,
     INFMON_PARSE_ERR_GRE_BAD_PROTO,
@@ -37,7 +37,7 @@ typedef enum {
     INFMON_PARSE_ERR_INNER_ETH_TRUNCATED,
     INFMON_PARSE_ERR_INNER_L3_TRUNCATED,
     INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED,
-    INFMON_PARSE_ERR__COUNT  /* sentinel */
+    INFMON_PARSE_ERR__COUNT /* sentinel */
 } infmon_parse_result_t;
 
 /* ── Counter names (indexed by infmon_parse_result_t) ─────────────── */
@@ -63,44 +63,44 @@ typedef struct {
 
 /* ── Valid-fields bitmask for inner L4 ────────────────────────────── */
 
-#define INFMON_VALID_PORTS      (1u << 0)
-#define INFMON_VALID_TCP_FLAGS  (1u << 1)
-#define INFMON_VALID_TCP_SEQ    (1u << 2)
-#define INFMON_VALID_TCP_ACK    (1u << 3)
+#define INFMON_VALID_PORTS (1u << 0)
+#define INFMON_VALID_TCP_FLAGS (1u << 1)
+#define INFMON_VALID_TCP_SEQ (1u << 2)
+#define INFMON_VALID_TCP_ACK (1u << 3)
 #define INFMON_VALID_TCP_WINDOW (1u << 4)
 
 /* ── Inner-decap hook types (§4.6) ────────────────────────────────── */
 
 typedef enum {
     INFMON_DECAP_NONE = 0,
-    INFMON_DECAP_VXLAN,   /* future */
-    INFMON_DECAP_GENEVE,  /* future */
-    INFMON_DECAP_ROCEV2,  /* future */
+    INFMON_DECAP_VXLAN,  /* future */
+    INFMON_DECAP_GENEVE, /* future */
+    INFMON_DECAP_ROCEV2, /* future */
 } infmon_inner_decap_t;
 
 /* ── Parser output ────────────────────────────────────────────────── */
 
 typedef struct {
-    const uint8_t *inner_ptr;       /* pointer into original buffer    */
-    uint32_t       inner_len;       /* bytes available                 */
-    bool           inner_truncated; /* inner_len < declared_inner_len  */
+    const uint8_t *inner_ptr; /* pointer into original buffer    */
+    uint32_t inner_len;       /* bytes available                 */
+    bool inner_truncated;     /* inner_len < declared_inner_len  */
 
     infmon_mirror_src_ip_t mirror_src_ip;
 
     /* Inner L4 extracted fields (valid only when corresponding bit set) */
-    uint32_t       valid_fields;    /* bitmask of INFMON_VALID_* */
-    uint16_t       src_port;        /* network byte order */
-    uint16_t       dst_port;        /* network byte order */
-    uint8_t        tcp_flags;
-    uint32_t       tcp_seq;         /* network byte order */
-    uint32_t       tcp_ack;         /* network byte order */
-    uint16_t       tcp_window;      /* network byte order */
+    uint32_t valid_fields; /* bitmask of INFMON_VALID_* */
+    uint16_t src_port;     /* network byte order */
+    uint16_t dst_port;     /* network byte order */
+    uint8_t tcp_flags;
+    uint32_t tcp_seq;    /* network byte order */
+    uint32_t tcp_ack;    /* network byte order */
+    uint16_t tcp_window; /* network byte order */
 
-    bool           flow_key_partial; /* ports missing for TCP/UDP */
+    bool flow_key_partial; /* ports missing for TCP/UDP */
 
     /* Inner L3 info */
-    uint8_t        inner_ip_proto;
-    infmon_af_t    inner_af;
+    uint8_t inner_ip_proto;
+    infmon_af_t inner_af;
 } infmon_parsed_packet_t;
 
 /* ── Main parser entry point ──────────────────────────────────────── */
@@ -115,18 +115,16 @@ typedef struct {
  * @return INFMON_PARSE_OK or INFMON_PARSE_INNER_TRUNCATED_OK on success;
  *         an error code otherwise.
  */
-infmon_parse_result_t
-infmon_parse_erspan(const uint8_t *data, uint32_t len,
-                    infmon_parsed_packet_t *out);
+infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
+                                          infmon_parsed_packet_t *out);
 
 /* ── Inner-decap hook (§4.6) ──────────────────────────────────────── */
 
 /**
  * v1: only INFMON_DECAP_NONE is implemented (identity).
  */
-int infmon_inner_decap(infmon_inner_decap_t kind,
-                       const uint8_t *in, uint32_t in_len, bool in_truncated,
-                       const uint8_t **out_ptr, uint32_t *out_len,
+int infmon_inner_decap(infmon_inner_decap_t kind, const uint8_t *in, uint32_t in_len,
+                       bool in_truncated, const uint8_t **out_ptr, uint32_t *out_len,
                        bool *out_truncated);
 
 #ifdef __cplusplus

--- a/src/backend/include/infmon/erspan_parser.h
+++ b/src/backend/include/infmon/erspan_parser.h
@@ -1,0 +1,136 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * ERSPAN III / GRE parser — see specs/003-erspan-and-packet-parsing.md
+ *
+ * Pure-function parser: no allocations, no syscalls, no cross-packet state.
+ * Operates on a single contiguous buffer.
+ */
+
+#ifndef INFMON_ERSPAN_PARSER_H
+#define INFMON_ERSPAN_PARSER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Error / counter reason codes ─────────────────────────────────── */
+
+typedef enum {
+    INFMON_PARSE_OK = 0,              /* full inner packet present          */
+    INFMON_PARSE_INNER_TRUNCATED_OK,  /* inner truncated but usable         */
+    INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED,
+    INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED,
+    INFMON_PARSE_ERR_OUTER_V6_EXT_UNSUPPORTED,
+    INFMON_PARSE_ERR_OUTER_TRUNCATED,
+    INFMON_PARSE_ERR_MBUF_NOT_CONTIGUOUS,  /* reserved for VPP integration */
+    INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS,
+    INFMON_PARSE_ERR_GRE_BAD_VERSION,
+    INFMON_PARSE_ERR_GRE_BAD_PROTO,
+    INFMON_PARSE_ERR_ERSPAN_BAD_VERSION,
+    INFMON_PARSE_ERR_ERSPAN_TRUNCATED,
+    INFMON_PARSE_ERR_INNER_ETH_TRUNCATED,
+    INFMON_PARSE_ERR_INNER_L3_TRUNCATED,
+    INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED,
+    INFMON_PARSE_ERR__COUNT  /* sentinel */
+} infmon_parse_result_t;
+
+/* ── Counter names (indexed by infmon_parse_result_t) ─────────────── */
+
+extern const char *infmon_parse_counter_names[];
+
+/* ── IP address family ────────────────────────────────────────────── */
+
+typedef enum {
+    INFMON_AF_V4 = 0,
+    INFMON_AF_V6,
+} infmon_af_t;
+
+/* ── Mirror source IP (tagged union) ──────────────────────────────── */
+
+typedef struct {
+    infmon_af_t family;
+    union {
+        uint8_t v4[4];
+        uint8_t v6[16];
+    } addr;
+} infmon_mirror_src_ip_t;
+
+/* ── Valid-fields bitmask for inner L4 ────────────────────────────── */
+
+#define INFMON_VALID_PORTS      (1u << 0)
+#define INFMON_VALID_TCP_FLAGS  (1u << 1)
+#define INFMON_VALID_TCP_SEQ    (1u << 2)
+#define INFMON_VALID_TCP_ACK    (1u << 3)
+#define INFMON_VALID_TCP_WINDOW (1u << 4)
+
+/* ── Inner-decap hook types (§4.6) ────────────────────────────────── */
+
+typedef enum {
+    INFMON_DECAP_NONE = 0,
+    INFMON_DECAP_VXLAN,   /* future */
+    INFMON_DECAP_GENEVE,  /* future */
+    INFMON_DECAP_ROCEV2,  /* future */
+} infmon_inner_decap_t;
+
+/* ── Parser output ────────────────────────────────────────────────── */
+
+typedef struct {
+    const uint8_t *inner_ptr;       /* pointer into original buffer    */
+    uint32_t       inner_len;       /* bytes available                 */
+    bool           inner_truncated; /* inner_len < declared_inner_len  */
+
+    infmon_mirror_src_ip_t mirror_src_ip;
+
+    /* Inner L4 extracted fields (valid only when corresponding bit set) */
+    uint32_t       valid_fields;    /* bitmask of INFMON_VALID_* */
+    uint16_t       src_port;        /* network byte order */
+    uint16_t       dst_port;        /* network byte order */
+    uint8_t        tcp_flags;
+    uint32_t       tcp_seq;         /* network byte order */
+    uint32_t       tcp_ack;         /* network byte order */
+    uint16_t       tcp_window;      /* network byte order */
+
+    bool           flow_key_partial; /* ports missing for TCP/UDP */
+
+    /* Inner L3 info */
+    uint8_t        inner_ip_proto;
+    infmon_af_t    inner_af;
+} infmon_parsed_packet_t;
+
+/* ── Main parser entry point ──────────────────────────────────────── */
+
+/**
+ * Parse an ERSPAN III over GRE packet from a contiguous buffer.
+ *
+ * @param data   Pointer to the start of the outer Ethernet frame.
+ * @param len    Length of the buffer in bytes.
+ * @param out    Output struct (populated on PARSE_OK or INNER_TRUNCATED_OK).
+ *
+ * @return INFMON_PARSE_OK or INFMON_PARSE_INNER_TRUNCATED_OK on success;
+ *         an error code otherwise.
+ */
+infmon_parse_result_t
+infmon_parse_erspan(const uint8_t *data, uint32_t len,
+                    infmon_parsed_packet_t *out);
+
+/* ── Inner-decap hook (§4.6) ──────────────────────────────────────── */
+
+/**
+ * v1: only INFMON_DECAP_NONE is implemented (identity).
+ */
+int infmon_inner_decap(infmon_inner_decap_t kind,
+                       const uint8_t *in, uint32_t in_len, bool in_truncated,
+                       const uint8_t **out_ptr, uint32_t *out_len,
+                       bool *out_truncated);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INFMON_ERSPAN_PARSER_H */

--- a/src/backend/include/infmon/erspan_parser.h
+++ b/src/backend/include/infmon/erspan_parser.h
@@ -89,12 +89,12 @@ typedef struct {
 
     /* Inner L4 extracted fields (valid only when corresponding bit set) */
     uint32_t valid_fields; /* bitmask of INFMON_VALID_* */
-    uint16_t src_port;     /* network byte order */
-    uint16_t dst_port;     /* network byte order */
+    uint16_t src_port;     /* host byte order */
+    uint16_t dst_port;     /* host byte order */
     uint8_t tcp_flags;
-    uint32_t tcp_seq;    /* network byte order */
-    uint32_t tcp_ack;    /* network byte order */
-    uint16_t tcp_window; /* network byte order */
+    uint32_t tcp_seq;    /* host byte order */
+    uint32_t tcp_ack;    /* host byte order */
+    uint16_t tcp_window; /* host byte order */
 
     bool flow_key_partial; /* ports missing for TCP/UDP */
 

--- a/src/backend/src/erspan_parser.c
+++ b/src/backend/src/erspan_parser.c
@@ -1,0 +1,389 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * ERSPAN III / GRE parser implementation.
+ * See specs/003-erspan-and-packet-parsing.md for the authoritative spec.
+ */
+
+#include "infmon/erspan_parser.h"
+
+#include <string.h>
+
+/* ── Counter names ────────────────────────────────────────────────── */
+
+const char *infmon_parse_counter_names[] = {
+    [INFMON_PARSE_OK]                              = "parsed_ok",
+    [INFMON_PARSE_INNER_TRUNCATED_OK]              = "inner_truncated_ok",
+    [INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED]      = "outer_qinq_unsupported",
+    [INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED]  = "outer_ethertype_unsupported",
+    [INFMON_PARSE_ERR_OUTER_V6_EXT_UNSUPPORTED]     = "outer_v6_ext_unsupported",
+    [INFMON_PARSE_ERR_OUTER_TRUNCATED]              = "outer_truncated",
+    [INFMON_PARSE_ERR_MBUF_NOT_CONTIGUOUS]          = "mbuf_not_contiguous",
+    [INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS]         = "gre_unexpected_flags",
+    [INFMON_PARSE_ERR_GRE_BAD_VERSION]              = "gre_bad_version",
+    [INFMON_PARSE_ERR_GRE_BAD_PROTO]                = "gre_bad_proto",
+    [INFMON_PARSE_ERR_ERSPAN_BAD_VERSION]           = "erspan_bad_version",
+    [INFMON_PARSE_ERR_ERSPAN_TRUNCATED]             = "erspan_truncated",
+    [INFMON_PARSE_ERR_INNER_ETH_TRUNCATED]          = "inner_eth_truncated",
+    [INFMON_PARSE_ERR_INNER_L3_TRUNCATED]           = "inner_l3_truncated",
+    [INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED]   = "inner_double_encap_dropped",
+};
+
+/* ── Helpers ──────────────────────────────────────────────────────── */
+
+static inline uint16_t
+read_u16(const uint8_t *p)
+{
+    return (uint16_t)((uint16_t)p[0] << 8 | p[1]);
+}
+
+static inline uint32_t
+read_u32(const uint8_t *p)
+{
+    return (uint32_t)((uint32_t)p[0] << 24 | (uint32_t)p[1] << 16 |
+                      (uint32_t)p[2] << 8  | p[3]);
+}
+
+/* ── Inner-decap hook ─────────────────────────────────────────────── */
+
+int
+infmon_inner_decap(infmon_inner_decap_t kind,
+                   const uint8_t *in, uint32_t in_len, bool in_truncated,
+                   const uint8_t **out_ptr, uint32_t *out_len,
+                   bool *out_truncated)
+{
+    if (kind != INFMON_DECAP_NONE)
+        return -1;  /* unsupported in v1 */
+
+    *out_ptr = in;
+    *out_len = in_len;
+    *out_truncated = in_truncated;
+    return 0;
+}
+
+/* ── Main parser ──────────────────────────────────────────────────── */
+
+infmon_parse_result_t
+infmon_parse_erspan(const uint8_t *data, uint32_t len,
+                    infmon_parsed_packet_t *out)
+{
+    memset(out, 0, sizeof(*out));
+    uint32_t off = 0;
+
+    /* ── Outer Ethernet ─────────────────────────────────────────── */
+    if (len < 14)
+        return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
+    uint16_t ethertype = read_u16(data + 12);
+    off = 14;
+
+    /* Single VLAN tag */
+    if (ethertype == 0x8100) {
+        if (len < off + 4)
+            return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+        ethertype = read_u16(data + off + 2);
+        off += 4;
+
+        /* QinQ check: if after stripping one VLAN we see another 0x8100
+         * or 0x88A8, that's stacked VLAN */
+        if (ethertype == 0x8100 || ethertype == 0x88A8)
+            return INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED;
+    } else if (ethertype == 0x88A8) {
+        /* S-tag (QinQ outer tag) */
+        return INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED;
+    }
+
+    if (ethertype != 0x0800 && ethertype != 0x86DD)
+        return INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED;
+
+    /* ── Outer L3 ───────────────────────────────────────────────── */
+    uint16_t outer_ip_payload_len = 0; /* bytes after IP header(s) */
+    (void)0; /* l3_off removed — not needed */
+    uint32_t v6_ext_len = 0;
+
+    if (ethertype == 0x0800) {
+        /* IPv4 */
+        if (len < off + 20)
+            return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
+        uint8_t ver_ihl = data[off];
+        if ((ver_ihl >> 4) != 4)
+            return INFMON_PARSE_ERR_OUTER_TRUNCATED; /* bad version */
+
+        uint8_t ihl = ver_ihl & 0x0F;
+        if (ihl < 5)
+            return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
+        uint32_t ip_hdr_len = (uint32_t)ihl * 4;
+        if (len < off + ip_hdr_len)
+            return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
+        uint8_t protocol = data[off + 9];
+        if (protocol != 47) /* GRE */
+            return INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED;
+
+        uint16_t total_length = read_u16(data + off + 2);
+
+        /* Extract mirror_src_ip (IPv4 SA at offset 12) */
+        out->mirror_src_ip.family = INFMON_AF_V4;
+        memcpy(out->mirror_src_ip.addr.v4, data + off + 12, 4);
+
+        outer_ip_payload_len = total_length > ip_hdr_len
+                                   ? (uint16_t)(total_length - ip_hdr_len)
+                                   : 0;
+        off += ip_hdr_len;
+
+    } else {
+        /* IPv6 */
+        if (len < off + 40)
+            return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
+        uint8_t ver = data[off] >> 4;
+        if (ver != 6)
+            return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
+        uint16_t payload_length = read_u16(data + off + 4);
+        uint8_t next_hdr = data[off + 6];
+
+        /* Extract mirror_src_ip (IPv6 SA at offset 8) */
+        out->mirror_src_ip.family = INFMON_AF_V6;
+        memcpy(out->mirror_src_ip.addr.v6, data + off + 8, 16);
+
+        off += 40;
+
+        /* Parse allowed extension headers: Hop-by-Hop (0) and
+         * Destination Options (60) */
+        while (next_hdr == 0 || next_hdr == 60) {
+            if (len < off + 2)
+                return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+            uint8_t ext_next = data[off];
+            uint8_t ext_hdr_len_field = data[off + 1];
+            uint32_t ext_len = ((uint32_t)ext_hdr_len_field + 1) * 8;
+            if (len < off + ext_len)
+                return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+            v6_ext_len += ext_len;
+            next_hdr = ext_next;
+            off += ext_len;
+        }
+
+        if (next_hdr != 47) {
+            /* If next_hdr is an unsupported extension type vs non-GRE proto */
+            /* Extension headers: Routing(43), Fragment(44), AH(51),
+             * ESP(50), Mobility(135) */
+            if (next_hdr == 43 || next_hdr == 44 || next_hdr == 51 ||
+                next_hdr == 50 || next_hdr == 135)
+                return INFMON_PARSE_ERR_OUTER_V6_EXT_UNSUPPORTED;
+            return INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED;
+        }
+
+        outer_ip_payload_len = payload_length > (uint16_t)v6_ext_len
+                                   ? (uint16_t)(payload_length - (uint16_t)v6_ext_len)
+                                   : 0;
+    }
+
+    /* ── GRE ────────────────────────────────────────────────────── */
+    if (len < off + 4)
+        return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
+    uint16_t gre_flags_ver = read_u16(data + off);
+    uint16_t gre_proto = read_u16(data + off + 2);
+
+    uint8_t gre_version = gre_flags_ver & 0x07;
+    if (gre_version != 0)
+        return INFMON_PARSE_ERR_GRE_BAD_VERSION;
+
+    /* Flags: bits 15..0 of the first 16 bits.
+     * Bit layout (MSB first): C R K S s(recursion) flags ver
+     * C=bit15, R=bit14, K=bit13, S=bit12
+     * Only S (bit 12) is allowed. */
+    uint16_t flags = gre_flags_ver & 0xFFF8; /* mask out version bits */
+    bool has_seq = (flags & 0x1000) != 0;
+    uint16_t disallowed = flags & ~(uint16_t)0x1000;
+    if (disallowed != 0)
+        return INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS;
+
+    if (gre_proto != 0x22EB)
+        return INFMON_PARSE_ERR_GRE_BAD_PROTO;
+
+    uint32_t gre_len = 4 + (has_seq ? 4 : 0);
+    if (len < off + gre_len)
+        return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+    off += gre_len;
+
+    /* ── ERSPAN III Header (12 bytes) ───────────────────────────── */
+    if (len < off + 12)
+        return INFMON_PARSE_ERR_ERSPAN_TRUNCATED;
+
+    uint32_t erspan_w0 = read_u32(data + off);
+    uint32_t erspan_w2 = read_u32(data + off + 8);
+
+    /* Ver = bits [31:28] of word 0 */
+    uint8_t erspan_ver = (erspan_w0 >> 28) & 0x0F;
+    if (erspan_ver != 2)
+        return INFMON_PARSE_ERR_ERSPAN_BAD_VERSION;
+
+    /* O bit = bit 0 of word 2 (bit 95 of header, i.e. LSB of word 2) */
+    bool o_bit = (erspan_w2 & 0x01) != 0;
+
+    uint32_t erspan_hdr_len = 12 + (o_bit ? 8 : 0);
+    if (len < off + erspan_hdr_len)
+        return INFMON_PARSE_ERR_ERSPAN_TRUNCATED;
+    off += erspan_hdr_len;
+
+    /* ── Compute declared_inner_len ─────────────────────────────── */
+    uint32_t overhead_after_ip = gre_len + erspan_hdr_len;
+    uint32_t declared_inner_len = 0;
+    if (outer_ip_payload_len > overhead_after_ip)
+        declared_inner_len = outer_ip_payload_len - overhead_after_ip;
+
+    /* Actual inner bytes available in buffer */
+    uint32_t actual_inner_len = (len > off) ? (len - off) : 0;
+
+    /* Use the smaller of declared and actual */
+    uint32_t inner_len = actual_inner_len;
+    if (declared_inner_len > 0 && declared_inner_len < inner_len)
+        inner_len = declared_inner_len;
+
+    bool truncated = (inner_len < declared_inner_len);
+
+    /* ── Inner-decap hook (v1: identity) ────────────────────────── */
+    const uint8_t *inner_ptr = data + off;
+    uint32_t decap_len = inner_len;
+    bool decap_truncated = truncated;
+
+    if (infmon_inner_decap(INFMON_DECAP_NONE, inner_ptr, inner_len,
+                           truncated, &inner_ptr, &decap_len,
+                           &decap_truncated) != 0)
+        return INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED;
+
+    inner_len = decap_len;
+    truncated = decap_truncated;
+
+    /* ── Inner Ethernet (14 B required) ─────────────────────────── */
+    if (inner_len < 14)
+        return INFMON_PARSE_ERR_INNER_ETH_TRUNCATED;
+
+    /* ── Inner L3 ───────────────────────────────────────────────── */
+    uint16_t inner_ethertype = read_u16(inner_ptr + 12);
+    uint32_t inner_l3_off = 14;
+
+    /* Handle inner VLAN tag */
+    if (inner_ethertype == 0x8100) {
+        if (inner_len < inner_l3_off + 4)
+            return INFMON_PARSE_ERR_INNER_L3_TRUNCATED;
+        inner_ethertype = read_u16(inner_ptr + inner_l3_off + 2);
+        inner_l3_off += 4;
+    }
+
+    if (inner_ethertype == 0x0800) {
+        /* Inner IPv4 */
+        if (inner_len < inner_l3_off + 20)
+            return INFMON_PARSE_ERR_INNER_L3_TRUNCATED;
+
+        out->inner_af = INFMON_AF_V4;
+        out->inner_ip_proto = inner_ptr[inner_l3_off + 9];
+
+        uint8_t inner_ihl = inner_ptr[inner_l3_off] & 0x0F;
+        uint32_t inner_ip_hdr_len = (uint32_t)inner_ihl * 4;
+        if (inner_ip_hdr_len < 20)
+            inner_ip_hdr_len = 20;
+
+        uint32_t inner_l4_off = inner_l3_off + inner_ip_hdr_len;
+
+        /* Extract L4 fields (TCP/UDP only) */
+        if (out->inner_ip_proto == 6 || out->inner_ip_proto == 17) {
+            /* Need at least 4 bytes for ports */
+            if (inner_len >= inner_l4_off + 4) {
+                out->src_port = read_u16(inner_ptr + inner_l4_off);
+                out->dst_port = read_u16(inner_ptr + inner_l4_off + 2);
+                out->valid_fields |= INFMON_VALID_PORTS;
+            } else {
+                out->flow_key_partial = true;
+            }
+
+            /* TCP-specific fields */
+            if (out->inner_ip_proto == 6 &&
+                (out->valid_fields & INFMON_VALID_PORTS)) {
+                if (inner_len >= inner_l4_off + 8) {
+                    out->tcp_seq = read_u32(inner_ptr + inner_l4_off + 4);
+                    out->valid_fields |= INFMON_VALID_TCP_SEQ;
+                }
+                if (inner_len >= inner_l4_off + 12) {
+                    out->tcp_ack = read_u32(inner_ptr + inner_l4_off + 8);
+                    out->valid_fields |= INFMON_VALID_TCP_ACK;
+                }
+                if (inner_len >= inner_l4_off + 14) {
+                    uint8_t data_off_flags = inner_ptr[inner_l4_off + 13];
+                    out->tcp_flags = data_off_flags;
+                    out->valid_fields |= INFMON_VALID_TCP_FLAGS;
+                }
+                if (inner_len >= inner_l4_off + 16) {
+                    out->tcp_window =
+                        read_u16(inner_ptr + inner_l4_off + 14);
+                    out->valid_fields |= INFMON_VALID_TCP_WINDOW;
+                }
+            }
+        } else {
+            /* Non-TCP/UDP L4: no port extraction */
+            out->flow_key_partial = true;
+        }
+
+    } else if (inner_ethertype == 0x86DD) {
+        /* Inner IPv6 */
+        if (inner_len < inner_l3_off + 40)
+            return INFMON_PARSE_ERR_INNER_L3_TRUNCATED;
+
+        out->inner_af = INFMON_AF_V6;
+        out->inner_ip_proto = inner_ptr[inner_l3_off + 6];
+
+        uint32_t inner_l4_off = inner_l3_off + 40;
+
+        if (out->inner_ip_proto == 6 || out->inner_ip_proto == 17) {
+            if (inner_len >= inner_l4_off + 4) {
+                out->src_port = read_u16(inner_ptr + inner_l4_off);
+                out->dst_port = read_u16(inner_ptr + inner_l4_off + 2);
+                out->valid_fields |= INFMON_VALID_PORTS;
+            } else {
+                out->flow_key_partial = true;
+            }
+
+            if (out->inner_ip_proto == 6 &&
+                (out->valid_fields & INFMON_VALID_PORTS)) {
+                if (inner_len >= inner_l4_off + 8) {
+                    out->tcp_seq = read_u32(inner_ptr + inner_l4_off + 4);
+                    out->valid_fields |= INFMON_VALID_TCP_SEQ;
+                }
+                if (inner_len >= inner_l4_off + 12) {
+                    out->tcp_ack = read_u32(inner_ptr + inner_l4_off + 8);
+                    out->valid_fields |= INFMON_VALID_TCP_ACK;
+                }
+                if (inner_len >= inner_l4_off + 14) {
+                    out->tcp_flags = inner_ptr[inner_l4_off + 13];
+                    out->valid_fields |= INFMON_VALID_TCP_FLAGS;
+                }
+                if (inner_len >= inner_l4_off + 16) {
+                    out->tcp_window =
+                        read_u16(inner_ptr + inner_l4_off + 14);
+                    out->valid_fields |= INFMON_VALID_TCP_WINDOW;
+                }
+            }
+        } else {
+            out->flow_key_partial = true;
+        }
+    } else {
+        /* Non-IP inner: we still accept it but can't extract L3/L4 */
+        out->flow_key_partial = true;
+        out->inner_ptr = inner_ptr;
+        out->inner_len = inner_len;
+        out->inner_truncated = truncated;
+        return truncated ? INFMON_PARSE_INNER_TRUNCATED_OK
+                         : INFMON_PARSE_OK;
+    }
+
+    out->inner_ptr = inner_ptr;
+    out->inner_len = inner_len;
+    out->inner_truncated = truncated;
+
+    return truncated ? INFMON_PARSE_INNER_TRUNCATED_OK : INFMON_PARSE_OK;
+}

--- a/src/backend/src/erspan_parser.c
+++ b/src/backend/src/erspan_parser.c
@@ -30,7 +30,8 @@ const char *infmon_parse_counter_names[] = {
     [INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED] = "inner_double_encap_dropped",
 };
 
-_Static_assert(sizeof(infmon_parse_counter_names) / sizeof(infmon_parse_counter_names[0]) == INFMON_PARSE_ERR__COUNT,
+_Static_assert(sizeof(infmon_parse_counter_names) / sizeof(infmon_parse_counter_names[0]) ==
+                   INFMON_PARSE_ERR__COUNT,
                "counter_names out of sync with infmon_parse_result_t");
 
 /* ── Helpers ──────────────────────────────────────────────────────── */
@@ -47,9 +48,8 @@ static inline uint32_t read_u32(const uint8_t *p)
 
 /* ── Extract inner L4 fields (TCP/UDP) ───────────────────────────── */
 
-static void extract_inner_l4(const uint8_t *inner_ptr, uint32_t inner_l4_off,
-                             uint32_t inner_len, uint8_t inner_ip_proto,
-                             infmon_parsed_packet_t *out)
+static void extract_inner_l4(const uint8_t *inner_ptr, uint32_t inner_l4_off, uint32_t inner_len,
+                             uint8_t inner_ip_proto, infmon_parsed_packet_t *out)
 {
     if (inner_ip_proto == 6 || inner_ip_proto == 17) {
         /* Need at least 4 bytes for ports */

--- a/src/backend/src/erspan_parser.c
+++ b/src/backend/src/erspan_parser.c
@@ -13,48 +13,43 @@
 /* ── Counter names ────────────────────────────────────────────────── */
 
 const char *infmon_parse_counter_names[] = {
-    [INFMON_PARSE_OK]                              = "parsed_ok",
-    [INFMON_PARSE_INNER_TRUNCATED_OK]              = "inner_truncated_ok",
-    [INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED]      = "outer_qinq_unsupported",
-    [INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED]  = "outer_ethertype_unsupported",
-    [INFMON_PARSE_ERR_OUTER_V6_EXT_UNSUPPORTED]     = "outer_v6_ext_unsupported",
-    [INFMON_PARSE_ERR_OUTER_TRUNCATED]              = "outer_truncated",
-    [INFMON_PARSE_ERR_MBUF_NOT_CONTIGUOUS]          = "mbuf_not_contiguous",
-    [INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS]         = "gre_unexpected_flags",
-    [INFMON_PARSE_ERR_GRE_BAD_VERSION]              = "gre_bad_version",
-    [INFMON_PARSE_ERR_GRE_BAD_PROTO]                = "gre_bad_proto",
-    [INFMON_PARSE_ERR_ERSPAN_BAD_VERSION]           = "erspan_bad_version",
-    [INFMON_PARSE_ERR_ERSPAN_TRUNCATED]             = "erspan_truncated",
-    [INFMON_PARSE_ERR_INNER_ETH_TRUNCATED]          = "inner_eth_truncated",
-    [INFMON_PARSE_ERR_INNER_L3_TRUNCATED]           = "inner_l3_truncated",
-    [INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED]   = "inner_double_encap_dropped",
+    [INFMON_PARSE_OK] = "parsed_ok",
+    [INFMON_PARSE_INNER_TRUNCATED_OK] = "inner_truncated_ok",
+    [INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED] = "outer_qinq_unsupported",
+    [INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED] = "outer_ethertype_unsupported",
+    [INFMON_PARSE_ERR_OUTER_V6_EXT_UNSUPPORTED] = "outer_v6_ext_unsupported",
+    [INFMON_PARSE_ERR_OUTER_TRUNCATED] = "outer_truncated",
+    [INFMON_PARSE_ERR_MBUF_NOT_CONTIGUOUS] = "mbuf_not_contiguous",
+    [INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS] = "gre_unexpected_flags",
+    [INFMON_PARSE_ERR_GRE_BAD_VERSION] = "gre_bad_version",
+    [INFMON_PARSE_ERR_GRE_BAD_PROTO] = "gre_bad_proto",
+    [INFMON_PARSE_ERR_ERSPAN_BAD_VERSION] = "erspan_bad_version",
+    [INFMON_PARSE_ERR_ERSPAN_TRUNCATED] = "erspan_truncated",
+    [INFMON_PARSE_ERR_INNER_ETH_TRUNCATED] = "inner_eth_truncated",
+    [INFMON_PARSE_ERR_INNER_L3_TRUNCATED] = "inner_l3_truncated",
+    [INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED] = "inner_double_encap_dropped",
 };
 
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
-static inline uint16_t
-read_u16(const uint8_t *p)
+static inline uint16_t read_u16(const uint8_t *p)
 {
-    return (uint16_t)((uint16_t)p[0] << 8 | p[1]);
+    return (uint16_t) ((uint16_t) p[0] << 8 | p[1]);
 }
 
-static inline uint32_t
-read_u32(const uint8_t *p)
+static inline uint32_t read_u32(const uint8_t *p)
 {
-    return (uint32_t)((uint32_t)p[0] << 24 | (uint32_t)p[1] << 16 |
-                      (uint32_t)p[2] << 8  | p[3]);
+    return (uint32_t) ((uint32_t) p[0] << 24 | (uint32_t) p[1] << 16 | (uint32_t) p[2] << 8 | p[3]);
 }
 
 /* ── Inner-decap hook ─────────────────────────────────────────────── */
 
-int
-infmon_inner_decap(infmon_inner_decap_t kind,
-                   const uint8_t *in, uint32_t in_len, bool in_truncated,
-                   const uint8_t **out_ptr, uint32_t *out_len,
-                   bool *out_truncated)
+int infmon_inner_decap(infmon_inner_decap_t kind, const uint8_t *in, uint32_t in_len,
+                       bool in_truncated, const uint8_t **out_ptr, uint32_t *out_len,
+                       bool *out_truncated)
 {
     if (kind != INFMON_DECAP_NONE)
-        return -1;  /* unsupported in v1 */
+        return -1; /* unsupported in v1 */
 
     *out_ptr = in;
     *out_len = in_len;
@@ -64,9 +59,8 @@ infmon_inner_decap(infmon_inner_decap_t kind,
 
 /* ── Main parser ──────────────────────────────────────────────────── */
 
-infmon_parse_result_t
-infmon_parse_erspan(const uint8_t *data, uint32_t len,
-                    infmon_parsed_packet_t *out)
+infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
+                                          infmon_parsed_packet_t *out)
 {
     memset(out, 0, sizeof(*out));
     uint32_t off = 0;
@@ -99,7 +93,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
 
     /* ── Outer L3 ───────────────────────────────────────────────── */
     uint16_t outer_ip_payload_len = 0; /* bytes after IP header(s) */
-    (void)0; /* l3_off removed — not needed */
+    (void) 0;                          /* l3_off removed — not needed */
     uint32_t v6_ext_len = 0;
 
     if (ethertype == 0x0800) {
@@ -115,7 +109,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
         if (ihl < 5)
             return INFMON_PARSE_ERR_OUTER_TRUNCATED;
 
-        uint32_t ip_hdr_len = (uint32_t)ihl * 4;
+        uint32_t ip_hdr_len = (uint32_t) ihl * 4;
         if (len < off + ip_hdr_len)
             return INFMON_PARSE_ERR_OUTER_TRUNCATED;
 
@@ -129,9 +123,8 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
         out->mirror_src_ip.family = INFMON_AF_V4;
         memcpy(out->mirror_src_ip.addr.v4, data + off + 12, 4);
 
-        outer_ip_payload_len = total_length > ip_hdr_len
-                                   ? (uint16_t)(total_length - ip_hdr_len)
-                                   : 0;
+        outer_ip_payload_len =
+            total_length > ip_hdr_len ? (uint16_t) (total_length - ip_hdr_len) : 0;
         off += ip_hdr_len;
 
     } else {
@@ -159,7 +152,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
                 return INFMON_PARSE_ERR_OUTER_TRUNCATED;
             uint8_t ext_next = data[off];
             uint8_t ext_hdr_len_field = data[off + 1];
-            uint32_t ext_len = ((uint32_t)ext_hdr_len_field + 1) * 8;
+            uint32_t ext_len = ((uint32_t) ext_hdr_len_field + 1) * 8;
             if (len < off + ext_len)
                 return INFMON_PARSE_ERR_OUTER_TRUNCATED;
             v6_ext_len += ext_len;
@@ -171,14 +164,14 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
             /* If next_hdr is an unsupported extension type vs non-GRE proto */
             /* Extension headers: Routing(43), Fragment(44), AH(51),
              * ESP(50), Mobility(135) */
-            if (next_hdr == 43 || next_hdr == 44 || next_hdr == 51 ||
-                next_hdr == 50 || next_hdr == 135)
+            if (next_hdr == 43 || next_hdr == 44 || next_hdr == 51 || next_hdr == 50 ||
+                next_hdr == 135)
                 return INFMON_PARSE_ERR_OUTER_V6_EXT_UNSUPPORTED;
             return INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED;
         }
 
-        outer_ip_payload_len = payload_length > (uint16_t)v6_ext_len
-                                   ? (uint16_t)(payload_length - (uint16_t)v6_ext_len)
+        outer_ip_payload_len = payload_length > (uint16_t) v6_ext_len
+                                   ? (uint16_t) (payload_length - (uint16_t) v6_ext_len)
                                    : 0;
     }
 
@@ -199,7 +192,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
      * Only S (bit 12) is allowed. */
     uint16_t flags = gre_flags_ver & 0xFFF8; /* mask out version bits */
     bool has_seq = (flags & 0x1000) != 0;
-    uint16_t disallowed = flags & ~(uint16_t)0x1000;
+    uint16_t disallowed = flags & ~(uint16_t) 0x1000;
     if (disallowed != 0)
         return INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS;
 
@@ -252,9 +245,8 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
     uint32_t decap_len = inner_len;
     bool decap_truncated = truncated;
 
-    if (infmon_inner_decap(INFMON_DECAP_NONE, inner_ptr, inner_len,
-                           truncated, &inner_ptr, &decap_len,
-                           &decap_truncated) != 0)
+    if (infmon_inner_decap(INFMON_DECAP_NONE, inner_ptr, inner_len, truncated, &inner_ptr,
+                           &decap_len, &decap_truncated) != 0)
         return INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED;
 
     inner_len = decap_len;
@@ -285,7 +277,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
         out->inner_ip_proto = inner_ptr[inner_l3_off + 9];
 
         uint8_t inner_ihl = inner_ptr[inner_l3_off] & 0x0F;
-        uint32_t inner_ip_hdr_len = (uint32_t)inner_ihl * 4;
+        uint32_t inner_ip_hdr_len = (uint32_t) inner_ihl * 4;
         if (inner_ip_hdr_len < 20)
             inner_ip_hdr_len = 20;
 
@@ -303,8 +295,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
             }
 
             /* TCP-specific fields */
-            if (out->inner_ip_proto == 6 &&
-                (out->valid_fields & INFMON_VALID_PORTS)) {
+            if (out->inner_ip_proto == 6 && (out->valid_fields & INFMON_VALID_PORTS)) {
                 if (inner_len >= inner_l4_off + 8) {
                     out->tcp_seq = read_u32(inner_ptr + inner_l4_off + 4);
                     out->valid_fields |= INFMON_VALID_TCP_SEQ;
@@ -319,8 +310,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
                     out->valid_fields |= INFMON_VALID_TCP_FLAGS;
                 }
                 if (inner_len >= inner_l4_off + 16) {
-                    out->tcp_window =
-                        read_u16(inner_ptr + inner_l4_off + 14);
+                    out->tcp_window = read_u16(inner_ptr + inner_l4_off + 14);
                     out->valid_fields |= INFMON_VALID_TCP_WINDOW;
                 }
             }
@@ -348,8 +338,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
                 out->flow_key_partial = true;
             }
 
-            if (out->inner_ip_proto == 6 &&
-                (out->valid_fields & INFMON_VALID_PORTS)) {
+            if (out->inner_ip_proto == 6 && (out->valid_fields & INFMON_VALID_PORTS)) {
                 if (inner_len >= inner_l4_off + 8) {
                     out->tcp_seq = read_u32(inner_ptr + inner_l4_off + 4);
                     out->valid_fields |= INFMON_VALID_TCP_SEQ;
@@ -363,8 +352,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
                     out->valid_fields |= INFMON_VALID_TCP_FLAGS;
                 }
                 if (inner_len >= inner_l4_off + 16) {
-                    out->tcp_window =
-                        read_u16(inner_ptr + inner_l4_off + 14);
+                    out->tcp_window = read_u16(inner_ptr + inner_l4_off + 14);
                     out->valid_fields |= INFMON_VALID_TCP_WINDOW;
                 }
             }
@@ -377,8 +365,7 @@ infmon_parse_erspan(const uint8_t *data, uint32_t len,
         out->inner_ptr = inner_ptr;
         out->inner_len = inner_len;
         out->inner_truncated = truncated;
-        return truncated ? INFMON_PARSE_INNER_TRUNCATED_OK
-                         : INFMON_PARSE_OK;
+        return truncated ? INFMON_PARSE_INNER_TRUNCATED_OK : INFMON_PARSE_OK;
     }
 
     out->inner_ptr = inner_ptr;

--- a/src/backend/src/erspan_parser.c
+++ b/src/backend/src/erspan_parser.c
@@ -223,8 +223,7 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
             return INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED;
         }
 
-        outer_ip_payload_len =
-            payload_length > v6_ext_len ? payload_length - v6_ext_len : 0;
+        outer_ip_payload_len = payload_length > v6_ext_len ? payload_length - v6_ext_len : 0;
     }
 
     /* ── GRE ────────────────────────────────────────────────────── */
@@ -341,8 +340,7 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
         } else {
             uint32_t inner_ip_hdr_len = (uint32_t) inner_ihl * 4;
             uint32_t inner_l4_off = inner_l3_off + inner_ip_hdr_len;
-            extract_inner_l4(inner_ptr, inner_l4_off, inner_len,
-                             out->inner_ip_proto, out);
+            extract_inner_l4(inner_ptr, inner_l4_off, inner_len, out->inner_ip_proto, out);
         }
 
     } else if (inner_ethertype == 0x86DD) {
@@ -359,8 +357,7 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
         out->inner_ip_proto = inner_ptr[inner_l3_off + 6];
 
         uint32_t inner_l4_off = inner_l3_off + 40;
-        extract_inner_l4(inner_ptr, inner_l4_off, inner_len,
-                         out->inner_ip_proto, out);
+        extract_inner_l4(inner_ptr, inner_l4_off, inner_len, out->inner_ip_proto, out);
     } else {
         /* Non-IP inner: we still accept it but can't extract L3/L4 */
         out->flow_key_partial = true;

--- a/src/backend/src/erspan_parser.c
+++ b/src/backend/src/erspan_parser.c
@@ -30,6 +30,9 @@ const char *infmon_parse_counter_names[] = {
     [INFMON_PARSE_ERR_INNER_DOUBLE_ENCAP_DROPPED] = "inner_double_encap_dropped",
 };
 
+_Static_assert(sizeof(infmon_parse_counter_names) / sizeof(infmon_parse_counter_names[0]) == INFMON_PARSE_ERR__COUNT,
+               "counter_names out of sync with infmon_parse_result_t");
+
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
 static inline uint16_t read_u16(const uint8_t *p)
@@ -40,6 +43,47 @@ static inline uint16_t read_u16(const uint8_t *p)
 static inline uint32_t read_u32(const uint8_t *p)
 {
     return (uint32_t) ((uint32_t) p[0] << 24 | (uint32_t) p[1] << 16 | (uint32_t) p[2] << 8 | p[3]);
+}
+
+/* ── Extract inner L4 fields (TCP/UDP) ───────────────────────────── */
+
+static void extract_inner_l4(const uint8_t *inner_ptr, uint32_t inner_l4_off,
+                             uint32_t inner_len, uint8_t inner_ip_proto,
+                             infmon_parsed_packet_t *out)
+{
+    if (inner_ip_proto == 6 || inner_ip_proto == 17) {
+        /* Need at least 4 bytes for ports */
+        if (inner_len >= inner_l4_off + 4) {
+            out->src_port = read_u16(inner_ptr + inner_l4_off);
+            out->dst_port = read_u16(inner_ptr + inner_l4_off + 2);
+            out->valid_fields |= INFMON_VALID_PORTS;
+        } else {
+            out->flow_key_partial = true;
+        }
+
+        /* TCP-specific fields */
+        if (inner_ip_proto == 6 && (out->valid_fields & INFMON_VALID_PORTS)) {
+            if (inner_len >= inner_l4_off + 8) {
+                out->tcp_seq = read_u32(inner_ptr + inner_l4_off + 4);
+                out->valid_fields |= INFMON_VALID_TCP_SEQ;
+            }
+            if (inner_len >= inner_l4_off + 12) {
+                out->tcp_ack = read_u32(inner_ptr + inner_l4_off + 8);
+                out->valid_fields |= INFMON_VALID_TCP_ACK;
+            }
+            if (inner_len >= inner_l4_off + 14) {
+                out->tcp_flags = inner_ptr[inner_l4_off + 13];
+                out->valid_fields |= INFMON_VALID_TCP_FLAGS;
+            }
+            if (inner_len >= inner_l4_off + 16) {
+                out->tcp_window = read_u16(inner_ptr + inner_l4_off + 14);
+                out->valid_fields |= INFMON_VALID_TCP_WINDOW;
+            }
+        }
+    } else {
+        /* Non-TCP/UDP L4: no port extraction */
+        out->flow_key_partial = true;
+    }
 }
 
 /* ── Inner-decap hook ─────────────────────────────────────────────── */
@@ -56,6 +100,9 @@ int infmon_inner_decap(infmon_inner_decap_t kind, const uint8_t *in, uint32_t in
     *out_truncated = in_truncated;
     return 0;
 }
+
+/* Maximum number of IPv6 extension headers to traverse before giving up. */
+#define MAX_IPV6_EXT_HEADERS 8
 
 /* ── Main parser ──────────────────────────────────────────────────── */
 
@@ -92,9 +139,7 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
         return INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED;
 
     /* ── Outer L3 ───────────────────────────────────────────────── */
-    uint16_t outer_ip_payload_len = 0; /* bytes after IP header(s) */
-    (void) 0;                          /* l3_off removed — not needed */
-    uint32_t v6_ext_len = 0;
+    uint32_t outer_ip_payload_len = 0; /* bytes after IP header(s) */
 
     if (ethertype == 0x0800) {
         /* IPv4 */
@@ -119,12 +164,15 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
 
         uint16_t total_length = read_u16(data + off + 2);
 
+        /* Validate total_length against ip_hdr_len */
+        if (total_length < ip_hdr_len)
+            return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
         /* Extract mirror_src_ip (IPv4 SA at offset 12) */
         out->mirror_src_ip.family = INFMON_AF_V4;
         memcpy(out->mirror_src_ip.addr.v4, data + off + 12, 4);
 
-        outer_ip_payload_len =
-            total_length > ip_hdr_len ? (uint16_t) (total_length - ip_hdr_len) : 0;
+        outer_ip_payload_len = total_length - ip_hdr_len;
         off += ip_hdr_len;
 
     } else {
@@ -146,8 +194,13 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
         off += 40;
 
         /* Parse allowed extension headers: Hop-by-Hop (0) and
-         * Destination Options (60) */
+         * Destination Options (60).
+         * Cap iterations to avoid pathological chains. */
+        uint32_t v6_ext_len = 0;
+        int ext_iters = 0;
         while (next_hdr == 0 || next_hdr == 60) {
+            if (++ext_iters > MAX_IPV6_EXT_HEADERS)
+                return INFMON_PARSE_ERR_OUTER_V6_EXT_UNSUPPORTED;
             if (len < off + 2)
                 return INFMON_PARSE_ERR_OUTER_TRUNCATED;
             uint8_t ext_next = data[off];
@@ -170,9 +223,8 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
             return INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED;
         }
 
-        outer_ip_payload_len = payload_length > (uint16_t) v6_ext_len
-                                   ? (uint16_t) (payload_length - (uint16_t) v6_ext_len)
-                                   : 0;
+        outer_ip_payload_len =
+            payload_length > v6_ext_len ? payload_length - v6_ext_len : 0;
     }
 
     /* ── GRE ────────────────────────────────────────────────────── */
@@ -233,6 +285,12 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
     /* Actual inner bytes available in buffer */
     uint32_t actual_inner_len = (len > off) ? (len - off) : 0;
 
+    /* If declared_inner_len is 0 but we have actual data, the outer IP
+     * header is malformed (total_length too small).  Treat as truncated
+     * rather than silently parsing trailing buffer bytes. */
+    if (declared_inner_len == 0 && actual_inner_len > 0)
+        return INFMON_PARSE_ERR_OUTER_TRUNCATED;
+
     /* Use the smaller of declared and actual */
     uint32_t inner_len = actual_inner_len;
     if (declared_inner_len > 0 && declared_inner_len < inner_len)
@@ -277,46 +335,14 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
         out->inner_ip_proto = inner_ptr[inner_l3_off + 9];
 
         uint8_t inner_ihl = inner_ptr[inner_l3_off] & 0x0F;
-        uint32_t inner_ip_hdr_len = (uint32_t) inner_ihl * 4;
-        if (inner_ip_hdr_len < 20)
-            inner_ip_hdr_len = 20;
-
-        uint32_t inner_l4_off = inner_l3_off + inner_ip_hdr_len;
-
-        /* Extract L4 fields (TCP/UDP only) */
-        if (out->inner_ip_proto == 6 || out->inner_ip_proto == 17) {
-            /* Need at least 4 bytes for ports */
-            if (inner_len >= inner_l4_off + 4) {
-                out->src_port = read_u16(inner_ptr + inner_l4_off);
-                out->dst_port = read_u16(inner_ptr + inner_l4_off + 2);
-                out->valid_fields |= INFMON_VALID_PORTS;
-            } else {
-                out->flow_key_partial = true;
-            }
-
-            /* TCP-specific fields */
-            if (out->inner_ip_proto == 6 && (out->valid_fields & INFMON_VALID_PORTS)) {
-                if (inner_len >= inner_l4_off + 8) {
-                    out->tcp_seq = read_u32(inner_ptr + inner_l4_off + 4);
-                    out->valid_fields |= INFMON_VALID_TCP_SEQ;
-                }
-                if (inner_len >= inner_l4_off + 12) {
-                    out->tcp_ack = read_u32(inner_ptr + inner_l4_off + 8);
-                    out->valid_fields |= INFMON_VALID_TCP_ACK;
-                }
-                if (inner_len >= inner_l4_off + 14) {
-                    uint8_t data_off_flags = inner_ptr[inner_l4_off + 13];
-                    out->tcp_flags = data_off_flags;
-                    out->valid_fields |= INFMON_VALID_TCP_FLAGS;
-                }
-                if (inner_len >= inner_l4_off + 16) {
-                    out->tcp_window = read_u16(inner_ptr + inner_l4_off + 14);
-                    out->valid_fields |= INFMON_VALID_TCP_WINDOW;
-                }
-            }
-        } else {
-            /* Non-TCP/UDP L4: no port extraction */
+        if (inner_ihl < 5) {
+            /* Malformed inner IP header — skip L4 extraction */
             out->flow_key_partial = true;
+        } else {
+            uint32_t inner_ip_hdr_len = (uint32_t) inner_ihl * 4;
+            uint32_t inner_l4_off = inner_l3_off + inner_ip_hdr_len;
+            extract_inner_l4(inner_ptr, inner_l4_off, inner_len,
+                             out->inner_ip_proto, out);
         }
 
     } else if (inner_ethertype == 0x86DD) {
@@ -325,40 +351,16 @@ infmon_parse_result_t infmon_parse_erspan(const uint8_t *data, uint32_t len,
             return INFMON_PARSE_ERR_INNER_L3_TRUNCATED;
 
         out->inner_af = INFMON_AF_V6;
+        /* NOTE: inner_ip_proto is read from the fixed IPv6 next_hdr field.
+         * If the inner packet has extension headers (hop-by-hop, destination
+         * options, etc.), this will be the extension type rather than the
+         * actual L4 protocol, and port extraction will read the wrong bytes.
+         * This is a known limitation for v1 with ~128B ERSPAN snaps. */
         out->inner_ip_proto = inner_ptr[inner_l3_off + 6];
 
         uint32_t inner_l4_off = inner_l3_off + 40;
-
-        if (out->inner_ip_proto == 6 || out->inner_ip_proto == 17) {
-            if (inner_len >= inner_l4_off + 4) {
-                out->src_port = read_u16(inner_ptr + inner_l4_off);
-                out->dst_port = read_u16(inner_ptr + inner_l4_off + 2);
-                out->valid_fields |= INFMON_VALID_PORTS;
-            } else {
-                out->flow_key_partial = true;
-            }
-
-            if (out->inner_ip_proto == 6 && (out->valid_fields & INFMON_VALID_PORTS)) {
-                if (inner_len >= inner_l4_off + 8) {
-                    out->tcp_seq = read_u32(inner_ptr + inner_l4_off + 4);
-                    out->valid_fields |= INFMON_VALID_TCP_SEQ;
-                }
-                if (inner_len >= inner_l4_off + 12) {
-                    out->tcp_ack = read_u32(inner_ptr + inner_l4_off + 8);
-                    out->valid_fields |= INFMON_VALID_TCP_ACK;
-                }
-                if (inner_len >= inner_l4_off + 14) {
-                    out->tcp_flags = inner_ptr[inner_l4_off + 13];
-                    out->valid_fields |= INFMON_VALID_TCP_FLAGS;
-                }
-                if (inner_len >= inner_l4_off + 16) {
-                    out->tcp_window = read_u16(inner_ptr + inner_l4_off + 14);
-                    out->valid_fields |= INFMON_VALID_TCP_WINDOW;
-                }
-            }
-        } else {
-            out->flow_key_partial = true;
-        }
+        extract_inner_l4(inner_ptr, inner_l4_off, inner_len,
+                         out->inner_ip_proto, out);
     } else {
         /* Non-IP inner: we still accept it but can't extract L3/L4 */
         out->flow_key_partial = true;

--- a/src/backend/test/test_erspan_parser.cc
+++ b/src/backend/test/test_erspan_parser.cc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Apache-2.0
 // Comprehensive tests for the ERSPAN III parser.
 
 #include <arpa/inet.h>

--- a/src/backend/test/test_erspan_parser.cc
+++ b/src/backend/test/test_erspan_parser.cc
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Comprehensive tests for the ERSPAN III parser.
 
-#include <gtest/gtest.h>
-#include <cstring>
-#include <vector>
 #include <arpa/inet.h>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <vector>
 
 extern "C" {
 #include "infmon/erspan_parser.h"
@@ -13,37 +13,67 @@ extern "C" {
 // ---------------------------------------------------------------------------
 // Helper: packet builder
 // ---------------------------------------------------------------------------
-class PacketBuilder {
-public:
+class PacketBuilder
+{
+  public:
     std::vector<uint8_t> buf;
 
-    void push8(uint8_t v) { buf.push_back(v); }
-    void push16(uint16_t v) { buf.push_back(v >> 8); buf.push_back(v & 0xff); }
-    void push32(uint32_t v) {
+    void push8(uint8_t v)
+    {
+        buf.push_back(v);
+    }
+    void push16(uint16_t v)
+    {
+        buf.push_back(v >> 8);
+        buf.push_back(v & 0xff);
+    }
+    void push32(uint32_t v)
+    {
         buf.push_back((v >> 24) & 0xff);
         buf.push_back((v >> 16) & 0xff);
         buf.push_back((v >> 8) & 0xff);
         buf.push_back(v & 0xff);
     }
-    void pushN(const uint8_t *d, size_t n) { buf.insert(buf.end(), d, d + n); }
-    void pushZeros(size_t n) { buf.insert(buf.end(), n, 0); }
+    void pushN(const uint8_t *d, size_t n)
+    {
+        buf.insert(buf.end(), d, d + n);
+    }
+    void pushZeros(size_t n)
+    {
+        buf.insert(buf.end(), n, 0);
+    }
 
-    size_t size() const { return buf.size(); }
-    uint8_t *data() { return buf.data(); }
-    const uint8_t *data() const { return buf.data(); }
+    size_t size() const
+    {
+        return buf.size();
+    }
+    uint8_t *data()
+    {
+        return buf.data();
+    }
+    const uint8_t *data() const
+    {
+        return buf.data();
+    }
 
     // Patch a big-endian 16-bit value at offset
-    void patch16(size_t off, uint16_t v) {
-        buf[off] = v >> 8; buf[off+1] = v & 0xff;
+    void patch16(size_t off, uint16_t v)
+    {
+        buf[off] = v >> 8;
+        buf[off + 1] = v & 0xff;
     }
-    void patch8(size_t off, uint8_t v) { buf[off] = v; }
+    void patch8(size_t off, uint8_t v)
+    {
+        buf[off] = v;
+    }
 };
 
 // Build outer Ethernet header. Returns offset after it.
-static size_t addOuterEth(PacketBuilder &pb, uint16_t ethertype) {
+static size_t addOuterEth(PacketBuilder &pb, uint16_t ethertype)
+{
     // dst mac
-    uint8_t dst[6] = {0x00,0x11,0x22,0x33,0x44,0x55};
-    uint8_t src[6] = {0x66,0x77,0x88,0x99,0xaa,0xbb};
+    uint8_t dst[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+    uint8_t src[6] = {0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb};
     pb.pushN(dst, 6);
     pb.pushN(src, 6);
     pb.push16(ethertype);
@@ -51,9 +81,10 @@ static size_t addOuterEth(PacketBuilder &pb, uint16_t ethertype) {
 }
 
 // Add 802.1Q VLAN tag before the real ethertype. Call INSTEAD of addOuterEth.
-static size_t addOuterEthVlan(PacketBuilder &pb, uint16_t vlan_id, uint16_t inner_ethertype) {
-    uint8_t dst[6] = {0x00,0x11,0x22,0x33,0x44,0x55};
-    uint8_t src[6] = {0x66,0x77,0x88,0x99,0xaa,0xbb};
+static size_t addOuterEthVlan(PacketBuilder &pb, uint16_t vlan_id, uint16_t inner_ethertype)
+{
+    uint8_t dst[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+    uint8_t src[6] = {0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb};
     pb.pushN(dst, 6);
     pb.pushN(src, 6);
     pb.push16(0x8100); // TPID
@@ -63,9 +94,10 @@ static size_t addOuterEthVlan(PacketBuilder &pb, uint16_t vlan_id, uint16_t inne
 }
 
 // Add QinQ
-static size_t addOuterEthQinQ(PacketBuilder &pb) {
-    uint8_t dst[6] = {0x00,0x11,0x22,0x33,0x44,0x55};
-    uint8_t src[6] = {0x66,0x77,0x88,0x99,0xaa,0xbb};
+static size_t addOuterEthQinQ(PacketBuilder &pb)
+{
+    uint8_t dst[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+    uint8_t src[6] = {0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb};
     pb.pushN(dst, 6);
     pb.pushN(src, 6);
     pb.push16(0x88a8); // outer TPID (QinQ)
@@ -76,33 +108,37 @@ static size_t addOuterEthQinQ(PacketBuilder &pb) {
     return pb.size();
 }
 
-static const uint8_t kSrcIPv4[4] = {10,0,0,1};
-static const uint8_t kDstIPv4[4] = {10,0,0,2};
+static const uint8_t kSrcIPv4[4] = {10, 0, 0, 1};
+static const uint8_t kDstIPv4[4] = {10, 0, 0, 2};
 
 // Add outer IPv4. Returns offset of start of IPv4.
 // Caller must patch total_length after building rest.
-static size_t addOuterIPv4(PacketBuilder &pb, size_t *ip_start_out) {
+static size_t addOuterIPv4(PacketBuilder &pb, size_t *ip_start_out)
+{
     size_t ip_start = pb.size();
-    if (ip_start_out) *ip_start_out = ip_start;
-    pb.push8(0x45); // ver=4, ihl=5
-    pb.push8(0x00); // DSCP/ECN
-    pb.push16(0);   // total length - patch later
-    pb.push16(0);   // identification
+    if (ip_start_out)
+        *ip_start_out = ip_start;
+    pb.push8(0x45);    // ver=4, ihl=5
+    pb.push8(0x00);    // DSCP/ECN
+    pb.push16(0);      // total length - patch later
+    pb.push16(0);      // identification
     pb.push16(0x4000); // flags=DF, frag=0
-    pb.push8(64);   // TTL
-    pb.push8(47);   // protocol = GRE
-    pb.push16(0);   // checksum
+    pb.push8(64);      // TTL
+    pb.push8(47);      // protocol = GRE
+    pb.push16(0);      // checksum
     pb.pushN(kSrcIPv4, 4);
     pb.pushN(kDstIPv4, 4);
     return pb.size();
 }
 
-static const uint8_t kSrcIPv6[16] = {0x20,0x01,0x0d,0xb8, 0,0,0,0, 0,0,0,0, 0,0,0,1};
-static const uint8_t kDstIPv6[16] = {0x20,0x01,0x0d,0xb8, 0,0,0,0, 0,0,0,0, 0,0,0,2};
+static const uint8_t kSrcIPv6[16] = {0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+static const uint8_t kDstIPv6[16] = {0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2};
 
-static size_t addOuterIPv6(PacketBuilder &pb, size_t *ip_start_out) {
+static size_t addOuterIPv6(PacketBuilder &pb, size_t *ip_start_out)
+{
     size_t ip_start = pb.size();
-    if (ip_start_out) *ip_start_out = ip_start;
+    if (ip_start_out)
+        *ip_start_out = ip_start;
     pb.push32(0x60000000); // ver=6, tc=0, flow=0
     pb.push16(0);          // payload length - patch later
     pb.push8(47);          // next header = GRE
@@ -113,7 +149,9 @@ static size_t addOuterIPv6(PacketBuilder &pb, size_t *ip_start_out) {
 }
 
 // Add GRE header. Returns offset after GRE.
-static size_t addGRE(PacketBuilder &pb, uint16_t flags_ver = 0x0000, uint16_t proto = 0x22EB, bool add_seq = false) {
+static size_t addGRE(PacketBuilder &pb, uint16_t flags_ver = 0x0000, uint16_t proto = 0x22EB,
+                     bool add_seq = false)
+{
     pb.push16(flags_ver);
     pb.push16(proto);
     if (add_seq) {
@@ -124,7 +162,8 @@ static size_t addGRE(PacketBuilder &pb, uint16_t flags_ver = 0x0000, uint16_t pr
 
 // Add ERSPAN III header (12 bytes). ver=2 in top nibble of word0.
 // Returns offset after ERSPAN.
-static size_t addERSPANIII(PacketBuilder &pb, bool o_bit = false) {
+static size_t addERSPANIII(PacketBuilder &pb, bool o_bit = false)
+{
     // Word 0: ver(4) | vlan(12) | cos(3) | bso(2) | t(1) | session_id(10)
     // ver=2 => top nibble = 0x2
     uint32_t word0 = 0x20000000; // ver=2, rest zero
@@ -133,7 +172,8 @@ static size_t addERSPANIII(PacketBuilder &pb, bool o_bit = false) {
     pb.push32(0x12345678);
     // Word 2: sgt(16) | p(1) | ft(5) | hw_id(6) | d(1) | gra(2) | o(1)
     uint32_t word2 = 0;
-    if (o_bit) word2 |= 0x00000001; // O bit is LSB
+    if (o_bit)
+        word2 |= 0x00000001; // O bit is LSB
     pb.push32(word2);
     if (o_bit) {
         // 8-byte platform specific sub-header
@@ -144,17 +184,19 @@ static size_t addERSPANIII(PacketBuilder &pb, bool o_bit = false) {
 }
 
 // Inner Ethernet + IPv4 + TCP (full)
-static size_t addInnerEthIPv4TCP(PacketBuilder &pb, size_t *inner_start_out = nullptr) {
-    if (inner_start_out) *inner_start_out = pb.size();
+static size_t addInnerEthIPv4TCP(PacketBuilder &pb, size_t *inner_start_out = nullptr)
+{
+    if (inner_start_out)
+        *inner_start_out = pb.size();
     // Inner Ethernet
-    uint8_t idst[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
-    uint8_t isrc[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+    uint8_t idst[6] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+    uint8_t isrc[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
     pb.pushN(idst, 6);
     pb.pushN(isrc, 6);
     pb.push16(0x0800);
 
     // Inner IPv4
-    (void)pb.size(); /* inner IPv4 offset — not needed here */
+    (void) pb.size(); /* inner IPv4 offset — not needed here */
     pb.push8(0x45);
     pb.push8(0x00);
     uint16_t inner_ip_total = 20 + 20; // IPv4 + TCP
@@ -162,32 +204,34 @@ static size_t addInnerEthIPv4TCP(PacketBuilder &pb, size_t *inner_start_out = nu
     pb.push16(0); // id
     pb.push16(0x4000);
     pb.push8(64);
-    pb.push8(6); // TCP
+    pb.push8(6);  // TCP
     pb.push16(0); // checksum
-    uint8_t isrcip[4] = {192,168,1,1};
-    uint8_t idstip[4] = {192,168,1,2};
+    uint8_t isrcip[4] = {192, 168, 1, 1};
+    uint8_t idstip[4] = {192, 168, 1, 2};
     pb.pushN(isrcip, 4);
     pb.pushN(idstip, 4);
 
     // TCP header (20 bytes min)
-    pb.push16(12345); // src port
-    pb.push16(80);    // dst port
+    pb.push16(12345);      // src port
+    pb.push16(80);         // dst port
     pb.push32(0xAABBCCDD); // seq
     pb.push32(0x11223344); // ack
-    pb.push8(0x50); // data offset = 5 (20 bytes), reserved
-    pb.push8(0x12); // flags: SYN+ACK
-    pb.push16(65535); // window
-    pb.push16(0); // checksum
-    pb.push16(0); // urgent
+    pb.push8(0x50);        // data offset = 5 (20 bytes), reserved
+    pb.push8(0x12);        // flags: SYN+ACK
+    pb.push16(65535);      // window
+    pb.push16(0);          // checksum
+    pb.push16(0);          // urgent
 
     return pb.size();
 }
 
 // Inner Ethernet + IPv4 + UDP
-static size_t addInnerEthIPv4UDP(PacketBuilder &pb, size_t *inner_start_out = nullptr) {
-    if (inner_start_out) *inner_start_out = pb.size();
-    uint8_t idst[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
-    uint8_t isrc[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+static size_t addInnerEthIPv4UDP(PacketBuilder &pb, size_t *inner_start_out = nullptr)
+{
+    if (inner_start_out)
+        *inner_start_out = pb.size();
+    uint8_t idst[6] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+    uint8_t isrc[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
     pb.pushN(idst, 6);
     pb.pushN(isrc, 6);
     pb.push16(0x0800);
@@ -200,23 +244,25 @@ static size_t addInnerEthIPv4UDP(PacketBuilder &pb, size_t *inner_start_out = nu
     pb.push8(64);
     pb.push8(17); // UDP
     pb.push16(0);
-    uint8_t isrcip[4] = {192,168,1,1};
-    uint8_t idstip[4] = {192,168,1,2};
+    uint8_t isrcip[4] = {192, 168, 1, 1};
+    uint8_t idstip[4] = {192, 168, 1, 2};
     pb.pushN(isrcip, 4);
     pb.pushN(idstip, 4);
 
-    pb.push16(5353);  // src port
-    pb.push16(53);    // dst port
-    pb.push16(8);     // length
-    pb.push16(0);     // checksum
+    pb.push16(5353); // src port
+    pb.push16(53);   // dst port
+    pb.push16(8);    // length
+    pb.push16(0);    // checksum
     return pb.size();
 }
 
 // Inner Ethernet + IPv4 + ICMP (non-TCP/UDP)
-static size_t addInnerEthIPv4ICMP(PacketBuilder &pb, size_t *inner_start_out = nullptr) {
-    if (inner_start_out) *inner_start_out = pb.size();
-    uint8_t idst[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
-    uint8_t isrc[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+static size_t addInnerEthIPv4ICMP(PacketBuilder &pb, size_t *inner_start_out = nullptr)
+{
+    if (inner_start_out)
+        *inner_start_out = pb.size();
+    uint8_t idst[6] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+    uint8_t isrc[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
     pb.pushN(idst, 6);
     pb.pushN(isrc, 6);
     pb.push16(0x0800);
@@ -229,30 +275,37 @@ static size_t addInnerEthIPv4ICMP(PacketBuilder &pb, size_t *inner_start_out = n
     pb.push8(64);
     pb.push8(1); // ICMP
     pb.push16(0);
-    uint8_t isrcip[4] = {192,168,1,1};
-    uint8_t idstip[4] = {192,168,1,2};
+    uint8_t isrcip[4] = {192, 168, 1, 1};
+    uint8_t idstip[4] = {192, 168, 1, 2};
     pb.pushN(isrcip, 4);
     pb.pushN(idstip, 4);
 
     // ICMP echo
-    pb.push8(8); pb.push8(0); pb.push16(0); pb.push16(1); pb.push16(1);
+    pb.push8(8);
+    pb.push8(0);
+    pb.push16(0);
+    pb.push16(1);
+    pb.push16(1);
     return pb.size();
 }
 
 // Finalize IPv4 total_length field
-static void fixupIPv4Length(PacketBuilder &pb, size_t ip_start) {
-    uint16_t total = (uint16_t)(pb.size() - ip_start);
+static void fixupIPv4Length(PacketBuilder &pb, size_t ip_start)
+{
+    uint16_t total = (uint16_t) (pb.size() - ip_start);
     pb.patch16(ip_start + 2, total);
 }
 
 // Finalize IPv6 payload_length
-static void fixupIPv6Length(PacketBuilder &pb, size_t ip_start) {
-    uint16_t payload = (uint16_t)(pb.size() - ip_start - 40);
+static void fixupIPv6Length(PacketBuilder &pb, size_t ip_start)
+{
+    uint16_t payload = (uint16_t) (pb.size() - ip_start - 40);
     pb.patch16(ip_start + 4, payload);
 }
 
 // Build a standard valid ERSPAN III over GRE over IPv4 with inner TCP
-static PacketBuilder buildValidPacketTCP() {
+static PacketBuilder buildValidPacketTCP()
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -268,13 +321,18 @@ static PacketBuilder buildValidPacketTCP() {
 // Tests
 // ---------------------------------------------------------------------------
 
-class ErspanParserTest : public ::testing::Test {
-protected:
+class ErspanParserTest : public ::testing::Test
+{
+  protected:
     infmon_parsed_packet_t out;
-    void SetUp() override { memset(&out, 0, sizeof(out)); }
+    void SetUp() override
+    {
+        memset(&out, 0, sizeof(out));
+    }
 };
 
-TEST_F(ErspanParserTest, ValidFullERSPANIII_IPv4_TCP) {
+TEST_F(ErspanParserTest, ValidFullERSPANIII_IPv4_TCP)
+{
     auto pb = buildValidPacketTCP();
     auto rc = infmon_parse_erspan(pb.data(), pb.size(), &out);
     EXPECT_EQ(rc, INFMON_PARSE_OK);
@@ -286,7 +344,8 @@ TEST_F(ErspanParserTest, ValidFullERSPANIII_IPv4_TCP) {
     EXPECT_FALSE(out.flow_key_partial);
 }
 
-TEST_F(ErspanParserTest, ValidGRESequenceBit) {
+TEST_F(ErspanParserTest, ValidGRESequenceBit)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -298,7 +357,8 @@ TEST_F(ErspanParserTest, ValidGRESequenceBit) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_OK);
 }
 
-TEST_F(ErspanParserTest, ValidOBitPlatformSubheader) {
+TEST_F(ErspanParserTest, ValidOBitPlatformSubheader)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -310,7 +370,8 @@ TEST_F(ErspanParserTest, ValidOBitPlatformSubheader) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_OK);
 }
 
-TEST_F(ErspanParserTest, ValidOverIPv6) {
+TEST_F(ErspanParserTest, ValidOverIPv6)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x86DD);
     size_t ip_start;
@@ -325,7 +386,8 @@ TEST_F(ErspanParserTest, ValidOverIPv6) {
     EXPECT_EQ(memcmp(out.mirror_src_ip.addr.v6, kSrcIPv6, 16), 0);
 }
 
-TEST_F(ErspanParserTest, TruncatedInnerPacket) {
+TEST_F(ErspanParserTest, TruncatedInnerPacket)
+{
     // Build full packet then truncate
     auto pb = buildValidPacketTCP();
     // Truncate: remove last 20 bytes (cut into TCP header)
@@ -334,7 +396,8 @@ TEST_F(ErspanParserTest, TruncatedInnerPacket) {
     EXPECT_TRUE(out.inner_truncated);
 }
 
-TEST_F(ErspanParserTest, OuterQinQ) {
+TEST_F(ErspanParserTest, OuterQinQ)
+{
     PacketBuilder pb;
     addOuterEthQinQ(pb);
     size_t ip_start;
@@ -343,17 +406,21 @@ TEST_F(ErspanParserTest, OuterQinQ) {
     addERSPANIII(pb);
     addInnerEthIPv4TCP(pb);
     fixupIPv4Length(pb, ip_start);
-    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out),
+              INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED);
 }
 
-TEST_F(ErspanParserTest, BadOuterEtherType) {
+TEST_F(ErspanParserTest, BadOuterEtherType)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0806); // ARP
-    pb.pushZeros(60); // some payload
-    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED);
+    pb.pushZeros(60);        // some payload
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out),
+              INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED);
 }
 
-TEST_F(ErspanParserTest, GREWithKFlag) {
+TEST_F(ErspanParserTest, GREWithKFlag)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -362,10 +429,12 @@ TEST_F(ErspanParserTest, GREWithKFlag) {
     addERSPANIII(pb);
     addInnerEthIPv4TCP(pb);
     fixupIPv4Length(pb, ip_start);
-    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out),
+              INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS);
 }
 
-TEST_F(ErspanParserTest, BadGREVersion) {
+TEST_F(ErspanParserTest, BadGREVersion)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -377,7 +446,8 @@ TEST_F(ErspanParserTest, BadGREVersion) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_GRE_BAD_VERSION);
 }
 
-TEST_F(ErspanParserTest, WrongGREProto) {
+TEST_F(ErspanParserTest, WrongGREProto)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -389,7 +459,8 @@ TEST_F(ErspanParserTest, WrongGREProto) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_GRE_BAD_PROTO);
 }
 
-TEST_F(ErspanParserTest, ERSPANBadVersion) {
+TEST_F(ErspanParserTest, ERSPANBadVersion)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -404,7 +475,8 @@ TEST_F(ErspanParserTest, ERSPANBadVersion) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_ERSPAN_BAD_VERSION);
 }
 
-TEST_F(ErspanParserTest, TruncatedOuterHeaders) {
+TEST_F(ErspanParserTest, TruncatedOuterHeaders)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     // Only partial IPv4 header (10 bytes instead of 20)
@@ -413,7 +485,8 @@ TEST_F(ErspanParserTest, TruncatedOuterHeaders) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_OUTER_TRUNCATED);
 }
 
-TEST_F(ErspanParserTest, TruncatedERSPANHeader) {
+TEST_F(ErspanParserTest, TruncatedERSPANHeader)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -426,7 +499,8 @@ TEST_F(ErspanParserTest, TruncatedERSPANHeader) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_ERSPAN_TRUNCATED);
 }
 
-TEST_F(ErspanParserTest, InnerEthernetTruncated) {
+TEST_F(ErspanParserTest, InnerEthernetTruncated)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -436,10 +510,12 @@ TEST_F(ErspanParserTest, InnerEthernetTruncated) {
     // Only 10 bytes of inner Ethernet (need 14)
     pb.pushZeros(10);
     fixupIPv4Length(pb, ip_start);
-    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_INNER_ETH_TRUNCATED);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out),
+              INFMON_PARSE_ERR_INNER_ETH_TRUNCATED);
 }
 
-TEST_F(ErspanParserTest, InnerL3Truncated) {
+TEST_F(ErspanParserTest, InnerL3Truncated)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -447,8 +523,8 @@ TEST_F(ErspanParserTest, InnerL3Truncated) {
     addGRE(pb);
     addERSPANIII(pb);
     // Inner Ethernet (14B) but only partial IPv4 (10 bytes)
-    uint8_t idst[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
-    uint8_t isrc[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+    uint8_t idst[6] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+    uint8_t isrc[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
     pb.pushN(idst, 6);
     pb.pushN(isrc, 6);
     pb.push16(0x0800);
@@ -458,7 +534,8 @@ TEST_F(ErspanParserTest, InnerL3Truncated) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_INNER_L3_TRUNCATED);
 }
 
-TEST_F(ErspanParserTest, MirrorSrcIPv4Extracted) {
+TEST_F(ErspanParserTest, MirrorSrcIPv4Extracted)
+{
     auto pb = buildValidPacketTCP();
     infmon_parse_erspan(pb.data(), pb.size(), &out);
     EXPECT_EQ(out.mirror_src_ip.family, INFMON_AF_V4);
@@ -468,7 +545,8 @@ TEST_F(ErspanParserTest, MirrorSrcIPv4Extracted) {
     EXPECT_EQ(out.mirror_src_ip.addr.v4[3], 1);
 }
 
-TEST_F(ErspanParserTest, MirrorSrcIPv6Extracted) {
+TEST_F(ErspanParserTest, MirrorSrcIPv6Extracted)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x86DD);
     size_t ip_start;
@@ -482,7 +560,8 @@ TEST_F(ErspanParserTest, MirrorSrcIPv6Extracted) {
     EXPECT_EQ(memcmp(out.mirror_src_ip.addr.v6, kSrcIPv6, 16), 0);
 }
 
-TEST_F(ErspanParserTest, InnerPtrPointsIntoOriginalBuffer) {
+TEST_F(ErspanParserTest, InnerPtrPointsIntoOriginalBuffer)
+{
     auto pb = buildValidPacketTCP();
     infmon_parse_erspan(pb.data(), pb.size(), &out);
     ASSERT_NE(out.inner_ptr, nullptr);
@@ -491,7 +570,8 @@ TEST_F(ErspanParserTest, InnerPtrPointsIntoOriginalBuffer) {
     EXPECT_LT(out.inner_ptr, pb.data() + pb.size());
 }
 
-TEST_F(ErspanParserTest, TCPPortExtraction) {
+TEST_F(ErspanParserTest, TCPPortExtraction)
+{
     auto pb = buildValidPacketTCP();
     infmon_parse_erspan(pb.data(), pb.size(), &out);
     EXPECT_EQ(out.src_port, 12345);
@@ -499,7 +579,8 @@ TEST_F(ErspanParserTest, TCPPortExtraction) {
     EXPECT_TRUE(out.valid_fields & INFMON_VALID_PORTS);
 }
 
-TEST_F(ErspanParserTest, UDPPortExtraction) {
+TEST_F(ErspanParserTest, UDPPortExtraction)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -516,7 +597,8 @@ TEST_F(ErspanParserTest, UDPPortExtraction) {
     EXPECT_EQ(out.inner_ip_proto, 17);
 }
 
-TEST_F(ErspanParserTest, TCPFlagsSeqAckWindow) {
+TEST_F(ErspanParserTest, TCPFlagsSeqAckWindow)
+{
     auto pb = buildValidPacketTCP();
     infmon_parse_erspan(pb.data(), pb.size(), &out);
     EXPECT_TRUE(out.valid_fields & INFMON_VALID_TCP_FLAGS);
@@ -529,7 +611,8 @@ TEST_F(ErspanParserTest, TCPFlagsSeqAckWindow) {
     EXPECT_EQ(out.tcp_window, 65535);
 }
 
-TEST_F(ErspanParserTest, FlowKeyPartialForICMP) {
+TEST_F(ErspanParserTest, FlowKeyPartialForICMP)
+{
     PacketBuilder pb;
     addOuterEth(pb, 0x0800);
     size_t ip_start;
@@ -544,7 +627,8 @@ TEST_F(ErspanParserTest, FlowKeyPartialForICMP) {
     EXPECT_EQ(out.inner_ip_proto, 1);
 }
 
-TEST_F(ErspanParserTest, VLANTaggedOuterFrame) {
+TEST_F(ErspanParserTest, VLANTaggedOuterFrame)
+{
     PacketBuilder pb;
     addOuterEthVlan(pb, 100, 0x0800);
     size_t ip_start;
@@ -556,11 +640,14 @@ TEST_F(ErspanParserTest, VLANTaggedOuterFrame) {
     EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_OK);
 }
 
-TEST_F(ErspanParserTest, CounterNamesArray) {
+TEST_F(ErspanParserTest, CounterNamesArray)
+{
     // Verify the array has entries and is non-null
     ASSERT_NE(infmon_parse_counter_names, nullptr);
     for (int i = 0; i < INFMON_PARSE_ERR__COUNT; i++) {
-        EXPECT_NE(infmon_parse_counter_names[i], nullptr) << "Counter name at index " << i << " is null";
-        EXPECT_GT(strlen(infmon_parse_counter_names[i]), 0u) << "Counter name at index " << i << " is empty";
+        EXPECT_NE(infmon_parse_counter_names[i], nullptr)
+            << "Counter name at index " << i << " is null";
+        EXPECT_GT(strlen(infmon_parse_counter_names[i]), 0u)
+            << "Counter name at index " << i << " is empty";
     }
 }

--- a/src/backend/test/test_erspan_parser.cc
+++ b/src/backend/test/test_erspan_parser.cc
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: MIT
+// Comprehensive tests for the ERSPAN III parser.
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include <vector>
+#include <arpa/inet.h>
+
+extern "C" {
+#include "infmon/erspan_parser.h"
+}
+
+// ---------------------------------------------------------------------------
+// Helper: packet builder
+// ---------------------------------------------------------------------------
+class PacketBuilder {
+public:
+    std::vector<uint8_t> buf;
+
+    void push8(uint8_t v) { buf.push_back(v); }
+    void push16(uint16_t v) { buf.push_back(v >> 8); buf.push_back(v & 0xff); }
+    void push32(uint32_t v) {
+        buf.push_back((v >> 24) & 0xff);
+        buf.push_back((v >> 16) & 0xff);
+        buf.push_back((v >> 8) & 0xff);
+        buf.push_back(v & 0xff);
+    }
+    void pushN(const uint8_t *d, size_t n) { buf.insert(buf.end(), d, d + n); }
+    void pushZeros(size_t n) { buf.insert(buf.end(), n, 0); }
+
+    size_t size() const { return buf.size(); }
+    uint8_t *data() { return buf.data(); }
+    const uint8_t *data() const { return buf.data(); }
+
+    // Patch a big-endian 16-bit value at offset
+    void patch16(size_t off, uint16_t v) {
+        buf[off] = v >> 8; buf[off+1] = v & 0xff;
+    }
+    void patch8(size_t off, uint8_t v) { buf[off] = v; }
+};
+
+// Build outer Ethernet header. Returns offset after it.
+static size_t addOuterEth(PacketBuilder &pb, uint16_t ethertype) {
+    // dst mac
+    uint8_t dst[6] = {0x00,0x11,0x22,0x33,0x44,0x55};
+    uint8_t src[6] = {0x66,0x77,0x88,0x99,0xaa,0xbb};
+    pb.pushN(dst, 6);
+    pb.pushN(src, 6);
+    pb.push16(ethertype);
+    return pb.size();
+}
+
+// Add 802.1Q VLAN tag before the real ethertype. Call INSTEAD of addOuterEth.
+static size_t addOuterEthVlan(PacketBuilder &pb, uint16_t vlan_id, uint16_t inner_ethertype) {
+    uint8_t dst[6] = {0x00,0x11,0x22,0x33,0x44,0x55};
+    uint8_t src[6] = {0x66,0x77,0x88,0x99,0xaa,0xbb};
+    pb.pushN(dst, 6);
+    pb.pushN(src, 6);
+    pb.push16(0x8100); // TPID
+    pb.push16(vlan_id & 0x0fff);
+    pb.push16(inner_ethertype);
+    return pb.size();
+}
+
+// Add QinQ
+static size_t addOuterEthQinQ(PacketBuilder &pb) {
+    uint8_t dst[6] = {0x00,0x11,0x22,0x33,0x44,0x55};
+    uint8_t src[6] = {0x66,0x77,0x88,0x99,0xaa,0xbb};
+    pb.pushN(dst, 6);
+    pb.pushN(src, 6);
+    pb.push16(0x88a8); // outer TPID (QinQ)
+    pb.push16(100);
+    pb.push16(0x8100); // inner TPID
+    pb.push16(200);
+    pb.push16(0x0800);
+    return pb.size();
+}
+
+static const uint8_t kSrcIPv4[4] = {10,0,0,1};
+static const uint8_t kDstIPv4[4] = {10,0,0,2};
+
+// Add outer IPv4. Returns offset of start of IPv4.
+// Caller must patch total_length after building rest.
+static size_t addOuterIPv4(PacketBuilder &pb, size_t *ip_start_out) {
+    size_t ip_start = pb.size();
+    if (ip_start_out) *ip_start_out = ip_start;
+    pb.push8(0x45); // ver=4, ihl=5
+    pb.push8(0x00); // DSCP/ECN
+    pb.push16(0);   // total length - patch later
+    pb.push16(0);   // identification
+    pb.push16(0x4000); // flags=DF, frag=0
+    pb.push8(64);   // TTL
+    pb.push8(47);   // protocol = GRE
+    pb.push16(0);   // checksum
+    pb.pushN(kSrcIPv4, 4);
+    pb.pushN(kDstIPv4, 4);
+    return pb.size();
+}
+
+static const uint8_t kSrcIPv6[16] = {0x20,0x01,0x0d,0xb8, 0,0,0,0, 0,0,0,0, 0,0,0,1};
+static const uint8_t kDstIPv6[16] = {0x20,0x01,0x0d,0xb8, 0,0,0,0, 0,0,0,0, 0,0,0,2};
+
+static size_t addOuterIPv6(PacketBuilder &pb, size_t *ip_start_out) {
+    size_t ip_start = pb.size();
+    if (ip_start_out) *ip_start_out = ip_start;
+    pb.push32(0x60000000); // ver=6, tc=0, flow=0
+    pb.push16(0);          // payload length - patch later
+    pb.push8(47);          // next header = GRE
+    pb.push8(64);          // hop limit
+    pb.pushN(kSrcIPv6, 16);
+    pb.pushN(kDstIPv6, 16);
+    return pb.size();
+}
+
+// Add GRE header. Returns offset after GRE.
+static size_t addGRE(PacketBuilder &pb, uint16_t flags_ver = 0x0000, uint16_t proto = 0x22EB, bool add_seq = false) {
+    pb.push16(flags_ver);
+    pb.push16(proto);
+    if (add_seq) {
+        pb.push32(0x00000042); // sequence number
+    }
+    return pb.size();
+}
+
+// Add ERSPAN III header (12 bytes). ver=2 in top nibble of word0.
+// Returns offset after ERSPAN.
+static size_t addERSPANIII(PacketBuilder &pb, bool o_bit = false) {
+    // Word 0: ver(4) | vlan(12) | cos(3) | bso(2) | t(1) | session_id(10)
+    // ver=2 => top nibble = 0x2
+    uint32_t word0 = 0x20000000; // ver=2, rest zero
+    pb.push32(word0);
+    // Word 1: timestamp
+    pb.push32(0x12345678);
+    // Word 2: sgt(16) | p(1) | ft(5) | hw_id(6) | d(1) | gra(2) | o(1)
+    uint32_t word2 = 0;
+    if (o_bit) word2 |= 0x00000001; // O bit is LSB
+    pb.push32(word2);
+    if (o_bit) {
+        // 8-byte platform specific sub-header
+        pb.push32(0xDEADBEEF);
+        pb.push32(0xCAFEBABE);
+    }
+    return pb.size();
+}
+
+// Inner Ethernet + IPv4 + TCP (full)
+static size_t addInnerEthIPv4TCP(PacketBuilder &pb, size_t *inner_start_out = nullptr) {
+    if (inner_start_out) *inner_start_out = pb.size();
+    // Inner Ethernet
+    uint8_t idst[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
+    uint8_t isrc[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+    pb.pushN(idst, 6);
+    pb.pushN(isrc, 6);
+    pb.push16(0x0800);
+
+    // Inner IPv4
+    (void)pb.size(); /* inner IPv4 offset — not needed here */
+    pb.push8(0x45);
+    pb.push8(0x00);
+    uint16_t inner_ip_total = 20 + 20; // IPv4 + TCP
+    pb.push16(inner_ip_total);
+    pb.push16(0); // id
+    pb.push16(0x4000);
+    pb.push8(64);
+    pb.push8(6); // TCP
+    pb.push16(0); // checksum
+    uint8_t isrcip[4] = {192,168,1,1};
+    uint8_t idstip[4] = {192,168,1,2};
+    pb.pushN(isrcip, 4);
+    pb.pushN(idstip, 4);
+
+    // TCP header (20 bytes min)
+    pb.push16(12345); // src port
+    pb.push16(80);    // dst port
+    pb.push32(0xAABBCCDD); // seq
+    pb.push32(0x11223344); // ack
+    pb.push8(0x50); // data offset = 5 (20 bytes), reserved
+    pb.push8(0x12); // flags: SYN+ACK
+    pb.push16(65535); // window
+    pb.push16(0); // checksum
+    pb.push16(0); // urgent
+
+    return pb.size();
+}
+
+// Inner Ethernet + IPv4 + UDP
+static size_t addInnerEthIPv4UDP(PacketBuilder &pb, size_t *inner_start_out = nullptr) {
+    if (inner_start_out) *inner_start_out = pb.size();
+    uint8_t idst[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
+    uint8_t isrc[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+    pb.pushN(idst, 6);
+    pb.pushN(isrc, 6);
+    pb.push16(0x0800);
+
+    pb.push8(0x45);
+    pb.push8(0x00);
+    pb.push16(20 + 8); // IPv4 + UDP
+    pb.push16(0);
+    pb.push16(0x4000);
+    pb.push8(64);
+    pb.push8(17); // UDP
+    pb.push16(0);
+    uint8_t isrcip[4] = {192,168,1,1};
+    uint8_t idstip[4] = {192,168,1,2};
+    pb.pushN(isrcip, 4);
+    pb.pushN(idstip, 4);
+
+    pb.push16(5353);  // src port
+    pb.push16(53);    // dst port
+    pb.push16(8);     // length
+    pb.push16(0);     // checksum
+    return pb.size();
+}
+
+// Inner Ethernet + IPv4 + ICMP (non-TCP/UDP)
+static size_t addInnerEthIPv4ICMP(PacketBuilder &pb, size_t *inner_start_out = nullptr) {
+    if (inner_start_out) *inner_start_out = pb.size();
+    uint8_t idst[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
+    uint8_t isrc[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+    pb.pushN(idst, 6);
+    pb.pushN(isrc, 6);
+    pb.push16(0x0800);
+
+    pb.push8(0x45);
+    pb.push8(0x00);
+    pb.push16(20 + 8); // IPv4 + 8 bytes ICMP
+    pb.push16(0);
+    pb.push16(0x4000);
+    pb.push8(64);
+    pb.push8(1); // ICMP
+    pb.push16(0);
+    uint8_t isrcip[4] = {192,168,1,1};
+    uint8_t idstip[4] = {192,168,1,2};
+    pb.pushN(isrcip, 4);
+    pb.pushN(idstip, 4);
+
+    // ICMP echo
+    pb.push8(8); pb.push8(0); pb.push16(0); pb.push16(1); pb.push16(1);
+    return pb.size();
+}
+
+// Finalize IPv4 total_length field
+static void fixupIPv4Length(PacketBuilder &pb, size_t ip_start) {
+    uint16_t total = (uint16_t)(pb.size() - ip_start);
+    pb.patch16(ip_start + 2, total);
+}
+
+// Finalize IPv6 payload_length
+static void fixupIPv6Length(PacketBuilder &pb, size_t ip_start) {
+    uint16_t payload = (uint16_t)(pb.size() - ip_start - 40);
+    pb.patch16(ip_start + 4, payload);
+}
+
+// Build a standard valid ERSPAN III over GRE over IPv4 with inner TCP
+static PacketBuilder buildValidPacketTCP() {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    return pb;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+class ErspanParserTest : public ::testing::Test {
+protected:
+    infmon_parsed_packet_t out;
+    void SetUp() override { memset(&out, 0, sizeof(out)); }
+};
+
+TEST_F(ErspanParserTest, ValidFullERSPANIII_IPv4_TCP) {
+    auto pb = buildValidPacketTCP();
+    auto rc = infmon_parse_erspan(pb.data(), pb.size(), &out);
+    EXPECT_EQ(rc, INFMON_PARSE_OK);
+    EXPECT_FALSE(out.inner_truncated);
+    EXPECT_EQ(out.mirror_src_ip.family, INFMON_AF_V4);
+    EXPECT_EQ(memcmp(out.mirror_src_ip.addr.v4, kSrcIPv4, 4), 0);
+    EXPECT_EQ(out.inner_ip_proto, 6);
+    EXPECT_EQ(out.inner_af, INFMON_AF_V4);
+    EXPECT_FALSE(out.flow_key_partial);
+}
+
+TEST_F(ErspanParserTest, ValidGRESequenceBit) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb, 0x1000, 0x22EB, true); // S flag + seq
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_OK);
+}
+
+TEST_F(ErspanParserTest, ValidOBitPlatformSubheader) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb, true); // O=1, adds 8B sub-header
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_OK);
+}
+
+TEST_F(ErspanParserTest, ValidOverIPv6) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x86DD);
+    size_t ip_start;
+    addOuterIPv6(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv6Length(pb, ip_start);
+    auto rc = infmon_parse_erspan(pb.data(), pb.size(), &out);
+    EXPECT_EQ(rc, INFMON_PARSE_OK);
+    EXPECT_EQ(out.mirror_src_ip.family, INFMON_AF_V6);
+    EXPECT_EQ(memcmp(out.mirror_src_ip.addr.v6, kSrcIPv6, 16), 0);
+}
+
+TEST_F(ErspanParserTest, TruncatedInnerPacket) {
+    // Build full packet then truncate
+    auto pb = buildValidPacketTCP();
+    // Truncate: remove last 20 bytes (cut into TCP header)
+    size_t truncated_len = pb.size() - 20;
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), truncated_len, &out), INFMON_PARSE_INNER_TRUNCATED_OK);
+    EXPECT_TRUE(out.inner_truncated);
+}
+
+TEST_F(ErspanParserTest, OuterQinQ) {
+    PacketBuilder pb;
+    addOuterEthQinQ(pb);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_OUTER_QINQ_UNSUPPORTED);
+}
+
+TEST_F(ErspanParserTest, BadOuterEtherType) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0806); // ARP
+    pb.pushZeros(60); // some payload
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_OUTER_ETHERTYPE_UNSUPPORTED);
+}
+
+TEST_F(ErspanParserTest, GREWithKFlag) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb, 0x2000, 0x22EB); // K flag set (bit 13)
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_GRE_UNEXPECTED_FLAGS);
+}
+
+TEST_F(ErspanParserTest, BadGREVersion) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb, 0x0001, 0x22EB); // version=1
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_GRE_BAD_VERSION);
+}
+
+TEST_F(ErspanParserTest, WrongGREProto) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb, 0x0000, 0x0800); // proto=IPv4 instead of ERSPAN
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_GRE_BAD_PROTO);
+}
+
+TEST_F(ErspanParserTest, ERSPANBadVersion) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    // Manually build ERSPAN with ver=1 (top nibble = 0x1)
+    pb.push32(0x10000000); // ver=1
+    pb.push32(0x12345678);
+    pb.push32(0x00000000);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_ERSPAN_BAD_VERSION);
+}
+
+TEST_F(ErspanParserTest, TruncatedOuterHeaders) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    // Only partial IPv4 header (10 bytes instead of 20)
+    pb.push8(0x45);
+    pb.pushZeros(9);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_OUTER_TRUNCATED);
+}
+
+TEST_F(ErspanParserTest, TruncatedERSPANHeader) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    // Only 8 bytes of ERSPAN instead of 12
+    pb.push32(0x20000000);
+    pb.push32(0x12345678);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_ERSPAN_TRUNCATED);
+}
+
+TEST_F(ErspanParserTest, InnerEthernetTruncated) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    // Only 10 bytes of inner Ethernet (need 14)
+    pb.pushZeros(10);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_INNER_ETH_TRUNCATED);
+}
+
+TEST_F(ErspanParserTest, InnerL3Truncated) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    // Inner Ethernet (14B) but only partial IPv4 (10 bytes)
+    uint8_t idst[6] = {0xaa,0xbb,0xcc,0xdd,0xee,0xff};
+    uint8_t isrc[6] = {0x11,0x22,0x33,0x44,0x55,0x66};
+    pb.pushN(idst, 6);
+    pb.pushN(isrc, 6);
+    pb.push16(0x0800);
+    pb.push8(0x45);
+    pb.pushZeros(9); // only 10 bytes of IPv4
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_ERR_INNER_L3_TRUNCATED);
+}
+
+TEST_F(ErspanParserTest, MirrorSrcIPv4Extracted) {
+    auto pb = buildValidPacketTCP();
+    infmon_parse_erspan(pb.data(), pb.size(), &out);
+    EXPECT_EQ(out.mirror_src_ip.family, INFMON_AF_V4);
+    EXPECT_EQ(out.mirror_src_ip.addr.v4[0], 10);
+    EXPECT_EQ(out.mirror_src_ip.addr.v4[1], 0);
+    EXPECT_EQ(out.mirror_src_ip.addr.v4[2], 0);
+    EXPECT_EQ(out.mirror_src_ip.addr.v4[3], 1);
+}
+
+TEST_F(ErspanParserTest, MirrorSrcIPv6Extracted) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x86DD);
+    size_t ip_start;
+    addOuterIPv6(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv6Length(pb, ip_start);
+    infmon_parse_erspan(pb.data(), pb.size(), &out);
+    EXPECT_EQ(out.mirror_src_ip.family, INFMON_AF_V6);
+    EXPECT_EQ(memcmp(out.mirror_src_ip.addr.v6, kSrcIPv6, 16), 0);
+}
+
+TEST_F(ErspanParserTest, InnerPtrPointsIntoOriginalBuffer) {
+    auto pb = buildValidPacketTCP();
+    infmon_parse_erspan(pb.data(), pb.size(), &out);
+    ASSERT_NE(out.inner_ptr, nullptr);
+    // inner_ptr should point within the original buffer
+    EXPECT_GE(out.inner_ptr, pb.data());
+    EXPECT_LT(out.inner_ptr, pb.data() + pb.size());
+}
+
+TEST_F(ErspanParserTest, TCPPortExtraction) {
+    auto pb = buildValidPacketTCP();
+    infmon_parse_erspan(pb.data(), pb.size(), &out);
+    EXPECT_EQ(out.src_port, 12345);
+    EXPECT_EQ(out.dst_port, 80);
+    EXPECT_TRUE(out.valid_fields & INFMON_VALID_PORTS);
+}
+
+TEST_F(ErspanParserTest, UDPPortExtraction) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    addInnerEthIPv4UDP(pb);
+    fixupIPv4Length(pb, ip_start);
+    auto rc = infmon_parse_erspan(pb.data(), pb.size(), &out);
+    EXPECT_EQ(rc, INFMON_PARSE_OK);
+    EXPECT_EQ(out.src_port, 5353);
+    EXPECT_EQ(out.dst_port, 53);
+    EXPECT_TRUE(out.valid_fields & INFMON_VALID_PORTS);
+    EXPECT_EQ(out.inner_ip_proto, 17);
+}
+
+TEST_F(ErspanParserTest, TCPFlagsSeqAckWindow) {
+    auto pb = buildValidPacketTCP();
+    infmon_parse_erspan(pb.data(), pb.size(), &out);
+    EXPECT_TRUE(out.valid_fields & INFMON_VALID_TCP_FLAGS);
+    EXPECT_TRUE(out.valid_fields & INFMON_VALID_TCP_SEQ);
+    EXPECT_TRUE(out.valid_fields & INFMON_VALID_TCP_ACK);
+    EXPECT_TRUE(out.valid_fields & INFMON_VALID_TCP_WINDOW);
+    EXPECT_EQ(out.tcp_flags, 0x12); // SYN+ACK
+    EXPECT_EQ(out.tcp_seq, 0xAABBCCDD);
+    EXPECT_EQ(out.tcp_ack, 0x11223344);
+    EXPECT_EQ(out.tcp_window, 65535);
+}
+
+TEST_F(ErspanParserTest, FlowKeyPartialForICMP) {
+    PacketBuilder pb;
+    addOuterEth(pb, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    addInnerEthIPv4ICMP(pb);
+    fixupIPv4Length(pb, ip_start);
+    auto rc = infmon_parse_erspan(pb.data(), pb.size(), &out);
+    EXPECT_EQ(rc, INFMON_PARSE_OK);
+    EXPECT_TRUE(out.flow_key_partial);
+    EXPECT_EQ(out.inner_ip_proto, 1);
+}
+
+TEST_F(ErspanParserTest, VLANTaggedOuterFrame) {
+    PacketBuilder pb;
+    addOuterEthVlan(pb, 100, 0x0800);
+    size_t ip_start;
+    addOuterIPv4(pb, &ip_start);
+    addGRE(pb);
+    addERSPANIII(pb);
+    addInnerEthIPv4TCP(pb);
+    fixupIPv4Length(pb, ip_start);
+    EXPECT_EQ(infmon_parse_erspan(pb.data(), pb.size(), &out), INFMON_PARSE_OK);
+}
+
+TEST_F(ErspanParserTest, CounterNamesArray) {
+    // Verify the array has entries and is non-null
+    ASSERT_NE(infmon_parse_counter_names, nullptr);
+    for (int i = 0; i < INFMON_PARSE_ERR__COUNT; i++) {
+        EXPECT_NE(infmon_parse_counter_names[i], nullptr) << "Counter name at index " << i << " is null";
+        EXPECT_GT(strlen(infmon_parse_counter_names[i]), 0u) << "Counter name at index " << i << " is empty";
+    }
+}


### PR DESCRIPTION
## Summary

Implement the ERSPAN III over GRE parser as specified in [specs/003-erspan-and-packet-parsing.md](specs/003-erspan-and-packet-parsing.md).

### What's included

- **Parser library** (`libinfmon_parser.a`): Pure-function C parser with no allocations, no syscalls, no cross-packet state
- **Outer header skip**: Ethernet → optional single VLAN → IPv4/IPv6 → GRE (0x22EB) → ERSPAN III header (+ optional 8B Platform Sub-Header when O=1)
- **mirror_src_ip extraction**: Outer L3 source address extracted as tagged union (v4/v6) — the only outer-header value crossing the parser boundary
- **Inner packet view**: `inner_ptr` (zero-copy pointer into original buffer), `inner_len`, `inner_truncated`
- **Truncation handling** (~128B snap): Inner L2 required, inner L3 required, inner L4 best-effort with `valid_fields` bitmask (`PORTS_VALID`, `TCP_FLAGS_VALID`, `TCP_SEQ_VALID`, `TCP_ACK_VALID`, `TCP_WINDOW_VALID`)
- **Inner-decap hook seam** (§4.6): v1 = `INFMON_DECAP_NONE` (identity), reserved for future VXLAN/GENEVE/RoCEv2
- **14 error/drop counters** per spec §6 (all indexed by `infmon_parse_result_t`)
- **CMake build** producing static library + gtest binary
- **24 gtest unit tests** covering all parse paths, error conditions, field extraction, and counter names

### Spec compliance

All requirements from spec 003 §1–§6 are implemented. Test plan items from §8 (golden PCAPs, fuzzer) are tracked separately in #37.

Closes #36