### PR TITLE
feat: flow-rule data model - key layout, field encodings, validation

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -50,7 +50,6 @@ target_link_libraries(test_flow_rule PRIVATE infmon_flow_rule GTest::gtest GTest
 target_include_directories(test_flow_rule PRIVATE include)
 add_test(NAME flow_rule COMMAND test_flow_rule)
 
-# --- Fuzz target (clang only, requires -fsanitize=fuzzer) ---
 if(ENABLE_FUZZER)
     add_executable(fuzz_erspan_parser
         test/fuzz_erspan_parser.cc

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -37,6 +37,20 @@ add_test(NAME erspan_pcap COMMAND test_erspan_pcap)
 
 # --- Fuzz target (clang only, requires -fsanitize=fuzzer) ---
 option(ENABLE_FUZZER "Build libFuzzer targets (requires clang)" OFF)
+# --- Flow-rule data model library ---
+add_library(infmon_flow_rule STATIC
+    src/flow_rule.c
+)
+target_include_directories(infmon_flow_rule PUBLIC include)
+
+add_executable(test_flow_rule
+    test/test_flow_rule.cc
+)
+target_link_libraries(test_flow_rule PRIVATE infmon_flow_rule GTest::gtest GTest::gtest_main)
+target_include_directories(test_flow_rule PRIVATE include)
+add_test(NAME flow_rule COMMAND test_flow_rule)
+
+# --- Fuzz target (clang only, requires -fsanitize=fuzzer) ---
 if(ENABLE_FUZZER)
     add_executable(fuzz_erspan_parser
         test/fuzz_erspan_parser.cc

--- a/src/backend/include/infmon/flow_rule.h
+++ b/src/backend/include/infmon/flow_rule.h
@@ -42,6 +42,7 @@ typedef enum {
     INFMON_FLOW_RULE_ERR_NOT_FOUND,
     INFMON_FLOW_RULE_ERR_INVALID_SPEC,
     INFMON_FLOW_RULE_ERR_BUDGET_EXCEEDED,
+    INFMON_FLOW_RULE_ERR_SET_FULL,
     INFMON_FLOW_RULE_ERR_INTERNAL,
 } infmon_flow_rule_result_t;
 
@@ -61,11 +62,12 @@ typedef struct {
     uint32_t field_count;
     uint32_t max_keys;
     infmon_eviction_policy_t eviction_policy;
-    uint32_t key_width; /* computed, cached */
+    uint32_t key_width; /* computed by add(); only valid after infmon_flow_rule_add() */
 } infmon_flow_rule_t;
 
 /* ── Per-flow-rule metrics ───────────────────────────────────────── */
 
+/* Scaffolding for the metrics subsystem (next PR); not yet referenced by any API. */
 typedef struct {
     uint64_t flows;           /* gauge: current key count */
     uint64_t evictions_total; /* counter */
@@ -105,6 +107,12 @@ const infmon_flow_rule_t *infmon_flow_rule_get(const infmon_flow_rule_set_t *set
 
 /* ── Validation (single rule, no set constraints) ────────────────── */
 
+/**
+ * Validate a flow rule in isolation.
+ *
+ * Name constraints: 2-31 chars, pattern ^[a-z0-9][a-z0-9_-]+$.
+ * max_keys must be in [1, INFMON_FLOW_RULE_MAX_KEYS_BUDGET].
+ */
 infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *rule);
 
 /* ── Key encoding ────────────────────────────────────────────────── */

--- a/src/backend/include/infmon/flow_rule.h
+++ b/src/backend/include/infmon/flow_rule.h
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * Flow-rule data model — see specs/002-flow-tracking-model.md
+ */
+
+#ifndef INFMON_FLOW_RULE_H
+#define INFMON_FLOW_RULE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Field enum ──────────────────────────────────────────────────── */
+
+typedef enum {
+    INFMON_FIELD_SRC_IP = 0,
+    INFMON_FIELD_DST_IP,
+    INFMON_FIELD_IP_PROTO,
+    INFMON_FIELD_DSCP,
+    INFMON_FIELD_MIRROR_SRC_IP,
+    INFMON_FIELD__COUNT,
+} infmon_field_t;
+
+/* ── Eviction policy ─────────────────────────────────────────────── */
+
+typedef enum {
+    INFMON_EVICTION_LRU_DROP = 0,
+    INFMON_EVICTION__COUNT,
+} infmon_eviction_policy_t;
+
+/* ── CRUD error codes ────────────────────────────────────────────── */
+
+typedef enum {
+    INFMON_FLOW_RULE_OK = 0,
+    INFMON_FLOW_RULE_ERR_NAME_EXISTS,
+    INFMON_FLOW_RULE_ERR_NOT_FOUND,
+    INFMON_FLOW_RULE_ERR_INVALID_SPEC,
+    INFMON_FLOW_RULE_ERR_BUDGET_EXCEEDED,
+    INFMON_FLOW_RULE_ERR_INTERNAL,
+} infmon_flow_rule_result_t;
+
+/* ── Constants ───────────────────────────────────────────────────── */
+
+#define INFMON_FLOW_RULE_NAME_MAX 31
+#define INFMON_FLOW_RULE_KEY_MAX  64
+#define INFMON_FLOW_RULE_FIELDS_MAX INFMON_FIELD__COUNT
+#define INFMON_FLOW_RULE_MAX_KEYS_BUDGET (16u * 1024 * 1024) /* 16 Mi */
+#define INFMON_FLOW_RULE_SET_MAX 16
+
+/* ── Flow rule (immutable after creation) ────────────────────────── */
+
+typedef struct {
+    char                    name[INFMON_FLOW_RULE_NAME_MAX + 1];
+    infmon_field_t          fields[INFMON_FLOW_RULE_FIELDS_MAX];
+    uint32_t                field_count;
+    uint32_t                max_keys;
+    infmon_eviction_policy_t eviction_policy;
+    uint32_t                key_width; /* computed, cached */
+} infmon_flow_rule_t;
+
+/* ── Per-flow-rule metrics ───────────────────────────────────────── */
+
+typedef struct {
+    uint64_t flows;           /* gauge: current key count */
+    uint64_t evictions_total; /* counter */
+    uint64_t drops_total;     /* counter */
+    uint64_t packets_total;   /* counter */
+    uint64_t bytes_total;     /* counter */
+} infmon_flow_rule_metrics_t;
+
+/* ── Normalised flow fields (input to key encoder) ───────────────── */
+
+typedef struct {
+    uint8_t src_ip[16];        /* IPv4-mapped-IPv6, network byte order */
+    uint8_t dst_ip[16];        /* IPv4-mapped-IPv6, network byte order */
+    uint8_t mirror_src_ip[16]; /* IPv4-mapped-IPv6, network byte order */
+    uint8_t ip_proto;
+    uint8_t dscp;              /* 0..63, upper 2 bits zero */
+} infmon_flow_fields_t;
+
+/* ── Flow rule set (opaque) ──────────────────────────────────────── */
+
+typedef struct infmon_flow_rule_set infmon_flow_rule_set_t;
+
+/* ── Lifecycle ───────────────────────────────────────────────────── */
+
+infmon_flow_rule_set_t *infmon_flow_rule_set_create(uint32_t max_keys_budget);
+void                    infmon_flow_rule_set_destroy(infmon_flow_rule_set_t *set);
+
+/* ── CRUD ────────────────────────────────────────────────────────── */
+
+infmon_flow_rule_result_t infmon_flow_rule_add(infmon_flow_rule_set_t *set,
+                                               const infmon_flow_rule_t *rule);
+infmon_flow_rule_result_t infmon_flow_rule_rm(infmon_flow_rule_set_t *set,
+                                              const char *name);
+const infmon_flow_rule_t *infmon_flow_rule_find(const infmon_flow_rule_set_t *set,
+                                                const char *name);
+uint32_t                  infmon_flow_rule_count(const infmon_flow_rule_set_t *set);
+const infmon_flow_rule_t *infmon_flow_rule_get(const infmon_flow_rule_set_t *set,
+                                               uint32_t index);
+
+/* ── Validation (single rule, no set constraints) ────────────────── */
+
+infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *rule);
+
+/* ── Key encoding ────────────────────────────────────────────────── */
+
+uint32_t infmon_flow_rule_key_width(const infmon_field_t *fields,
+                                    uint32_t field_count);
+
+void infmon_flow_rule_encode_key(const infmon_flow_rule_t *rule,
+                                 const infmon_flow_fields_t *fields,
+                                 uint8_t *key_buf);
+
+/* ── Field / policy metadata ─────────────────────────────────────── */
+
+uint32_t    infmon_field_width(infmon_field_t field);
+const char *infmon_field_name(infmon_field_t field);
+bool        infmon_field_parse(const char *name, infmon_field_t *out);
+const char *infmon_eviction_policy_name(infmon_eviction_policy_t policy);
+bool        infmon_eviction_policy_parse(const char *name,
+                                         infmon_eviction_policy_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INFMON_FLOW_RULE_H */

--- a/src/backend/include/infmon/flow_rule.h
+++ b/src/backend/include/infmon/flow_rule.h
@@ -48,7 +48,7 @@ typedef enum {
 /* ── Constants ───────────────────────────────────────────────────── */
 
 #define INFMON_FLOW_RULE_NAME_MAX 31
-#define INFMON_FLOW_RULE_KEY_MAX  64
+#define INFMON_FLOW_RULE_KEY_MAX 64
 #define INFMON_FLOW_RULE_FIELDS_MAX INFMON_FIELD__COUNT
 #define INFMON_FLOW_RULE_MAX_KEYS_BUDGET (16u * 1024 * 1024) /* 16 Mi */
 #define INFMON_FLOW_RULE_SET_MAX 16
@@ -56,12 +56,12 @@ typedef enum {
 /* ── Flow rule (immutable after creation) ────────────────────────── */
 
 typedef struct {
-    char                    name[INFMON_FLOW_RULE_NAME_MAX + 1];
-    infmon_field_t          fields[INFMON_FLOW_RULE_FIELDS_MAX];
-    uint32_t                field_count;
-    uint32_t                max_keys;
+    char name[INFMON_FLOW_RULE_NAME_MAX + 1];
+    infmon_field_t fields[INFMON_FLOW_RULE_FIELDS_MAX];
+    uint32_t field_count;
+    uint32_t max_keys;
     infmon_eviction_policy_t eviction_policy;
-    uint32_t                key_width; /* computed, cached */
+    uint32_t key_width; /* computed, cached */
 } infmon_flow_rule_t;
 
 /* ── Per-flow-rule metrics ───────────────────────────────────────── */
@@ -81,7 +81,7 @@ typedef struct {
     uint8_t dst_ip[16];        /* IPv4-mapped-IPv6, network byte order */
     uint8_t mirror_src_ip[16]; /* IPv4-mapped-IPv6, network byte order */
     uint8_t ip_proto;
-    uint8_t dscp;              /* 0..63, upper 2 bits zero */
+    uint8_t dscp; /* 0..63, upper 2 bits zero */
 } infmon_flow_fields_t;
 
 /* ── Flow rule set (opaque) ──────────────────────────────────────── */
@@ -91,19 +91,17 @@ typedef struct infmon_flow_rule_set infmon_flow_rule_set_t;
 /* ── Lifecycle ───────────────────────────────────────────────────── */
 
 infmon_flow_rule_set_t *infmon_flow_rule_set_create(uint32_t max_keys_budget);
-void                    infmon_flow_rule_set_destroy(infmon_flow_rule_set_t *set);
+void infmon_flow_rule_set_destroy(infmon_flow_rule_set_t *set);
 
 /* ── CRUD ────────────────────────────────────────────────────────── */
 
 infmon_flow_rule_result_t infmon_flow_rule_add(infmon_flow_rule_set_t *set,
                                                const infmon_flow_rule_t *rule);
-infmon_flow_rule_result_t infmon_flow_rule_rm(infmon_flow_rule_set_t *set,
-                                              const char *name);
+infmon_flow_rule_result_t infmon_flow_rule_rm(infmon_flow_rule_set_t *set, const char *name);
 const infmon_flow_rule_t *infmon_flow_rule_find(const infmon_flow_rule_set_t *set,
                                                 const char *name);
-uint32_t                  infmon_flow_rule_count(const infmon_flow_rule_set_t *set);
-const infmon_flow_rule_t *infmon_flow_rule_get(const infmon_flow_rule_set_t *set,
-                                               uint32_t index);
+uint32_t infmon_flow_rule_count(const infmon_flow_rule_set_t *set);
+const infmon_flow_rule_t *infmon_flow_rule_get(const infmon_flow_rule_set_t *set, uint32_t index);
 
 /* ── Validation (single rule, no set constraints) ────────────────── */
 
@@ -111,21 +109,18 @@ infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *ru
 
 /* ── Key encoding ────────────────────────────────────────────────── */
 
-uint32_t infmon_flow_rule_key_width(const infmon_field_t *fields,
-                                    uint32_t field_count);
+uint32_t infmon_flow_rule_key_width(const infmon_field_t *fields, uint32_t field_count);
 
-void infmon_flow_rule_encode_key(const infmon_flow_rule_t *rule,
-                                 const infmon_flow_fields_t *fields,
+void infmon_flow_rule_encode_key(const infmon_flow_rule_t *rule, const infmon_flow_fields_t *fields,
                                  uint8_t *key_buf);
 
 /* ── Field / policy metadata ─────────────────────────────────────── */
 
-uint32_t    infmon_field_width(infmon_field_t field);
+uint32_t infmon_field_width(infmon_field_t field);
 const char *infmon_field_name(infmon_field_t field);
-bool        infmon_field_parse(const char *name, infmon_field_t *out);
+bool infmon_field_parse(const char *name, infmon_field_t *out);
 const char *infmon_eviction_policy_name(infmon_eviction_policy_t policy);
-bool        infmon_eviction_policy_parse(const char *name,
-                                         infmon_eviction_policy_t *out);
+bool infmon_eviction_policy_parse(const char *name, infmon_eviction_policy_t *out);
 
 #ifdef __cplusplus
 }

--- a/src/backend/include/infmon/flow_rule.h
+++ b/src/backend/include/infmon/flow_rule.h
@@ -96,6 +96,8 @@ infmon_flow_rule_set_t *infmon_flow_rule_set_create(uint32_t max_keys_budget);
 void infmon_flow_rule_set_destroy(infmon_flow_rule_set_t *set);
 
 /* ── CRUD ────────────────────────────────────────────────────────── */
+/* NOTE: Pointers returned by find()/get() point into the internal array
+ * and are invalidated by any subsequent add() or rm() call. */
 
 infmon_flow_rule_result_t infmon_flow_rule_add(infmon_flow_rule_set_t *set,
                                                const infmon_flow_rule_t *rule);

--- a/src/backend/src/flow_rule.c
+++ b/src/backend/src/flow_rule.c
@@ -11,18 +11,15 @@
 /* ── Field metadata tables ───────────────────────────────────────── */
 
 static const uint32_t field_widths[INFMON_FIELD__COUNT] = {
-    [INFMON_FIELD_SRC_IP]        = 16,
-    [INFMON_FIELD_DST_IP]        = 16,
-    [INFMON_FIELD_IP_PROTO]      = 1,
-    [INFMON_FIELD_DSCP]          = 1,
-    [INFMON_FIELD_MIRROR_SRC_IP] = 16,
+    [INFMON_FIELD_SRC_IP] = 16, [INFMON_FIELD_DST_IP] = 16,        [INFMON_FIELD_IP_PROTO] = 1,
+    [INFMON_FIELD_DSCP] = 1,    [INFMON_FIELD_MIRROR_SRC_IP] = 16,
 };
 
 static const char *field_names[INFMON_FIELD__COUNT] = {
-    [INFMON_FIELD_SRC_IP]        = "src_ip",
-    [INFMON_FIELD_DST_IP]        = "dst_ip",
-    [INFMON_FIELD_IP_PROTO]      = "ip_proto",
-    [INFMON_FIELD_DSCP]          = "dscp",
+    [INFMON_FIELD_SRC_IP] = "src_ip",
+    [INFMON_FIELD_DST_IP] = "dst_ip",
+    [INFMON_FIELD_IP_PROTO] = "ip_proto",
+    [INFMON_FIELD_DSCP] = "dscp",
     [INFMON_FIELD_MIRROR_SRC_IP] = "mirror_src_ip",
 };
 
@@ -30,37 +27,49 @@ static const char *eviction_names[INFMON_EVICTION__COUNT] = {
     [INFMON_EVICTION_LRU_DROP] = "lru_drop",
 };
 
-uint32_t infmon_field_width(infmon_field_t field) {
-    if ((unsigned)field >= INFMON_FIELD__COUNT) return 0;
+uint32_t infmon_field_width(infmon_field_t field)
+{
+    if ((unsigned) field >= INFMON_FIELD__COUNT)
+        return 0;
     return field_widths[field];
 }
 
-const char *infmon_field_name(infmon_field_t field) {
-    if ((unsigned)field >= INFMON_FIELD__COUNT) return NULL;
+const char *infmon_field_name(infmon_field_t field)
+{
+    if ((unsigned) field >= INFMON_FIELD__COUNT)
+        return NULL;
     return field_names[field];
 }
 
-bool infmon_field_parse(const char *name, infmon_field_t *out) {
-    if (!name) return false;
+bool infmon_field_parse(const char *name, infmon_field_t *out)
+{
+    if (!name)
+        return false;
     for (int i = 0; i < INFMON_FIELD__COUNT; i++) {
         if (strcmp(name, field_names[i]) == 0) {
-            if (out) *out = (infmon_field_t)i;
+            if (out)
+                *out = (infmon_field_t) i;
             return true;
         }
     }
     return false;
 }
 
-const char *infmon_eviction_policy_name(infmon_eviction_policy_t policy) {
-    if ((unsigned)policy >= INFMON_EVICTION__COUNT) return NULL;
+const char *infmon_eviction_policy_name(infmon_eviction_policy_t policy)
+{
+    if ((unsigned) policy >= INFMON_EVICTION__COUNT)
+        return NULL;
     return eviction_names[policy];
 }
 
-bool infmon_eviction_policy_parse(const char *name, infmon_eviction_policy_t *out) {
-    if (!name) return false;
+bool infmon_eviction_policy_parse(const char *name, infmon_eviction_policy_t *out)
+{
+    if (!name)
+        return false;
     for (int i = 0; i < INFMON_EVICTION__COUNT; i++) {
         if (strcmp(name, eviction_names[i]) == 0) {
-            if (out) *out = (infmon_eviction_policy_t)i;
+            if (out)
+                *out = (infmon_eviction_policy_t) i;
             return true;
         }
     }
@@ -69,19 +78,22 @@ bool infmon_eviction_policy_parse(const char *name, infmon_eviction_policy_t *ou
 
 /* ── Name validation: ^[a-z0-9][a-z0-9_-]{1,30}$ ────────────────── */
 
-static bool name_valid(const char *name) {
-    if (!name) return false;
+static bool name_valid(const char *name)
+{
+    if (!name)
+        return false;
     size_t len = strlen(name);
-    if (len < 2 || len > INFMON_FLOW_RULE_NAME_MAX) return false;
+    if (len < 2 || len > INFMON_FLOW_RULE_NAME_MAX)
+        return false;
 
     /* First char: [a-z0-9] */
     char c = name[0];
-    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))) return false;
+    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')))
+        return false;
 
     for (size_t i = 1; i < len; i++) {
         c = name[i];
-        if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-              c == '_' || c == '-'))
+        if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '-'))
             return false;
     }
     return true;
@@ -89,12 +101,13 @@ static bool name_valid(const char *name) {
 
 /* ── Key width ───────────────────────────────────────────────────── */
 
-uint32_t infmon_flow_rule_key_width(const infmon_field_t *fields,
-                                    uint32_t field_count) {
+uint32_t infmon_flow_rule_key_width(const infmon_field_t *fields, uint32_t field_count)
+{
     uint32_t w = 0;
     for (uint32_t i = 0; i < field_count; i++) {
         uint32_t fw = infmon_field_width(fields[i]);
-        if (fw == 0) return 0;
+        if (fw == 0)
+            return 0;
         w += fw;
     }
     return w;
@@ -102,8 +115,10 @@ uint32_t infmon_flow_rule_key_width(const infmon_field_t *fields,
 
 /* ── Validation (single rule) ────────────────────────────────────── */
 
-infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *rule) {
-    if (!rule) return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *rule)
+{
+    if (!rule)
+        return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
 
     if (!name_valid(rule->name))
         return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
@@ -114,7 +129,7 @@ infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *ru
     /* Check unknown fields and duplicates */
     bool seen[INFMON_FIELD__COUNT] = {false};
     for (uint32_t i = 0; i < rule->field_count; i++) {
-        if ((unsigned)rule->fields[i] >= INFMON_FIELD__COUNT)
+        if ((unsigned) rule->fields[i] >= INFMON_FIELD__COUNT)
             return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
         if (seen[rule->fields[i]])
             return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
@@ -124,7 +139,7 @@ infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *ru
     if (rule->max_keys == 0)
         return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
 
-    if ((unsigned)rule->eviction_policy >= INFMON_EVICTION__COUNT)
+    if ((unsigned) rule->eviction_policy >= INFMON_EVICTION__COUNT)
         return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
 
     uint32_t kw = infmon_flow_rule_key_width(rule->fields, rule->field_count);
@@ -136,9 +151,9 @@ infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *ru
 
 /* ── Key encoding ────────────────────────────────────────────────── */
 
-void infmon_flow_rule_encode_key(const infmon_flow_rule_t *rule,
-                                 const infmon_flow_fields_t *fields,
-                                 uint8_t *key_buf) {
+void infmon_flow_rule_encode_key(const infmon_flow_rule_t *rule, const infmon_flow_fields_t *fields,
+                                 uint8_t *key_buf)
+{
     uint32_t off = 0;
     for (uint32_t i = 0; i < rule->field_count; i++) {
         switch (rule->fields[i]) {
@@ -175,24 +190,29 @@ struct infmon_flow_rule_set {
     uint32_t used_keys;
 };
 
-infmon_flow_rule_set_t *infmon_flow_rule_set_create(uint32_t max_keys_budget) {
+infmon_flow_rule_set_t *infmon_flow_rule_set_create(uint32_t max_keys_budget)
+{
     infmon_flow_rule_set_t *s = calloc(1, sizeof(*s));
-    if (!s) return NULL;
+    if (!s)
+        return NULL;
     s->max_keys_budget = max_keys_budget;
     return s;
 }
 
-void infmon_flow_rule_set_destroy(infmon_flow_rule_set_t *set) {
+void infmon_flow_rule_set_destroy(infmon_flow_rule_set_t *set)
+{
     free(set);
 }
 
-uint32_t infmon_flow_rule_count(const infmon_flow_rule_set_t *set) {
+uint32_t infmon_flow_rule_count(const infmon_flow_rule_set_t *set)
+{
     return set ? set->count : 0;
 }
 
-const infmon_flow_rule_t *infmon_flow_rule_find(const infmon_flow_rule_set_t *set,
-                                                const char *name) {
-    if (!set || !name) return NULL;
+const infmon_flow_rule_t *infmon_flow_rule_find(const infmon_flow_rule_set_t *set, const char *name)
+{
+    if (!set || !name)
+        return NULL;
     for (uint32_t i = 0; i < set->count; i++) {
         if (strcmp(set->rules[i].name, name) == 0)
             return &set->rules[i];
@@ -200,18 +220,22 @@ const infmon_flow_rule_t *infmon_flow_rule_find(const infmon_flow_rule_set_t *se
     return NULL;
 }
 
-const infmon_flow_rule_t *infmon_flow_rule_get(const infmon_flow_rule_set_t *set,
-                                               uint32_t index) {
-    if (!set || index >= set->count) return NULL;
+const infmon_flow_rule_t *infmon_flow_rule_get(const infmon_flow_rule_set_t *set, uint32_t index)
+{
+    if (!set || index >= set->count)
+        return NULL;
     return &set->rules[index];
 }
 
 infmon_flow_rule_result_t infmon_flow_rule_add(infmon_flow_rule_set_t *set,
-                                               const infmon_flow_rule_t *rule) {
-    if (!set || !rule) return INFMON_FLOW_RULE_ERR_INTERNAL;
+                                               const infmon_flow_rule_t *rule)
+{
+    if (!set || !rule)
+        return INFMON_FLOW_RULE_ERR_INTERNAL;
 
     infmon_flow_rule_result_t rc = infmon_flow_rule_validate(rule);
-    if (rc != INFMON_FLOW_RULE_OK) return rc;
+    if (rc != INFMON_FLOW_RULE_OK)
+        return rc;
 
     if (set->count >= INFMON_FLOW_RULE_SET_MAX)
         return INFMON_FLOW_RULE_ERR_INTERNAL;
@@ -230,9 +254,10 @@ infmon_flow_rule_result_t infmon_flow_rule_add(infmon_flow_rule_set_t *set,
     return INFMON_FLOW_RULE_OK;
 }
 
-infmon_flow_rule_result_t infmon_flow_rule_rm(infmon_flow_rule_set_t *set,
-                                              const char *name) {
-    if (!set || !name) return INFMON_FLOW_RULE_ERR_INTERNAL;
+infmon_flow_rule_result_t infmon_flow_rule_rm(infmon_flow_rule_set_t *set, const char *name)
+{
+    if (!set || !name)
+        return INFMON_FLOW_RULE_ERR_INTERNAL;
 
     for (uint32_t i = 0; i < set->count; i++) {
         if (strcmp(set->rules[i].name, name) == 0) {

--- a/src/backend/src/flow_rule.c
+++ b/src/backend/src/flow_rule.c
@@ -1,0 +1,248 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ */
+
+#include "infmon/flow_rule.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* ── Field metadata tables ───────────────────────────────────────── */
+
+static const uint32_t field_widths[INFMON_FIELD__COUNT] = {
+    [INFMON_FIELD_SRC_IP]        = 16,
+    [INFMON_FIELD_DST_IP]        = 16,
+    [INFMON_FIELD_IP_PROTO]      = 1,
+    [INFMON_FIELD_DSCP]          = 1,
+    [INFMON_FIELD_MIRROR_SRC_IP] = 16,
+};
+
+static const char *field_names[INFMON_FIELD__COUNT] = {
+    [INFMON_FIELD_SRC_IP]        = "src_ip",
+    [INFMON_FIELD_DST_IP]        = "dst_ip",
+    [INFMON_FIELD_IP_PROTO]      = "ip_proto",
+    [INFMON_FIELD_DSCP]          = "dscp",
+    [INFMON_FIELD_MIRROR_SRC_IP] = "mirror_src_ip",
+};
+
+static const char *eviction_names[INFMON_EVICTION__COUNT] = {
+    [INFMON_EVICTION_LRU_DROP] = "lru_drop",
+};
+
+uint32_t infmon_field_width(infmon_field_t field) {
+    if ((unsigned)field >= INFMON_FIELD__COUNT) return 0;
+    return field_widths[field];
+}
+
+const char *infmon_field_name(infmon_field_t field) {
+    if ((unsigned)field >= INFMON_FIELD__COUNT) return NULL;
+    return field_names[field];
+}
+
+bool infmon_field_parse(const char *name, infmon_field_t *out) {
+    if (!name) return false;
+    for (int i = 0; i < INFMON_FIELD__COUNT; i++) {
+        if (strcmp(name, field_names[i]) == 0) {
+            if (out) *out = (infmon_field_t)i;
+            return true;
+        }
+    }
+    return false;
+}
+
+const char *infmon_eviction_policy_name(infmon_eviction_policy_t policy) {
+    if ((unsigned)policy >= INFMON_EVICTION__COUNT) return NULL;
+    return eviction_names[policy];
+}
+
+bool infmon_eviction_policy_parse(const char *name, infmon_eviction_policy_t *out) {
+    if (!name) return false;
+    for (int i = 0; i < INFMON_EVICTION__COUNT; i++) {
+        if (strcmp(name, eviction_names[i]) == 0) {
+            if (out) *out = (infmon_eviction_policy_t)i;
+            return true;
+        }
+    }
+    return false;
+}
+
+/* ── Name validation: ^[a-z0-9][a-z0-9_-]{1,30}$ ────────────────── */
+
+static bool name_valid(const char *name) {
+    if (!name) return false;
+    size_t len = strlen(name);
+    if (len < 2 || len > INFMON_FLOW_RULE_NAME_MAX) return false;
+
+    /* First char: [a-z0-9] */
+    char c = name[0];
+    if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))) return false;
+
+    for (size_t i = 1; i < len; i++) {
+        c = name[i];
+        if (!((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+              c == '_' || c == '-'))
+            return false;
+    }
+    return true;
+}
+
+/* ── Key width ───────────────────────────────────────────────────── */
+
+uint32_t infmon_flow_rule_key_width(const infmon_field_t *fields,
+                                    uint32_t field_count) {
+    uint32_t w = 0;
+    for (uint32_t i = 0; i < field_count; i++) {
+        uint32_t fw = infmon_field_width(fields[i]);
+        if (fw == 0) return 0;
+        w += fw;
+    }
+    return w;
+}
+
+/* ── Validation (single rule) ────────────────────────────────────── */
+
+infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *rule) {
+    if (!rule) return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+
+    if (!name_valid(rule->name))
+        return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+
+    if (rule->field_count == 0 || rule->field_count > INFMON_FLOW_RULE_FIELDS_MAX)
+        return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+
+    /* Check unknown fields and duplicates */
+    bool seen[INFMON_FIELD__COUNT] = {false};
+    for (uint32_t i = 0; i < rule->field_count; i++) {
+        if ((unsigned)rule->fields[i] >= INFMON_FIELD__COUNT)
+            return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+        if (seen[rule->fields[i]])
+            return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+        seen[rule->fields[i]] = true;
+    }
+
+    if (rule->max_keys == 0)
+        return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+
+    if ((unsigned)rule->eviction_policy >= INFMON_EVICTION__COUNT)
+        return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+
+    uint32_t kw = infmon_flow_rule_key_width(rule->fields, rule->field_count);
+    if (kw == 0 || kw > INFMON_FLOW_RULE_KEY_MAX)
+        return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+
+    return INFMON_FLOW_RULE_OK;
+}
+
+/* ── Key encoding ────────────────────────────────────────────────── */
+
+void infmon_flow_rule_encode_key(const infmon_flow_rule_t *rule,
+                                 const infmon_flow_fields_t *fields,
+                                 uint8_t *key_buf) {
+    uint32_t off = 0;
+    for (uint32_t i = 0; i < rule->field_count; i++) {
+        switch (rule->fields[i]) {
+        case INFMON_FIELD_SRC_IP:
+            memcpy(key_buf + off, fields->src_ip, 16);
+            off += 16;
+            break;
+        case INFMON_FIELD_DST_IP:
+            memcpy(key_buf + off, fields->dst_ip, 16);
+            off += 16;
+            break;
+        case INFMON_FIELD_IP_PROTO:
+            key_buf[off++] = fields->ip_proto;
+            break;
+        case INFMON_FIELD_DSCP:
+            key_buf[off++] = fields->dscp & 0x3F;
+            break;
+        case INFMON_FIELD_MIRROR_SRC_IP:
+            memcpy(key_buf + off, fields->mirror_src_ip, 16);
+            off += 16;
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+/* ── Flow rule set ───────────────────────────────────────────────── */
+
+struct infmon_flow_rule_set {
+    infmon_flow_rule_t rules[INFMON_FLOW_RULE_SET_MAX];
+    uint32_t count;
+    uint32_t max_keys_budget;
+    uint32_t used_keys;
+};
+
+infmon_flow_rule_set_t *infmon_flow_rule_set_create(uint32_t max_keys_budget) {
+    infmon_flow_rule_set_t *s = calloc(1, sizeof(*s));
+    if (!s) return NULL;
+    s->max_keys_budget = max_keys_budget;
+    return s;
+}
+
+void infmon_flow_rule_set_destroy(infmon_flow_rule_set_t *set) {
+    free(set);
+}
+
+uint32_t infmon_flow_rule_count(const infmon_flow_rule_set_t *set) {
+    return set ? set->count : 0;
+}
+
+const infmon_flow_rule_t *infmon_flow_rule_find(const infmon_flow_rule_set_t *set,
+                                                const char *name) {
+    if (!set || !name) return NULL;
+    for (uint32_t i = 0; i < set->count; i++) {
+        if (strcmp(set->rules[i].name, name) == 0)
+            return &set->rules[i];
+    }
+    return NULL;
+}
+
+const infmon_flow_rule_t *infmon_flow_rule_get(const infmon_flow_rule_set_t *set,
+                                               uint32_t index) {
+    if (!set || index >= set->count) return NULL;
+    return &set->rules[index];
+}
+
+infmon_flow_rule_result_t infmon_flow_rule_add(infmon_flow_rule_set_t *set,
+                                               const infmon_flow_rule_t *rule) {
+    if (!set || !rule) return INFMON_FLOW_RULE_ERR_INTERNAL;
+
+    infmon_flow_rule_result_t rc = infmon_flow_rule_validate(rule);
+    if (rc != INFMON_FLOW_RULE_OK) return rc;
+
+    if (set->count >= INFMON_FLOW_RULE_SET_MAX)
+        return INFMON_FLOW_RULE_ERR_INTERNAL;
+
+    if (infmon_flow_rule_find(set, rule->name))
+        return INFMON_FLOW_RULE_ERR_NAME_EXISTS;
+
+    if (set->used_keys + rule->max_keys > set->max_keys_budget)
+        return INFMON_FLOW_RULE_ERR_BUDGET_EXCEEDED;
+
+    infmon_flow_rule_t *dst = &set->rules[set->count];
+    *dst = *rule;
+    dst->key_width = infmon_flow_rule_key_width(rule->fields, rule->field_count);
+    set->used_keys += dst->max_keys;
+    set->count++;
+    return INFMON_FLOW_RULE_OK;
+}
+
+infmon_flow_rule_result_t infmon_flow_rule_rm(infmon_flow_rule_set_t *set,
+                                              const char *name) {
+    if (!set || !name) return INFMON_FLOW_RULE_ERR_INTERNAL;
+
+    for (uint32_t i = 0; i < set->count; i++) {
+        if (strcmp(set->rules[i].name, name) == 0) {
+            set->used_keys -= set->rules[i].max_keys;
+            /* Shift remaining rules down */
+            for (uint32_t j = i; j + 1 < set->count; j++)
+                set->rules[j] = set->rules[j + 1];
+            set->count--;
+            return INFMON_FLOW_RULE_OK;
+        }
+    }
+    return INFMON_FLOW_RULE_ERR_NOT_FOUND;
+}

--- a/src/backend/src/flow_rule.c
+++ b/src/backend/src/flow_rule.c
@@ -250,7 +250,7 @@ infmon_flow_rule_result_t infmon_flow_rule_add(infmon_flow_rule_set_t *set,
     if (infmon_flow_rule_find(set, rule->name))
         return INFMON_FLOW_RULE_ERR_NAME_EXISTS;
 
-    if ((uint64_t)set->used_keys + rule->max_keys > set->max_keys_budget)
+    if ((uint64_t) set->used_keys + rule->max_keys > set->max_keys_budget)
         return INFMON_FLOW_RULE_ERR_BUDGET_EXCEEDED;
 
     infmon_flow_rule_t *dst = &set->rules[set->count];

--- a/src/backend/src/flow_rule.c
+++ b/src/backend/src/flow_rule.c
@@ -197,6 +197,8 @@ struct infmon_flow_rule_set {
 
 infmon_flow_rule_set_t *infmon_flow_rule_set_create(uint32_t max_keys_budget)
 {
+    if (max_keys_budget > INFMON_FLOW_RULE_MAX_KEYS_BUDGET)
+        return NULL;
     infmon_flow_rule_set_t *s = calloc(1, sizeof(*s));
     if (!s)
         return NULL;
@@ -271,6 +273,7 @@ infmon_flow_rule_result_t infmon_flow_rule_rm(infmon_flow_rule_set_t *set, const
             for (uint32_t j = i; j + 1 < set->count; j++)
                 set->rules[j] = set->rules[j + 1];
             set->count--;
+            memset(&set->rules[set->count], 0, sizeof(set->rules[0]));
             return INFMON_FLOW_RULE_OK;
         }
     }

--- a/src/backend/src/flow_rule.c
+++ b/src/backend/src/flow_rule.c
@@ -138,6 +138,8 @@ infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *ru
 
     if (rule->max_keys == 0)
         return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
+    if (rule->max_keys > INFMON_FLOW_RULE_MAX_KEYS_BUDGET)
+        return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
 
     if ((unsigned) rule->eviction_policy >= INFMON_EVICTION__COUNT)
         return INFMON_FLOW_RULE_ERR_INVALID_SPEC;
@@ -154,6 +156,9 @@ infmon_flow_rule_result_t infmon_flow_rule_validate(const infmon_flow_rule_t *ru
 void infmon_flow_rule_encode_key(const infmon_flow_rule_t *rule, const infmon_flow_fields_t *fields,
                                  uint8_t *key_buf)
 {
+    if (!rule || !fields || !key_buf)
+        return;
+
     uint32_t off = 0;
     for (uint32_t i = 0; i < rule->field_count; i++) {
         switch (rule->fields[i]) {
@@ -238,12 +243,12 @@ infmon_flow_rule_result_t infmon_flow_rule_add(infmon_flow_rule_set_t *set,
         return rc;
 
     if (set->count >= INFMON_FLOW_RULE_SET_MAX)
-        return INFMON_FLOW_RULE_ERR_INTERNAL;
+        return INFMON_FLOW_RULE_ERR_SET_FULL;
 
     if (infmon_flow_rule_find(set, rule->name))
         return INFMON_FLOW_RULE_ERR_NAME_EXISTS;
 
-    if (set->used_keys + rule->max_keys > set->max_keys_budget)
+    if ((uint64_t)set->used_keys + rule->max_keys > set->max_keys_budget)
         return INFMON_FLOW_RULE_ERR_BUDGET_EXCEEDED;
 
     infmon_flow_rule_t *dst = &set->rules[set->count];

--- a/src/backend/test/test_flow_rule.cc
+++ b/src/backend/test/test_flow_rule.cc
@@ -16,8 +16,8 @@ static infmon_flow_rule_t make_rule(const char *name, const infmon_field_t *fiel
                                     uint32_t max_keys = 1024)
 {
     infmon_flow_rule_t r{};
-    std::strncpy(r.name, name, INFMON_FLOW_RULE_NAME_MAX);
-    r.name[INFMON_FLOW_RULE_NAME_MAX] = '\0';
+    std::memset(r.name, 0, sizeof(r.name));
+    std::strncpy(r.name, name, sizeof(r.name) - 1);
     if (fc > 0) {
         std::memcpy(r.fields, fields, fc * sizeof(infmon_field_t));
     }

--- a/src/backend/test/test_flow_rule.cc
+++ b/src/backend/test/test_flow_rule.cc
@@ -3,8 +3,8 @@
  * Copyright 2026 Riff
  */
 
-#include <gtest/gtest.h>
 #include <cstring>
+#include <gtest/gtest.h>
 
 extern "C" {
 #include "infmon/flow_rule.h"
@@ -12,13 +12,15 @@ extern "C" {
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
 
-static infmon_flow_rule_t make_rule(const char *name,
-                                    const infmon_field_t *fields,
-                                    uint32_t fc,
-                                    uint32_t max_keys = 1024) {
+static infmon_flow_rule_t make_rule(const char *name, const infmon_field_t *fields, uint32_t fc,
+                                    uint32_t max_keys = 1024)
+{
     infmon_flow_rule_t r{};
     std::strncpy(r.name, name, INFMON_FLOW_RULE_NAME_MAX);
-    std::memcpy(r.fields, fields, fc * sizeof(infmon_field_t));
+    r.name[INFMON_FLOW_RULE_NAME_MAX] = '\0';
+    if (fc > 0) {
+        std::memcpy(r.fields, fields, fc * sizeof(infmon_field_t));
+    }
     r.field_count = fc;
     r.max_keys = max_keys;
     r.eviction_policy = INFMON_EVICTION_LRU_DROP;
@@ -27,22 +29,25 @@ static infmon_flow_rule_t make_rule(const char *name,
 
 /* ── 1. Field width / name lookups ───────────────────────────────── */
 
-TEST(FieldMeta, Widths) {
+TEST(FieldMeta, Widths)
+{
     EXPECT_EQ(infmon_field_width(INFMON_FIELD_SRC_IP), 16u);
     EXPECT_EQ(infmon_field_width(INFMON_FIELD_DST_IP), 16u);
     EXPECT_EQ(infmon_field_width(INFMON_FIELD_IP_PROTO), 1u);
     EXPECT_EQ(infmon_field_width(INFMON_FIELD_DSCP), 1u);
     EXPECT_EQ(infmon_field_width(INFMON_FIELD_MIRROR_SRC_IP), 16u);
-    EXPECT_EQ(infmon_field_width((infmon_field_t)99), 0u);
+    EXPECT_EQ(infmon_field_width((infmon_field_t) 99), 0u);
 }
 
-TEST(FieldMeta, Names) {
+TEST(FieldMeta, Names)
+{
     EXPECT_STREQ(infmon_field_name(INFMON_FIELD_SRC_IP), "src_ip");
     EXPECT_STREQ(infmon_field_name(INFMON_FIELD_DSCP), "dscp");
-    EXPECT_EQ(infmon_field_name((infmon_field_t)99), nullptr);
+    EXPECT_EQ(infmon_field_name((infmon_field_t) 99), nullptr);
 }
 
-TEST(FieldMeta, Parse) {
+TEST(FieldMeta, Parse)
+{
     infmon_field_t f;
     EXPECT_TRUE(infmon_field_parse("src_ip", &f));
     EXPECT_EQ(f, INFMON_FIELD_SRC_IP);
@@ -52,9 +57,10 @@ TEST(FieldMeta, Parse) {
     EXPECT_FALSE(infmon_field_parse(nullptr, &f));
 }
 
-TEST(FieldMeta, EvictionPolicy) {
+TEST(FieldMeta, EvictionPolicy)
+{
     EXPECT_STREQ(infmon_eviction_policy_name(INFMON_EVICTION_LRU_DROP), "lru_drop");
-    EXPECT_EQ(infmon_eviction_policy_name((infmon_eviction_policy_t)99), nullptr);
+    EXPECT_EQ(infmon_eviction_policy_name((infmon_eviction_policy_t) 99), nullptr);
 
     infmon_eviction_policy_t p;
     EXPECT_TRUE(infmon_eviction_policy_parse("lru_drop", &p));
@@ -64,7 +70,8 @@ TEST(FieldMeta, EvictionPolicy) {
 
 /* ── 2. Name validation ─────────────────────────────────────────── */
 
-TEST(Validation, NameValid) {
+TEST(Validation, NameValid)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("ab", f, 1);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_OK);
@@ -73,13 +80,15 @@ TEST(Validation, NameValid) {
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_OK);
 }
 
-TEST(Validation, NameTooShort) {
+TEST(Validation, NameTooShort)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("a", f, 1);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
 }
 
-TEST(Validation, NameMaxLengthOk) {
+TEST(Validation, NameMaxLengthOk)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     // 31 chars = exactly at limit, should be valid
     auto r = make_rule("abcdefghijklmnopqrstuvwxyz01234", f, 1);
@@ -88,13 +97,15 @@ TEST(Validation, NameMaxLengthOk) {
     // prevented by the buffer size itself.
 }
 
-TEST(Validation, NameInvalidChars) {
+TEST(Validation, NameInvalidChars)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("AB-cd", f, 1);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
 }
 
-TEST(Validation, NameStartsWithHyphen) {
+TEST(Validation, NameStartsWithHyphen)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("-abc", f, 1);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
@@ -102,40 +113,45 @@ TEST(Validation, NameStartsWithHyphen) {
 
 /* ── 3. Flow rule validation ────────────────────────────────────── */
 
-TEST(Validation, EmptyFields) {
+TEST(Validation, EmptyFields)
+{
     auto r = make_rule("test01", nullptr, 0);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
 }
 
-TEST(Validation, DuplicateFields) {
+TEST(Validation, DuplicateFields)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_SRC_IP};
     auto r = make_rule("test01", f, 2);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
 }
 
-TEST(Validation, UnknownField) {
-    infmon_field_t f[] = {(infmon_field_t)99};
+TEST(Validation, UnknownField)
+{
+    infmon_field_t f[] = {(infmon_field_t) 99};
     auto r = make_rule("test01", f, 1);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
 }
 
-TEST(Validation, ZeroMaxKeys) {
+TEST(Validation, ZeroMaxKeys)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("test01", f, 1, 0);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
 }
 
-TEST(Validation, BadEvictionPolicy) {
+TEST(Validation, BadEvictionPolicy)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("test01", f, 1);
-    r.eviction_policy = (infmon_eviction_policy_t)99;
+    r.eviction_policy = (infmon_eviction_policy_t) 99;
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
 }
 
-TEST(Validation, ValidAllFields) {
-    infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_DST_IP,
-                          INFMON_FIELD_IP_PROTO, INFMON_FIELD_DSCP,
-                          INFMON_FIELD_MIRROR_SRC_IP};
+TEST(Validation, ValidAllFields)
+{
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_DST_IP, INFMON_FIELD_IP_PROTO,
+                          INFMON_FIELD_DSCP, INFMON_FIELD_MIRROR_SRC_IP};
     auto r = make_rule("all-fields", f, 5);
     EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_OK);
     // Total width = 16+16+1+1+16 = 50, within 64
@@ -143,7 +159,8 @@ TEST(Validation, ValidAllFields) {
 
 /* ── 4. Flow rule set CRUD ──────────────────────────────────────── */
 
-TEST(RuleSet, AddFindRm) {
+TEST(RuleSet, AddFindRm)
+{
     auto *set = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
     ASSERT_NE(set, nullptr);
 
@@ -165,7 +182,8 @@ TEST(RuleSet, AddFindRm) {
     infmon_flow_rule_set_destroy(set);
 }
 
-TEST(RuleSet, DuplicateName) {
+TEST(RuleSet, DuplicateName)
+{
     auto *set = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("dup-rule", f, 1, 10);
@@ -176,7 +194,8 @@ TEST(RuleSet, DuplicateName) {
     infmon_flow_rule_set_destroy(set);
 }
 
-TEST(RuleSet, BudgetExceeded) {
+TEST(RuleSet, BudgetExceeded)
+{
     auto *set = infmon_flow_rule_set_create(100);
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("rule-aa", f, 1, 60);
@@ -191,13 +210,15 @@ TEST(RuleSet, BudgetExceeded) {
     infmon_flow_rule_set_destroy(set);
 }
 
-TEST(RuleSet, RmNotFound) {
+TEST(RuleSet, RmNotFound)
+{
     auto *set = infmon_flow_rule_set_create(100);
     EXPECT_EQ(infmon_flow_rule_rm(set, "nope"), INFMON_FLOW_RULE_ERR_NOT_FOUND);
     infmon_flow_rule_set_destroy(set);
 }
 
-TEST(RuleSet, GetByIndex) {
+TEST(RuleSet, GetByIndex)
+{
     auto *set = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r1 = make_rule("rule-aa", f, 1, 10);
@@ -214,7 +235,8 @@ TEST(RuleSet, GetByIndex) {
 
 /* ── 5. Key encoding ────────────────────────────────────────────── */
 
-TEST(KeyEncode, BasicLayout) {
+TEST(KeyEncode, BasicLayout)
+{
     infmon_field_t f[] = {INFMON_FIELD_IP_PROTO, INFMON_FIELD_SRC_IP};
     auto r = make_rule("ke-test", f, 2);
     r.key_width = infmon_flow_rule_key_width(f, 2);
@@ -235,7 +257,7 @@ TEST(KeyEncode, BasicLayout) {
 
     EXPECT_EQ(key[0], 6); // ip_proto first
     // Then 16 bytes of src_ip
-    EXPECT_EQ(key[1], 0);      // first 10 bytes zero
+    EXPECT_EQ(key[1], 0); // first 10 bytes zero
     EXPECT_EQ(key[11], 0xff);
     EXPECT_EQ(key[12], 0xff);
     EXPECT_EQ(key[13], 10);
@@ -246,7 +268,8 @@ TEST(KeyEncode, BasicLayout) {
 
 /* ── 6. IPv4-mapped-IPv6 in keys ─────────────────────────────────── */
 
-TEST(KeyEncode, IPv4Mapped) {
+TEST(KeyEncode, IPv4Mapped)
+{
     infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
     auto r = make_rule("v4map", f, 1);
     r.key_width = 16;
@@ -275,7 +298,8 @@ TEST(KeyEncode, IPv4Mapped) {
     EXPECT_EQ(key[15], 2);
 }
 
-TEST(KeyEncode, DscpMasked) {
+TEST(KeyEncode, DscpMasked)
+{
     infmon_field_t f[] = {INFMON_FIELD_DSCP};
     auto r = make_rule("dscp-test", f, 1);
     r.key_width = 1;
@@ -288,13 +312,13 @@ TEST(KeyEncode, DscpMasked) {
     EXPECT_EQ(key[0], 0x3F);
 }
 
-TEST(KeyWidth, Computation) {
-    infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_DST_IP,
-                          INFMON_FIELD_IP_PROTO, INFMON_FIELD_DSCP,
-                          INFMON_FIELD_MIRROR_SRC_IP};
+TEST(KeyWidth, Computation)
+{
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_DST_IP, INFMON_FIELD_IP_PROTO,
+                          INFMON_FIELD_DSCP, INFMON_FIELD_MIRROR_SRC_IP};
     EXPECT_EQ(infmon_flow_rule_key_width(f, 5), 50u);
     EXPECT_EQ(infmon_flow_rule_key_width(f, 0), 0u);
 
-    infmon_field_t bad[] = {(infmon_field_t)99};
+    infmon_field_t bad[] = {(infmon_field_t) 99};
     EXPECT_EQ(infmon_flow_rule_key_width(bad, 1), 0u);
 }

--- a/src/backend/test/test_flow_rule.cc
+++ b/src/backend/test/test_flow_rule.cc
@@ -1,0 +1,300 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ */
+
+#include <gtest/gtest.h>
+#include <cstring>
+
+extern "C" {
+#include "infmon/flow_rule.h"
+}
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+static infmon_flow_rule_t make_rule(const char *name,
+                                    const infmon_field_t *fields,
+                                    uint32_t fc,
+                                    uint32_t max_keys = 1024) {
+    infmon_flow_rule_t r{};
+    std::strncpy(r.name, name, INFMON_FLOW_RULE_NAME_MAX);
+    std::memcpy(r.fields, fields, fc * sizeof(infmon_field_t));
+    r.field_count = fc;
+    r.max_keys = max_keys;
+    r.eviction_policy = INFMON_EVICTION_LRU_DROP;
+    return r;
+}
+
+/* ── 1. Field width / name lookups ───────────────────────────────── */
+
+TEST(FieldMeta, Widths) {
+    EXPECT_EQ(infmon_field_width(INFMON_FIELD_SRC_IP), 16u);
+    EXPECT_EQ(infmon_field_width(INFMON_FIELD_DST_IP), 16u);
+    EXPECT_EQ(infmon_field_width(INFMON_FIELD_IP_PROTO), 1u);
+    EXPECT_EQ(infmon_field_width(INFMON_FIELD_DSCP), 1u);
+    EXPECT_EQ(infmon_field_width(INFMON_FIELD_MIRROR_SRC_IP), 16u);
+    EXPECT_EQ(infmon_field_width((infmon_field_t)99), 0u);
+}
+
+TEST(FieldMeta, Names) {
+    EXPECT_STREQ(infmon_field_name(INFMON_FIELD_SRC_IP), "src_ip");
+    EXPECT_STREQ(infmon_field_name(INFMON_FIELD_DSCP), "dscp");
+    EXPECT_EQ(infmon_field_name((infmon_field_t)99), nullptr);
+}
+
+TEST(FieldMeta, Parse) {
+    infmon_field_t f;
+    EXPECT_TRUE(infmon_field_parse("src_ip", &f));
+    EXPECT_EQ(f, INFMON_FIELD_SRC_IP);
+    EXPECT_TRUE(infmon_field_parse("mirror_src_ip", &f));
+    EXPECT_EQ(f, INFMON_FIELD_MIRROR_SRC_IP);
+    EXPECT_FALSE(infmon_field_parse("bogus", &f));
+    EXPECT_FALSE(infmon_field_parse(nullptr, &f));
+}
+
+TEST(FieldMeta, EvictionPolicy) {
+    EXPECT_STREQ(infmon_eviction_policy_name(INFMON_EVICTION_LRU_DROP), "lru_drop");
+    EXPECT_EQ(infmon_eviction_policy_name((infmon_eviction_policy_t)99), nullptr);
+
+    infmon_eviction_policy_t p;
+    EXPECT_TRUE(infmon_eviction_policy_parse("lru_drop", &p));
+    EXPECT_EQ(p, INFMON_EVICTION_LRU_DROP);
+    EXPECT_FALSE(infmon_eviction_policy_parse("fifo", &p));
+}
+
+/* ── 2. Name validation ─────────────────────────────────────────── */
+
+TEST(Validation, NameValid) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("ab", f, 1);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_OK);
+
+    r = make_rule("my-rule_01", f, 1);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_OK);
+}
+
+TEST(Validation, NameTooShort) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("a", f, 1);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
+}
+
+TEST(Validation, NameMaxLengthOk) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    // 31 chars = exactly at limit, should be valid
+    auto r = make_rule("abcdefghijklmnopqrstuvwxyz01234", f, 1);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_OK);
+    // Buffer is 32 bytes (31+1), can't store >31 chars, so too-long is
+    // prevented by the buffer size itself.
+}
+
+TEST(Validation, NameInvalidChars) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("AB-cd", f, 1);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
+}
+
+TEST(Validation, NameStartsWithHyphen) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("-abc", f, 1);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
+}
+
+/* ── 3. Flow rule validation ────────────────────────────────────── */
+
+TEST(Validation, EmptyFields) {
+    auto r = make_rule("test01", nullptr, 0);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
+}
+
+TEST(Validation, DuplicateFields) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_SRC_IP};
+    auto r = make_rule("test01", f, 2);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
+}
+
+TEST(Validation, UnknownField) {
+    infmon_field_t f[] = {(infmon_field_t)99};
+    auto r = make_rule("test01", f, 1);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
+}
+
+TEST(Validation, ZeroMaxKeys) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("test01", f, 1, 0);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
+}
+
+TEST(Validation, BadEvictionPolicy) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("test01", f, 1);
+    r.eviction_policy = (infmon_eviction_policy_t)99;
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_ERR_INVALID_SPEC);
+}
+
+TEST(Validation, ValidAllFields) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_DST_IP,
+                          INFMON_FIELD_IP_PROTO, INFMON_FIELD_DSCP,
+                          INFMON_FIELD_MIRROR_SRC_IP};
+    auto r = make_rule("all-fields", f, 5);
+    EXPECT_EQ(infmon_flow_rule_validate(&r), INFMON_FLOW_RULE_OK);
+    // Total width = 16+16+1+1+16 = 50, within 64
+}
+
+/* ── 4. Flow rule set CRUD ──────────────────────────────────────── */
+
+TEST(RuleSet, AddFindRm) {
+    auto *set = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
+    ASSERT_NE(set, nullptr);
+
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_DST_IP};
+    auto r = make_rule("my-rule", f, 2, 100);
+
+    EXPECT_EQ(infmon_flow_rule_add(set, &r), INFMON_FLOW_RULE_OK);
+    EXPECT_EQ(infmon_flow_rule_count(set), 1u);
+
+    auto *found = infmon_flow_rule_find(set, "my-rule");
+    ASSERT_NE(found, nullptr);
+    EXPECT_STREQ(found->name, "my-rule");
+    EXPECT_EQ(found->key_width, 32u);
+
+    EXPECT_EQ(infmon_flow_rule_rm(set, "my-rule"), INFMON_FLOW_RULE_OK);
+    EXPECT_EQ(infmon_flow_rule_count(set), 0u);
+    EXPECT_EQ(infmon_flow_rule_find(set, "my-rule"), nullptr);
+
+    infmon_flow_rule_set_destroy(set);
+}
+
+TEST(RuleSet, DuplicateName) {
+    auto *set = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("dup-rule", f, 1, 10);
+
+    EXPECT_EQ(infmon_flow_rule_add(set, &r), INFMON_FLOW_RULE_OK);
+    EXPECT_EQ(infmon_flow_rule_add(set, &r), INFMON_FLOW_RULE_ERR_NAME_EXISTS);
+
+    infmon_flow_rule_set_destroy(set);
+}
+
+TEST(RuleSet, BudgetExceeded) {
+    auto *set = infmon_flow_rule_set_create(100);
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("rule-aa", f, 1, 60);
+    EXPECT_EQ(infmon_flow_rule_add(set, &r), INFMON_FLOW_RULE_OK);
+
+    auto r2 = make_rule("rule-bb", f, 1, 41);
+    EXPECT_EQ(infmon_flow_rule_add(set, &r2), INFMON_FLOW_RULE_ERR_BUDGET_EXCEEDED);
+
+    auto r3 = make_rule("rule-cc", f, 1, 40);
+    EXPECT_EQ(infmon_flow_rule_add(set, &r3), INFMON_FLOW_RULE_OK);
+
+    infmon_flow_rule_set_destroy(set);
+}
+
+TEST(RuleSet, RmNotFound) {
+    auto *set = infmon_flow_rule_set_create(100);
+    EXPECT_EQ(infmon_flow_rule_rm(set, "nope"), INFMON_FLOW_RULE_ERR_NOT_FOUND);
+    infmon_flow_rule_set_destroy(set);
+}
+
+TEST(RuleSet, GetByIndex) {
+    auto *set = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r1 = make_rule("rule-aa", f, 1, 10);
+    auto r2 = make_rule("rule-bb", f, 1, 10);
+    infmon_flow_rule_add(set, &r1);
+    infmon_flow_rule_add(set, &r2);
+
+    EXPECT_STREQ(infmon_flow_rule_get(set, 0)->name, "rule-aa");
+    EXPECT_STREQ(infmon_flow_rule_get(set, 1)->name, "rule-bb");
+    EXPECT_EQ(infmon_flow_rule_get(set, 2), nullptr);
+
+    infmon_flow_rule_set_destroy(set);
+}
+
+/* ── 5. Key encoding ────────────────────────────────────────────── */
+
+TEST(KeyEncode, BasicLayout) {
+    infmon_field_t f[] = {INFMON_FIELD_IP_PROTO, INFMON_FIELD_SRC_IP};
+    auto r = make_rule("ke-test", f, 2);
+    r.key_width = infmon_flow_rule_key_width(f, 2);
+    EXPECT_EQ(r.key_width, 17u);
+
+    infmon_flow_fields_t ff{};
+    ff.ip_proto = 6; // TCP
+    // src_ip = ::ffff:10.0.0.1 (IPv4-mapped)
+    ff.src_ip[10] = 0xff;
+    ff.src_ip[11] = 0xff;
+    ff.src_ip[12] = 10;
+    ff.src_ip[13] = 0;
+    ff.src_ip[14] = 0;
+    ff.src_ip[15] = 1;
+
+    uint8_t key[64] = {};
+    infmon_flow_rule_encode_key(&r, &ff, key);
+
+    EXPECT_EQ(key[0], 6); // ip_proto first
+    // Then 16 bytes of src_ip
+    EXPECT_EQ(key[1], 0);      // first 10 bytes zero
+    EXPECT_EQ(key[11], 0xff);
+    EXPECT_EQ(key[12], 0xff);
+    EXPECT_EQ(key[13], 10);
+    EXPECT_EQ(key[14], 0);
+    EXPECT_EQ(key[15], 0);
+    EXPECT_EQ(key[16], 1);
+}
+
+/* ── 6. IPv4-mapped-IPv6 in keys ─────────────────────────────────── */
+
+TEST(KeyEncode, IPv4Mapped) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP};
+    auto r = make_rule("v4map", f, 1);
+    r.key_width = 16;
+
+    // Build ::ffff:192.168.1.2
+    infmon_flow_fields_t ff{};
+    std::memset(ff.src_ip, 0, 16);
+    ff.src_ip[10] = 0xff;
+    ff.src_ip[11] = 0xff;
+    ff.src_ip[12] = 192;
+    ff.src_ip[13] = 168;
+    ff.src_ip[14] = 1;
+    ff.src_ip[15] = 2;
+
+    uint8_t key[16] = {};
+    infmon_flow_rule_encode_key(&r, &ff, key);
+
+    // Verify: 10 zero bytes, 0xff, 0xff, 192, 168, 1, 2
+    for (int i = 0; i < 10; i++)
+        EXPECT_EQ(key[i], 0) << "byte " << i;
+    EXPECT_EQ(key[10], 0xff);
+    EXPECT_EQ(key[11], 0xff);
+    EXPECT_EQ(key[12], 192);
+    EXPECT_EQ(key[13], 168);
+    EXPECT_EQ(key[14], 1);
+    EXPECT_EQ(key[15], 2);
+}
+
+TEST(KeyEncode, DscpMasked) {
+    infmon_field_t f[] = {INFMON_FIELD_DSCP};
+    auto r = make_rule("dscp-test", f, 1);
+    r.key_width = 1;
+
+    infmon_flow_fields_t ff{};
+    ff.dscp = 0xFF; // upper bits should be masked
+
+    uint8_t key[1] = {};
+    infmon_flow_rule_encode_key(&r, &ff, key);
+    EXPECT_EQ(key[0], 0x3F);
+}
+
+TEST(KeyWidth, Computation) {
+    infmon_field_t f[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_DST_IP,
+                          INFMON_FIELD_IP_PROTO, INFMON_FIELD_DSCP,
+                          INFMON_FIELD_MIRROR_SRC_IP};
+    EXPECT_EQ(infmon_flow_rule_key_width(f, 5), 50u);
+    EXPECT_EQ(infmon_flow_rule_key_width(f, 0), 0u);
+
+    infmon_field_t bad[] = {(infmon_field_t)99};
+    EXPECT_EQ(infmon_flow_rule_key_width(bad, 1), 0u);
+}

--- a/src/backend/test/test_flow_rule.cc
+++ b/src/backend/test/test_flow_rule.cc
@@ -16,7 +16,6 @@ static infmon_flow_rule_t make_rule(const char *name, const infmon_field_t *fiel
                                     uint32_t max_keys = 1024)
 {
     infmon_flow_rule_t r{};
-    std::memset(r.name, 0, sizeof(r.name));
     std::size_t len = std::strlen(name);
     if (len > sizeof(r.name) - 1)
         len = sizeof(r.name) - 1;

--- a/src/backend/test/test_flow_rule.cc
+++ b/src/backend/test/test_flow_rule.cc
@@ -17,7 +17,9 @@ static infmon_flow_rule_t make_rule(const char *name, const infmon_field_t *fiel
 {
     infmon_flow_rule_t r{};
     std::memset(r.name, 0, sizeof(r.name));
-    std::strncpy(r.name, name, sizeof(r.name) - 1);
+    std::size_t len = std::strlen(name);
+    if (len > sizeof(r.name) - 1) len = sizeof(r.name) - 1;
+    std::memcpy(r.name, name, len);
     if (fc > 0) {
         std::memcpy(r.fields, fields, fc * sizeof(infmon_field_t));
     }

--- a/src/backend/test/test_flow_rule.cc
+++ b/src/backend/test/test_flow_rule.cc
@@ -18,7 +18,8 @@ static infmon_flow_rule_t make_rule(const char *name, const infmon_field_t *fiel
     infmon_flow_rule_t r{};
     std::memset(r.name, 0, sizeof(r.name));
     std::size_t len = std::strlen(name);
-    if (len > sizeof(r.name) - 1) len = sizeof(r.name) - 1;
+    if (len > sizeof(r.name) - 1)
+        len = sizeof(r.name) - 1;
     std::memcpy(r.name, name, len);
     if (fc > 0) {
         std::memcpy(r.fields, fields, fc * sizeof(infmon_field_t));


### PR DESCRIPTION
## Summary

Implements the flow-rule data model per [spec 002-flow-tracking-model](specs/002-flow-tracking-model.md).

### What's included

- **flow_rule structure**: `(name, ordered_field_list, max_keys, eviction_policy)`
- **v1 field set**: `src_ip`, `dst_ip`, `ip_proto`, `dscp`, `mirror_src_ip` with canonical encodings
- **Key layout**: concatenated field encodings in declared order, no padding, ≤64 bytes
- **IPv4-mapped-IPv6**: uniform 16-byte representation (`::ffff:a.b.c.d`) for all IP fields
- **6 validation rules** (all-or-nothing): name uniqueness, non-empty fields without duplicates, positive max_keys, supported eviction policy, key width ≤64B, cumulative budget ≤16Mi
- **Flow-rule set**: array-based storage with CRUD (add/rm/find/list)
- **Per-flow-rule metrics struct**: flows, evictions_total, drops_total, packets_total, bytes_total
- **Key encoding**: function to build key bytes from parsed flow fields
- **24 GTest unit tests** covering field metadata, name validation, rule validation, CRUD, key encoding, and IPv4-mapped-v6 layout

### Files

- `src/backend/include/infmon/flow_rule.h` — public API
- `src/backend/src/flow_rule.c` — implementation
- `src/backend/test/test_flow_rule.cc` — tests
- `src/backend/CMakeLists.txt` — build integration

Closes #38