### PR TITLE
feat: add VPP graph node logic (W7)

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -63,6 +63,20 @@ target_link_libraries(test_counter_table PRIVATE infmon_counter_table GTest::gte
 target_include_directories(test_counter_table PRIVATE include)
 add_test(NAME counter_table COMMAND test_counter_table)
 
+# --- Graph node library ---
+add_library(infmon_graph_node STATIC
+    src/graph_node.c
+)
+target_include_directories(infmon_graph_node PUBLIC include)
+target_link_libraries(infmon_graph_node PUBLIC infmon_parser infmon_flow_rule infmon_counter_table)
+
+add_executable(test_graph_node
+    test/test_graph_node.cc
+)
+target_link_libraries(test_graph_node PRIVATE infmon_graph_node GTest::gtest GTest::gtest_main)
+target_include_directories(test_graph_node PRIVATE include)
+add_test(NAME graph_node COMMAND test_graph_node)
+
 if(ENABLE_FUZZER)
     add_executable(fuzz_erspan_parser
         test/fuzz_erspan_parser.cc

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -119,7 +119,8 @@ typedef struct {
     uint16_t key_len;                     /*  4: length of key blob in bytes */
     uint16_t _pad;                        /*  6: alignment padding           */
     uint64_t key_hash;                    /*  8: full 64-bit hash            */
-    const uint8_t *key_ptr;               /* 16: pointer to key blob         */
+    uint64_t pkt_bytes;                   /* per-packet byte count           */
+    const uint8_t *key_ptr;               /* pointer to key blob             */
     uint8_t key_data[INFMON_KEY_BUF_MAX]; /* per-entry key copy  */
 } infmon_scratch_entry_t;
 
@@ -129,7 +130,7 @@ typedef struct {
  *             = 256 * 64 = 16384
  *
  * Sizing justification: 256 packets/frame x 64 rules = 16384 entries.
- * Each entry is ~88 bytes (with key_data), so ~1.4 MiB per worker.
+ * Each entry is ~96 bytes (with key_data + pkt_bytes), so ~1.5 MiB per worker.
  * With 4 workers that is ~5.6 MiB total TLS -- acceptable for a
  * dedicated appliance where VPP already consumes GiBs of hugepage.
  * A per-packet cap or dynamic allocation can be revisited in v2 if
@@ -193,7 +194,7 @@ bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed, const uint
  */
 uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
                            const infmon_flow_fields_t *fields, infmon_scratch_t *scratch,
-                           uint8_t *key_buf);
+                           uint8_t *key_buf, uint64_t pkt_bytes);
 
 /* ── Counter update (portable) ───────────────────────────────────── */
 
@@ -202,13 +203,11 @@ uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
  *
  * @param scratch   Per-worker scratch vector.
  * @param tables    Array of counter table pointers (indexed by flow_rule_index).
- * @param pkt_bytes Byte count of the packet.
  * @param tick      Current tick for LRU tracking.
  * @param insert_retry_exhausted  Incremented for each CAS-exhausted update.
  * @param table_full_count        Incremented for each table-full update.
  */
-void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table_t **tables,
-                           uint64_t pkt_bytes, uint64_t tick, uint64_t *insert_retry_exhausted,
+void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table_t **tables, uint64_t tick, uint64_t *insert_retry_exhausted,
                            uint64_t *table_full_count);
 
 /* ── Scratch vector helpers ──────────────────────────────────────── */

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -135,9 +135,8 @@ infmon_parse_result_t infmon_erspan_decap(const uint8_t *data, uint32_t len,
  *
  * @return true if extraction succeeded.
  */
-bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed,
-                                const uint8_t *inner, uint32_t inner_len,
-                                infmon_flow_fields_t *out);
+bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed, const uint8_t *inner,
+                                uint32_t inner_len, infmon_flow_fields_t *out);
 
 /**
  * Match one packet against all active flow rules, appending entries
@@ -153,8 +152,8 @@ bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed,
  *         with flow_rule_no_match counter).
  */
 uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
-                           const infmon_flow_fields_t *fields,
-                           infmon_scratch_t *scratch, uint8_t *key_buf);
+                           const infmon_flow_fields_t *fields, infmon_scratch_t *scratch,
+                           uint8_t *key_buf);
 
 /* ── Counter update (portable) ───────────────────────────────────── */
 
@@ -168,15 +167,13 @@ uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
  * @param insert_retry_exhausted  Incremented for each CAS-exhausted update.
  * @param table_full_count        Incremented for each table-full update.
  */
-void infmon_counter_update(const infmon_scratch_t *scratch,
-                           infmon_counter_table_t **tables, uint64_t pkt_bytes,
-                           uint64_t tick, uint64_t *insert_retry_exhausted,
+void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table_t **tables,
+                           uint64_t pkt_bytes, uint64_t tick, uint64_t *insert_retry_exhausted,
                            uint64_t *table_full_count);
 
 /* ── Scratch vector helpers ──────────────────────────────────────── */
 
-static inline void
-infmon_scratch_reset(infmon_scratch_t *scratch)
+static inline void infmon_scratch_reset(infmon_scratch_t *scratch)
 {
     scratch->count = 0;
 }

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * VPP graph node logic — see specs/004-backend-architecture.md §4, §9
+ *
+ * This header defines the per-worker scratch vector and the portable
+ * processing functions used by the VPP graph nodes.  The functions here
+ * are pure C with no VPP dependency so they can be unit-tested on any
+ * platform.
+ */
+
+#ifndef INFMON_GRAPH_NODE_H
+#define INFMON_GRAPH_NODE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "infmon/counter_table.h"
+#include "infmon/erspan_parser.h"
+#include "infmon/flow_rule.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Constants ───────────────────────────────────────────────────── */
+
+/** Maximum number of active flow rules per worker (v1 hard cap). */
+#define INFMON_MAX_ACTIVE_FLOW_RULES 64
+
+/** VPP frame size — maximum packets per batch. */
+#define INFMON_FRAME_SIZE 256
+
+/* ── Error counters (for VPP show errors) ────────────────────────── */
+
+typedef enum {
+    INFMON_NODE_ERR_ERSPAN_UNKNOWN_PROTO = 0,
+    INFMON_NODE_ERR_ERSPAN_TRUNCATED,
+    INFMON_NODE_ERR_INNER_PARSE_FAILED,
+    INFMON_NODE_ERR_FLOW_RULE_NO_MATCH,
+    INFMON_NODE_ERR_COUNTER_INSERT_RETRY_EXHAUSTED,
+    INFMON_NODE_ERR_COUNTER_TABLE_FULL,
+    INFMON_NODE_ERR__COUNT,
+} infmon_node_error_t;
+
+extern const char *infmon_node_error_names[];
+extern const char *infmon_node_error_strings[];
+
+/* ── Next-index enum for each node ───────────────────────────────── */
+
+typedef enum {
+    INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH = 0,
+    INFMON_ERSPAN_DECAP_NEXT_DROP,
+    INFMON_ERSPAN_DECAP_NEXT__COUNT,
+} infmon_erspan_decap_next_t;
+
+typedef enum {
+    INFMON_FLOW_MATCH_NEXT_COUNTER = 0,
+    INFMON_FLOW_MATCH_NEXT_DROP,
+    INFMON_FLOW_MATCH_NEXT__COUNT,
+} infmon_flow_match_next_t;
+
+typedef enum {
+    INFMON_COUNTER_NEXT_DROP = 0,
+    INFMON_COUNTER_NEXT__COUNT,
+} infmon_counter_next_t;
+
+/* ── Scratch vector entry (§9) ───────────────────────────────────── */
+
+/**
+ * One (flow_rule_index, key_hash, key_blob_ptr) triple.
+ * Size: 24 bytes on both 32-bit and 64-bit platforms.
+ */
+typedef struct {
+    uint32_t flow_rule_index; /*  0: index into flow_rule vector */
+    uint16_t key_len;         /*  4: length of key blob in bytes */
+    uint16_t _pad;            /*  6: alignment padding           */
+    uint64_t key_hash;        /*  8: full 64-bit hash            */
+    const uint8_t *key_ptr;   /* 16: pointer to key blob         */
+} infmon_scratch_entry_t;
+
+/**
+ * Per-worker scratch vector.  Statically sized, lives in TLS.
+ * Max entries = INFMON_FRAME_SIZE * INFMON_MAX_ACTIVE_FLOW_RULES
+ *             = 256 * 64 = 16384
+ * At 24 bytes each = 384 KiB per worker.
+ */
+typedef struct {
+    infmon_scratch_entry_t entries[INFMON_FRAME_SIZE * INFMON_MAX_ACTIVE_FLOW_RULES];
+    uint32_t count; /* number of valid entries this frame */
+} infmon_scratch_t;
+
+/* ── Key encoding buffer (per-worker, reused across packets) ─────── */
+
+/**
+ * Maximum possible key width: all 5 fields = 16+16+16+1+1 = 50 bytes.
+ * Round up to 64 for alignment.
+ */
+#define INFMON_KEY_BUF_MAX 64
+
+/* ── ERSPAN decap result (portable) ──────────────────────────────── */
+
+typedef struct {
+    infmon_parse_result_t parse_result;
+    infmon_parsed_packet_t parsed;
+    uint32_t inner_offset; /* byte offset from buffer start to inner frame */
+    uint32_t inner_len;    /* length of inner frame */
+} infmon_decap_result_t;
+
+/**
+ * Decapsulate one ERSPAN packet.
+ *
+ * @param data   Start of outer Ethernet frame.
+ * @param len    Total buffer length.
+ * @param out    Result (populated on success).
+ *
+ * @return  INFMON_PARSE_OK or INFMON_PARSE_INNER_TRUNCATED_OK on success;
+ *          an error code otherwise.  On success, out->inner_offset and
+ *          out->inner_len indicate where the inner frame begins.
+ */
+infmon_parse_result_t infmon_erspan_decap(const uint8_t *data, uint32_t len,
+                                          infmon_decap_result_t *out);
+
+/* ── Flow matching (portable) ────────────────────────────────────── */
+
+/**
+ * Extract normalised flow fields from a parsed packet.
+ *
+ * @param parsed  Parser output (from infmon_parse_erspan).
+ * @param inner   Pointer to start of inner Ethernet frame.
+ * @param inner_len  Length of inner frame.
+ * @param out     Normalised fields output.
+ *
+ * @return true if extraction succeeded.
+ */
+bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed,
+                                const uint8_t *inner, uint32_t inner_len,
+                                infmon_flow_fields_t *out);
+
+/**
+ * Match one packet against all active flow rules, appending entries
+ * to the scratch vector.
+ *
+ * @param rules       Array of active flow rules.
+ * @param rule_count  Number of active rules.
+ * @param fields      Normalised flow fields for this packet.
+ * @param scratch     Per-worker scratch vector (entries appended).
+ * @param key_buf     Scratch key buffer (at least INFMON_KEY_BUF_MAX bytes).
+ *
+ * @return Number of matches (0 = no match, packet should be dropped
+ *         with flow_rule_no_match counter).
+ */
+uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
+                           const infmon_flow_fields_t *fields,
+                           infmon_scratch_t *scratch, uint8_t *key_buf);
+
+/* ── Counter update (portable) ───────────────────────────────────── */
+
+/**
+ * Walk the scratch vector and update counter tables.
+ *
+ * @param scratch   Per-worker scratch vector.
+ * @param tables    Array of counter table pointers (indexed by flow_rule_index).
+ * @param pkt_bytes Byte count of the packet.
+ * @param tick      Current tick for LRU tracking.
+ * @param insert_retry_exhausted  Incremented for each CAS-exhausted update.
+ * @param table_full_count        Incremented for each table-full update.
+ */
+void infmon_counter_update(const infmon_scratch_t *scratch,
+                           infmon_counter_table_t **tables, uint64_t pkt_bytes,
+                           uint64_t tick, uint64_t *insert_retry_exhausted,
+                           uint64_t *table_full_count);
+
+/* ── Scratch vector helpers ──────────────────────────────────────── */
+
+static inline void
+infmon_scratch_reset(infmon_scratch_t *scratch)
+{
+    scratch->count = 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INFMON_GRAPH_NODE_H */

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -207,7 +207,8 @@ uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
  * @param insert_retry_exhausted  Incremented for each CAS-exhausted update.
  * @param table_full_count        Incremented for each table-full update.
  */
-void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table_t **tables, uint64_t tick, uint64_t *insert_retry_exhausted,
+void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table_t **tables,
+                           uint64_t tick, uint64_t *insert_retry_exhausted,
                            uint64_t *table_full_count);
 
 /* ── Scratch vector helpers ──────────────────────────────────────── */

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -115,11 +115,11 @@ typedef struct {
  * key buffer).
  */
 typedef struct {
-    uint32_t flow_rule_index; /*  0: index into flow_rule vector */
-    uint16_t key_len;         /*  4: length of key blob in bytes */
-    uint16_t _pad;            /*  6: alignment padding           */
-    uint64_t key_hash;        /*  8: full 64-bit hash            */
-    const uint8_t *key_ptr;   /* 16: pointer to key blob         */
+    uint32_t flow_rule_index;             /*  0: index into flow_rule vector */
+    uint16_t key_len;                     /*  4: length of key blob in bytes */
+    uint16_t _pad;                        /*  6: alignment padding           */
+    uint64_t key_hash;                    /*  8: full 64-bit hash            */
+    const uint8_t *key_ptr;               /* 16: pointer to key blob         */
     uint8_t key_data[INFMON_KEY_BUF_MAX]; /* per-entry key copy  */
 } infmon_scratch_entry_t;
 

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -67,30 +67,36 @@ typedef enum {
     INFMON_COUNTER_NEXT__COUNT,
 } infmon_counter_next_t;
 
-/* ── Scratch vector entry (§9) ───────────────────────────────────── */
+/* -- VPP buffer opaque (inter-node data) */
 
 /**
- * One (flow_rule_index, key_hash, key_blob_ptr) triple.
- * Size: 24 bytes on both 32-bit and 64-bit platforms.
+ * Data stashed in vlib_buffer opaque2 by infmon-erspan-decap for
+ * consumption by downstream nodes (infmon-flow-match).  Must fit in
+ * VLIB_BUFFER_OPAQUE2_SIZE (64 bytes).
  */
 typedef struct {
-    uint32_t flow_rule_index; /*  0: index into flow_rule vector */
-    uint16_t key_len;         /*  4: length of key blob in bytes */
-    uint16_t _pad;            /*  6: alignment padding           */
-    uint64_t key_hash;        /*  8: full 64-bit hash            */
-    const uint8_t *key_ptr;   /* 16: pointer to key blob         */
-} infmon_scratch_entry_t;
+    infmon_mirror_src_ip_t mirror_src_ip;
+} infmon_buffer_opaque_t;
+
+/* -- Atomic flow-rule reference (TOCTOU-safe) */
 
 /**
- * Per-worker scratch vector.  Statically sized, lives in TLS.
- * Max entries = INFMON_FRAME_SIZE * INFMON_MAX_ACTIVE_FLOW_RULES
- *             = 256 * 64 = 16384
- * At 24 bytes each = 384 KiB per worker.
+ * Packed pointer+count for single-pointer atomic swap.  The control
+ * plane allocates a new instance, populates it, then does a single
+ * __atomic_store_n of the pointer.  Data-plane loads it with ACQUIRE.
  */
 typedef struct {
-    infmon_scratch_entry_t entries[INFMON_FRAME_SIZE * INFMON_MAX_ACTIVE_FLOW_RULES];
-    uint32_t count; /* number of valid entries this frame */
-} infmon_scratch_t;
+    const infmon_flow_rule_t *rules;
+    uint32_t count;
+} infmon_flow_rule_set_ref_t;
+
+/* -- Shared plugin state (set by control plane) */
+
+typedef struct {
+    const infmon_flow_rule_set_ref_t *flow_rule_set;
+    infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES];
+    uint64_t tick;
+} infmon_plugin_main_t;
 
 /* ── Key encoding buffer (per-worker, reused across packets) ─────── */
 
@@ -99,6 +105,40 @@ typedef struct {
  * Round up to 64 for alignment.
  */
 #define INFMON_KEY_BUF_MAX 64
+
+/* ── Scratch vector entry (§9) ───────────────────────────────────── */
+
+/**
+ * One (flow_rule_index, key_hash, key_blob_ptr) triple.
+ * The key_data[] array stores a per-entry copy of the encoded key so that
+ * each scratch entry owns its key independently (no aliasing of a shared
+ * key buffer).
+ */
+typedef struct {
+    uint32_t flow_rule_index; /*  0: index into flow_rule vector */
+    uint16_t key_len;         /*  4: length of key blob in bytes */
+    uint16_t _pad;            /*  6: alignment padding           */
+    uint64_t key_hash;        /*  8: full 64-bit hash            */
+    const uint8_t *key_ptr;   /* 16: pointer to key blob         */
+    uint8_t key_data[INFMON_KEY_BUF_MAX]; /* per-entry key copy  */
+} infmon_scratch_entry_t;
+
+/**
+ * Per-worker scratch vector.  Statically sized, lives in TLS.
+ * Max entries = INFMON_FRAME_SIZE * INFMON_MAX_ACTIVE_FLOW_RULES
+ *             = 256 * 64 = 16384
+ *
+ * Sizing justification: 256 packets/frame x 64 rules = 16384 entries.
+ * Each entry is ~88 bytes (with key_data), so ~1.4 MiB per worker.
+ * With 4 workers that is ~5.6 MiB total TLS -- acceptable for a
+ * dedicated appliance where VPP already consumes GiBs of hugepage.
+ * A per-packet cap or dynamic allocation can be revisited in v2 if
+ * memory-constrained deployments appear.
+ */
+typedef struct {
+    infmon_scratch_entry_t entries[INFMON_FRAME_SIZE * INFMON_MAX_ACTIVE_FLOW_RULES];
+    uint32_t count; /* number of valid entries this frame */
+} infmon_scratch_t;
 
 /* ── ERSPAN decap result (portable) ──────────────────────────────── */
 

--- a/src/backend/src/graph_node.c
+++ b/src/backend/src/graph_node.c
@@ -36,7 +36,7 @@ const char *infmon_node_error_strings[] = {
 
 static inline uint16_t read_u16(const uint8_t *p)
 {
-    return (uint16_t)((uint16_t)p[0] << 8 | p[1]);
+    return (uint16_t) ((uint16_t) p[0] << 8 | p[1]);
 }
 
 /* ── Simple FNV-1a 64-bit hash ───────────────────────────────────── */
@@ -63,7 +63,7 @@ infmon_parse_result_t infmon_erspan_decap(const uint8_t *data, uint32_t len,
 
     if (rc == INFMON_PARSE_OK || rc == INFMON_PARSE_INNER_TRUNCATED_OK) {
         /* Compute inner_offset as the difference between inner_ptr and data */
-        out->inner_offset = (uint32_t)(out->parsed.inner_ptr - data);
+        out->inner_offset = (uint32_t) (out->parsed.inner_ptr - data);
         out->inner_len = out->parsed.inner_len;
     }
 
@@ -72,9 +72,8 @@ infmon_parse_result_t infmon_erspan_decap(const uint8_t *data, uint32_t len,
 
 /* ── Flow field extraction ───────────────────────────────────────── */
 
-bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed,
-                                const uint8_t *inner, uint32_t inner_len,
-                                infmon_flow_fields_t *out)
+bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed, const uint8_t *inner,
+                                uint32_t inner_len, infmon_flow_fields_t *out)
 {
     memset(out, 0, sizeof(*out));
 
@@ -105,8 +104,7 @@ bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed,
     if (inner_len < inner_l3_off + 1)
         return false;
 
-    uint16_t inner_et = (inner_l3_off == 14) ? read_u16(inner + 12)
-                                              : read_u16(inner + 16);
+    uint16_t inner_et = (inner_l3_off == 14) ? read_u16(inner + 12) : read_u16(inner + 16);
 
     if (inner_et == 0x0800) {
         /* IPv4 */
@@ -152,8 +150,8 @@ bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed,
 /* ── Flow matching ───────────────────────────────────────────────── */
 
 uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
-                           const infmon_flow_fields_t *fields,
-                           infmon_scratch_t *scratch, uint8_t *key_buf)
+                           const infmon_flow_fields_t *fields, infmon_scratch_t *scratch,
+                           uint8_t *key_buf)
 {
     if (!rules || !fields || !scratch || !key_buf)
         return 0;
@@ -180,7 +178,7 @@ uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
         if (scratch->count < INFMON_FRAME_SIZE * INFMON_MAX_ACTIVE_FLOW_RULES) {
             infmon_scratch_entry_t *e = &scratch->entries[scratch->count++];
             e->flow_rule_index = i;
-            e->key_len = (uint16_t)kw;
+            e->key_len = (uint16_t) kw;
             e->_pad = 0;
             e->key_hash = hash;
             e->key_ptr = key_buf;
@@ -193,9 +191,8 @@ uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
 
 /* ── Counter update ──────────────────────────────────────────────── */
 
-void infmon_counter_update(const infmon_scratch_t *scratch,
-                           infmon_counter_table_t **tables, uint64_t pkt_bytes,
-                           uint64_t tick, uint64_t *insert_retry_exhausted,
+void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table_t **tables,
+                           uint64_t pkt_bytes, uint64_t tick, uint64_t *insert_retry_exhausted,
                            uint64_t *table_full_count)
 {
     if (!scratch || !tables)
@@ -211,8 +208,8 @@ void infmon_counter_update(const infmon_scratch_t *scratch,
         if (e->key_len == 0)
             continue; /* safety: skip entries with no key width */
 
-        bool ok = infmon_counter_table_update(table, e->key_hash, e->key_ptr,
-                                              e->key_len, pkt_bytes, tick);
+        bool ok = infmon_counter_table_update(table, e->key_hash, e->key_ptr, e->key_len, pkt_bytes,
+                                              tick);
 
         if (!ok) {
             /* Distinguish: table full vs CAS exhausted.

--- a/src/backend/src/graph_node.c
+++ b/src/backend/src/graph_node.c
@@ -216,8 +216,8 @@ void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table
         if (e->key_len == 0)
             continue; /* safety: skip entries with no key width */
 
-        bool ok = infmon_counter_table_update(table, e->key_hash, e->key_ptr, e->key_len, e->pkt_bytes,
-                                              tick);
+        bool ok = infmon_counter_table_update(table, e->key_hash, e->key_ptr, e->key_len,
+                                              e->pkt_bytes, tick);
 
         if (!ok) {
             /* Distinguish: table full vs CAS exhausted.  Note: reading

--- a/src/backend/src/graph_node.c
+++ b/src/backend/src/graph_node.c
@@ -86,8 +86,10 @@ bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed, const uint
         out->mirror_src_ip[10] = 0xff;
         out->mirror_src_ip[11] = 0xff;
         memcpy(out->mirror_src_ip + 12, parsed->mirror_src_ip.addr.v4, 4);
-    } else {
+    } else if (parsed->mirror_src_ip.family == INFMON_AF_V6) {
         memcpy(out->mirror_src_ip, parsed->mirror_src_ip.addr.v6, 16);
+    } else {
+        return false; /* unknown address family */
     }
 
     /* Inner L3 addresses and protocol */
@@ -98,6 +100,9 @@ bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed, const uint
         uint16_t inner_et = read_u16(inner + 12);
         if (inner_et == 0x8100) {
             inner_l3_off = 18;
+        } else if (inner_et == 0x88a8) {
+            /* QinQ / 802.1ad -- not supported in v1 */
+            return false;
         }
     }
 
@@ -181,7 +186,9 @@ uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
             e->key_len = (uint16_t) kw;
             e->_pad = 0;
             e->key_hash = hash;
-            e->key_ptr = key_buf;
+            /* Copy key into per-entry storage to avoid aliasing */
+            memcpy(e->key_data, key_buf, kw);
+            e->key_ptr = e->key_data;
             matches++;
         }
     }
@@ -212,9 +219,11 @@ void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table
                                               tick);
 
         if (!ok) {
-            /* Distinguish: table full vs CAS exhausted.
-             * The counter_table_update doesn't distinguish these — it returns
-             * false for both. Check table stats. */
+            /* Distinguish: table full vs CAS exhausted.  Note: reading
+             * occupied_count after the failed update is racy (another
+             * worker could have changed it), but this is best-effort
+             * diagnostics -- exact attribution requires returning an
+             * enum from counter_table_update (tracked for v2). */
             if (table->occupied_count >= table->num_slots) {
                 if (table_full_count)
                     (*table_full_count)++;

--- a/src/backend/src/graph_node.c
+++ b/src/backend/src/graph_node.c
@@ -1,0 +1,230 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * VPP graph node logic — see specs/004-backend-architecture.md §4, §9
+ *
+ * Portable processing functions used by the VPP graph nodes.
+ * No VPP dependency — all VPP-specific wiring lives in vpp/infmon_nodes.c.
+ */
+
+#include "infmon/graph_node.h"
+
+#include <string.h>
+
+/* ── Error counter metadata ──────────────────────────────────────── */
+
+const char *infmon_node_error_names[] = {
+    [INFMON_NODE_ERR_ERSPAN_UNKNOWN_PROTO] = "erspan_unknown_proto",
+    [INFMON_NODE_ERR_ERSPAN_TRUNCATED] = "erspan_truncated",
+    [INFMON_NODE_ERR_INNER_PARSE_FAILED] = "inner_parse_failed",
+    [INFMON_NODE_ERR_FLOW_RULE_NO_MATCH] = "flow_rule_no_match",
+    [INFMON_NODE_ERR_COUNTER_INSERT_RETRY_EXHAUSTED] = "counter_insert_retry_exhausted",
+    [INFMON_NODE_ERR_COUNTER_TABLE_FULL] = "counter_table_full",
+};
+
+const char *infmon_node_error_strings[] = {
+    [INFMON_NODE_ERR_ERSPAN_UNKNOWN_PROTO] = "Outer header parsed but ERSPAN type unrecognised",
+    [INFMON_NODE_ERR_ERSPAN_TRUNCATED] = "Buffer too short for declared ERSPAN header",
+    [INFMON_NODE_ERR_INNER_PARSE_FAILED] = "Inner L2/L3/L4 parse error after decap",
+    [INFMON_NODE_ERR_FLOW_RULE_NO_MATCH] = "Packet matched zero flow rules",
+    [INFMON_NODE_ERR_COUNTER_INSERT_RETRY_EXHAUSTED] = "CAS retries exceeded INFMON_INSERT_RETRY",
+    [INFMON_NODE_ERR_COUNTER_TABLE_FULL] = "Table reached max_keys_per_flow_rule",
+};
+
+/* ── Helpers ──────────────────────────────────────────────────────── */
+
+static inline uint16_t read_u16(const uint8_t *p)
+{
+    return (uint16_t)((uint16_t)p[0] << 8 | p[1]);
+}
+
+/* ── Simple FNV-1a 64-bit hash ───────────────────────────────────── */
+
+static uint64_t fnv1a_64(const uint8_t *data, uint32_t len)
+{
+    uint64_t h = 0xcbf29ce484222325ULL;
+    for (uint32_t i = 0; i < len; i++) {
+        h ^= data[i];
+        h *= 0x100000001b3ULL;
+    }
+    return h;
+}
+
+/* ── ERSPAN decap ────────────────────────────────────────────────── */
+
+infmon_parse_result_t infmon_erspan_decap(const uint8_t *data, uint32_t len,
+                                          infmon_decap_result_t *out)
+{
+    memset(out, 0, sizeof(*out));
+
+    infmon_parse_result_t rc = infmon_parse_erspan(data, len, &out->parsed);
+    out->parse_result = rc;
+
+    if (rc == INFMON_PARSE_OK || rc == INFMON_PARSE_INNER_TRUNCATED_OK) {
+        /* Compute inner_offset as the difference between inner_ptr and data */
+        out->inner_offset = (uint32_t)(out->parsed.inner_ptr - data);
+        out->inner_len = out->parsed.inner_len;
+    }
+
+    return rc;
+}
+
+/* ── Flow field extraction ───────────────────────────────────────── */
+
+bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed,
+                                const uint8_t *inner, uint32_t inner_len,
+                                infmon_flow_fields_t *out)
+{
+    memset(out, 0, sizeof(*out));
+
+    if (!parsed || !inner)
+        return false;
+
+    /* Mirror source IP — always IPv4-mapped-IPv6 in the normalised struct */
+    if (parsed->mirror_src_ip.family == INFMON_AF_V4) {
+        /* ::ffff:x.x.x.x */
+        out->mirror_src_ip[10] = 0xff;
+        out->mirror_src_ip[11] = 0xff;
+        memcpy(out->mirror_src_ip + 12, parsed->mirror_src_ip.addr.v4, 4);
+    } else {
+        memcpy(out->mirror_src_ip, parsed->mirror_src_ip.addr.v6, 16);
+    }
+
+    /* Inner L3 addresses and protocol */
+    uint32_t inner_l3_off = 14;
+
+    /* Handle inner VLAN */
+    if (inner_len >= 16) {
+        uint16_t inner_et = read_u16(inner + 12);
+        if (inner_et == 0x8100) {
+            inner_l3_off = 18;
+        }
+    }
+
+    if (inner_len < inner_l3_off + 1)
+        return false;
+
+    uint16_t inner_et = (inner_l3_off == 14) ? read_u16(inner + 12)
+                                              : read_u16(inner + 16);
+
+    if (inner_et == 0x0800) {
+        /* IPv4 */
+        if (inner_len < inner_l3_off + 20)
+            return false;
+
+        out->ip_proto = inner[inner_l3_off + 9];
+
+        /* DSCP: top 6 bits of TOS byte (offset +1) */
+        out->dscp = (inner[inner_l3_off + 1] >> 2) & 0x3F;
+
+        /* src_ip and dst_ip as IPv4-mapped-IPv6 */
+        out->src_ip[10] = 0xff;
+        out->src_ip[11] = 0xff;
+        memcpy(out->src_ip + 12, inner + inner_l3_off + 12, 4);
+
+        out->dst_ip[10] = 0xff;
+        out->dst_ip[11] = 0xff;
+        memcpy(out->dst_ip + 12, inner + inner_l3_off + 16, 4);
+    } else if (inner_et == 0x86DD) {
+        /* IPv6 */
+        if (inner_len < inner_l3_off + 40)
+            return false;
+
+        out->ip_proto = inner[inner_l3_off + 6];
+
+        /* DSCP: bits 4-9 of the first 32-bit word (Traffic Class top 6 bits) */
+        uint8_t tc_hi = (inner[inner_l3_off] & 0x0F) << 4;
+        uint8_t tc_lo = (inner[inner_l3_off + 1] >> 4) & 0x0F;
+        uint8_t tc = tc_hi | tc_lo;
+        out->dscp = (tc >> 2) & 0x3F;
+
+        memcpy(out->src_ip, inner + inner_l3_off + 8, 16);
+        memcpy(out->dst_ip, inner + inner_l3_off + 24, 16);
+    } else {
+        /* Non-IP inner frame — can't extract flow fields */
+        return false;
+    }
+
+    return true;
+}
+
+/* ── Flow matching ───────────────────────────────────────────────── */
+
+uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
+                           const infmon_flow_fields_t *fields,
+                           infmon_scratch_t *scratch, uint8_t *key_buf)
+{
+    if (!rules || !fields || !scratch || !key_buf)
+        return 0;
+
+    uint32_t matches = 0;
+
+    for (uint32_t i = 0; i < rule_count && i < INFMON_MAX_ACTIVE_FLOW_RULES; i++) {
+        const infmon_flow_rule_t *rule = &rules[i];
+
+        /* v1: no filter expression — every packet matches every rule.
+         * Filter evaluation would go here in v2. */
+
+        /* Encode key */
+        infmon_flow_rule_encode_key(rule, fields, key_buf);
+
+        /* Hash */
+        uint32_t kw = rule->key_width;
+        if (kw == 0)
+            kw = infmon_flow_rule_key_width(rule->fields, rule->field_count);
+
+        uint64_t hash = fnv1a_64(key_buf, kw);
+
+        /* Append to scratch */
+        if (scratch->count < INFMON_FRAME_SIZE * INFMON_MAX_ACTIVE_FLOW_RULES) {
+            infmon_scratch_entry_t *e = &scratch->entries[scratch->count++];
+            e->flow_rule_index = i;
+            e->key_len = (uint16_t)kw;
+            e->_pad = 0;
+            e->key_hash = hash;
+            e->key_ptr = key_buf;
+            matches++;
+        }
+    }
+
+    return matches;
+}
+
+/* ── Counter update ──────────────────────────────────────────────── */
+
+void infmon_counter_update(const infmon_scratch_t *scratch,
+                           infmon_counter_table_t **tables, uint64_t pkt_bytes,
+                           uint64_t tick, uint64_t *insert_retry_exhausted,
+                           uint64_t *table_full_count)
+{
+    if (!scratch || !tables)
+        return;
+
+    for (uint32_t i = 0; i < scratch->count; i++) {
+        const infmon_scratch_entry_t *e = &scratch->entries[i];
+        infmon_counter_table_t *table = tables[e->flow_rule_index];
+
+        if (!table)
+            continue;
+
+        if (e->key_len == 0)
+            continue; /* safety: skip entries with no key width */
+
+        bool ok = infmon_counter_table_update(table, e->key_hash, e->key_ptr,
+                                              e->key_len, pkt_bytes, tick);
+
+        if (!ok) {
+            /* Distinguish: table full vs CAS exhausted.
+             * The counter_table_update doesn't distinguish these — it returns
+             * false for both. Check table stats. */
+            if (table->occupied_count >= table->num_slots) {
+                if (table_full_count)
+                    (*table_full_count)++;
+            } else {
+                if (insert_retry_exhausted)
+                    (*insert_retry_exhausted)++;
+            }
+        }
+    }
+}

--- a/src/backend/src/graph_node.c
+++ b/src/backend/src/graph_node.c
@@ -156,7 +156,7 @@ bool infmon_extract_flow_fields(const infmon_parsed_packet_t *parsed, const uint
 
 uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
                            const infmon_flow_fields_t *fields, infmon_scratch_t *scratch,
-                           uint8_t *key_buf)
+                           uint8_t *key_buf, uint64_t pkt_bytes)
 {
     if (!rules || !fields || !scratch || !key_buf)
         return 0;
@@ -189,6 +189,7 @@ uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
             /* Copy key into per-entry storage to avoid aliasing */
             memcpy(e->key_data, key_buf, kw);
             e->key_ptr = e->key_data;
+            e->pkt_bytes = pkt_bytes;
             matches++;
         }
     }
@@ -199,7 +200,7 @@ uint32_t infmon_flow_match(const infmon_flow_rule_t *rules, uint32_t rule_count,
 /* ── Counter update ──────────────────────────────────────────────── */
 
 void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table_t **tables,
-                           uint64_t pkt_bytes, uint64_t tick, uint64_t *insert_retry_exhausted,
+                           uint64_t tick, uint64_t *insert_retry_exhausted,
                            uint64_t *table_full_count)
 {
     if (!scratch || !tables)
@@ -215,7 +216,7 @@ void infmon_counter_update(const infmon_scratch_t *scratch, infmon_counter_table
         if (e->key_len == 0)
             continue; /* safety: skip entries with no key width */
 
-        bool ok = infmon_counter_table_update(table, e->key_hash, e->key_ptr, e->key_len, pkt_bytes,
+        bool ok = infmon_counter_table_update(table, e->key_hash, e->key_ptr, e->key_len, e->pkt_bytes,
                                               tick);
 
         if (!ok) {

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -233,8 +233,7 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
         uint32_t matches = 0;
         if (extracted && rules && rule_count > 0) {
             matches = infmon_flow_match(rules, rule_count, &fields, &infmon_tls_scratch,
-                                        infmon_tls_key_buf,
-                                        vlib_buffer_length_in_chain(vm, b));
+                                        infmon_tls_key_buf, vlib_buffer_length_in_chain(vm, b));
         }
 
         if (matches > 0) {
@@ -311,8 +310,7 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
     }
 
     /* Update counters once for the entire scratch vector */
-    infmon_counter_update(&infmon_tls_scratch, tables, tick, &insert_retry,
-                          &table_full);
+    infmon_counter_update(&infmon_tls_scratch, tables, tick, &insert_retry, &table_full);
 
     node->errors[INFMON_NODE_ERR_COUNTER_INSERT_RETRY_EXHAUSTED] += insert_retry;
     node->errors[INFMON_NODE_ERR_COUNTER_TABLE_FULL] += table_full;

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -86,7 +86,7 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
                 b->current_length = dr.inner_len;
 
                 /* Stash mirror_src_ip in buffer opaque for flow-match node */
-                infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *)vlib_buffer_get_opaque2(b);
+                infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) vlib_buffer_get_opaque2(b);
                 op->mirror_src_ip = dr.parsed.mirror_src_ip;
 
                 to_next_match[0] = bi;
@@ -138,7 +138,7 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
             b->current_length = dr.inner_len;
 
             /* Stash mirror_src_ip in buffer opaque for flow-match node */
-            infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *)vlib_buffer_get_opaque2(b);
+            infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) vlib_buffer_get_opaque2(b);
             op->mirror_src_ip = dr.parsed.mirror_src_ip;
 
             to_next_match[0] = bi;
@@ -182,7 +182,7 @@ VLIB_REGISTER_NODE(infmon_erspan_decap_node) = {
     .vector_size = sizeof(u32),
     .format_trace = format_infmon_erspan_decap_trace,
     .type = VLIB_NODE_TYPE_INTERNAL,
-    .n_errors = INFMON_NODE_ERR__COUNT,    /* shared enum; unused counters read zero */
+    .n_errors = INFMON_NODE_ERR__COUNT,         /* shared enum; unused counters read zero */
     .error_strings = infmon_node_error_strings, /* per-node subsets deferred to v2 */
     .n_next_nodes = INFMON_ERSPAN_DECAP_NEXT__COUNT,
     .next_nodes =
@@ -222,7 +222,7 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
         const uint8_t *inner = vlib_buffer_get_current(b);
         uint32_t inner_len = b->current_length;
 
-        infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *)vlib_buffer_get_opaque2(b);
+        infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) vlib_buffer_get_opaque2(b);
         infmon_parsed_packet_t parsed_pkt;
         memset(&parsed_pkt, 0, sizeof(parsed_pkt));
         parsed_pkt.mirror_src_ip = op->mirror_src_ip;

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -28,20 +28,8 @@ static __thread uint8_t infmon_tls_key_buf[INFMON_KEY_BUF_MAX];
 
 /* ── Shared plugin state (set by control plane) ──────────────────── */
 
-typedef struct {
-    /* Flow rules — loaded once per frame with ACQUIRE. */
-    const infmon_flow_rule_t *flow_rules;
-    uint32_t flow_rule_count;
-
-    /* Counter tables — one per flow_rule_index.
-     * Loaded once per frame with ACQUIRE for atomic swap support. */
-    infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES];
-
-    /* Tick counter for LRU tracking (bumped once per frame). */
-    uint64_t tick;
-} infmon_plugin_main_t;
-
-extern infmon_plugin_main_t infmon_plugin_main;
+/* -- Shared plugin state (definition in graph_node.h) */
+infmon_plugin_main_t infmon_plugin_main;
 
 /* ════════════════════════════════════════════════════════════════════
  *  Node 1: infmon-erspan-decap
@@ -70,12 +58,12 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
     u32 n_left = frame->n_vectors;
     u32 *from = vlib_frame_vector_args(frame);
     u32 *to_next_match, *to_next_drop;
-    u32 n_match = 0, n_drop = 0;
+    u32 n_left_match = 0, n_left_drop = 0;
     u16 next_match = INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH;
     u16 next_drop = INFMON_ERSPAN_DECAP_NEXT_DROP;
 
-    vlib_get_next_frame(vm, node, next_match, to_next_match, n_match);
-    vlib_get_next_frame(vm, node, next_drop, to_next_drop, n_drop);
+    vlib_get_next_frame(vm, node, next_match, to_next_match, n_left_match);
+    vlib_get_next_frame(vm, node, next_drop, to_next_drop, n_left_drop);
 
     /* ── Dual loop ──────────────────────────────────────────────── */
     while (n_left >= 4) {
@@ -97,9 +85,13 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
                 vlib_buffer_advance(b, (i32) dr.inner_offset);
                 b->current_length = dr.inner_len;
 
+                /* Stash mirror_src_ip in buffer opaque for flow-match node */
+                infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *)vlib_buffer_get_opaque2(b);
+                op->mirror_src_ip = dr.parsed.mirror_src_ip;
+
                 to_next_match[0] = bi;
                 to_next_match++;
-                n_match++;
+                n_left_match--;
             } else {
                 /* Map parse error to node error counter */
                 infmon_node_error_t err;
@@ -116,7 +108,7 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
 
                 to_next_drop[0] = bi;
                 to_next_drop++;
-                n_drop++;
+                n_left_drop--;
             }
 
             if (PREDICT_FALSE(b->flags & VLIB_BUFFER_IS_TRACED)) {
@@ -144,9 +136,14 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
         if (rc == INFMON_PARSE_OK || rc == INFMON_PARSE_INNER_TRUNCATED_OK) {
             vlib_buffer_advance(b, (i32) dr.inner_offset);
             b->current_length = dr.inner_len;
+
+            /* Stash mirror_src_ip in buffer opaque for flow-match node */
+            infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *)vlib_buffer_get_opaque2(b);
+            op->mirror_src_ip = dr.parsed.mirror_src_ip;
+
             to_next_match[0] = bi;
             to_next_match++;
-            n_match++;
+            n_left_match--;
         } else {
             infmon_node_error_t err;
             if (rc == INFMON_PARSE_ERR_GRE_BAD_PROTO || rc == INFMON_PARSE_ERR_ERSPAN_BAD_VERSION)
@@ -159,7 +156,7 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
             node->errors[err]++;
             to_next_drop[0] = bi;
             to_next_drop++;
-            n_drop++;
+            n_left_drop--;
         }
 
         if (PREDICT_FALSE(b->flags & VLIB_BUFFER_IS_TRACED)) {
@@ -173,8 +170,8 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
         n_left--;
     }
 
-    vlib_put_next_frame(vm, node, next_match, n_match);
-    vlib_put_next_frame(vm, node, next_drop, n_drop);
+    vlib_put_next_frame(vm, node, next_match, n_left_match);
+    vlib_put_next_frame(vm, node, next_drop, n_left_drop);
 
     return frame->n_vectors;
 }
@@ -185,8 +182,8 @@ VLIB_REGISTER_NODE(infmon_erspan_decap_node) = {
     .vector_size = sizeof(u32),
     .format_trace = format_infmon_erspan_decap_trace,
     .type = VLIB_NODE_TYPE_INTERNAL,
-    .n_errors = INFMON_NODE_ERR__COUNT,
-    .error_strings = infmon_node_error_strings,
+    .n_errors = INFMON_NODE_ERR__COUNT,    /* shared enum; unused counters read zero */
+    .error_strings = infmon_node_error_strings, /* per-node subsets deferred to v2 */
     .n_next_nodes = INFMON_ERSPAN_DECAP_NEXT__COUNT,
     .next_nodes =
         {
@@ -207,16 +204,17 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
     u32 *from = vlib_frame_vector_args(frame);
 
     /* Load flow rules with ACQUIRE once per frame (§8) */
-    const infmon_flow_rule_t *rules = __atomic_load_n(&pm->flow_rules, __ATOMIC_ACQUIRE);
-    uint32_t rule_count = __atomic_load_n(&pm->flow_rule_count, __ATOMIC_ACQUIRE);
+    const infmon_flow_rule_set_ref_t *rs = __atomic_load_n(&pm->flow_rule_set, __ATOMIC_ACQUIRE);
+    const infmon_flow_rule_t *rules = rs ? rs->rules : NULL;
+    uint32_t rule_count = rs ? rs->count : 0;
 
     infmon_scratch_reset(&infmon_tls_scratch);
 
     u32 *to_next_counter, *to_next_drop;
-    u32 n_counter = 0, n_drop = 0;
+    u32 n_left_counter = 0, n_left_drop = 0;
 
-    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_COUNTER, to_next_counter, n_counter);
-    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_DROP, to_next_drop, n_drop);
+    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_COUNTER, to_next_counter, n_left_counter);
+    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_DROP, to_next_drop, n_left_drop);
 
     while (n_left > 0) {
         u32 bi = from[0];
@@ -224,8 +222,13 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
         const uint8_t *inner = vlib_buffer_get_current(b);
         uint32_t inner_len = b->current_length;
 
+        infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *)vlib_buffer_get_opaque2(b);
+        infmon_parsed_packet_t parsed_pkt;
+        memset(&parsed_pkt, 0, sizeof(parsed_pkt));
+        parsed_pkt.mirror_src_ip = op->mirror_src_ip;
+
         infmon_flow_fields_t fields;
-        bool extracted = infmon_extract_flow_fields(NULL, inner, inner_len, &fields);
+        bool extracted = infmon_extract_flow_fields(&parsed_pkt, inner, inner_len, &fields);
 
         uint32_t matches = 0;
         if (extracted && rules && rule_count > 0) {
@@ -236,20 +239,20 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
         if (matches > 0) {
             to_next_counter[0] = bi;
             to_next_counter++;
-            n_counter++;
+            n_left_counter--;
         } else {
             node->errors[INFMON_NODE_ERR_FLOW_RULE_NO_MATCH]++;
             to_next_drop[0] = bi;
             to_next_drop++;
-            n_drop++;
+            n_left_drop--;
         }
 
         from++;
         n_left--;
     }
 
-    vlib_put_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_COUNTER, n_counter);
-    vlib_put_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_DROP, n_drop);
+    vlib_put_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_COUNTER, n_left_counter);
+    vlib_put_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_DROP, n_left_drop);
 
     return frame->n_vectors;
 }
@@ -292,32 +295,25 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
 
     /* All packets go to drop (InFMon never forwards) */
     u32 *to_next;
-    u32 n_next = 0;
-    vlib_get_next_frame(vm, node, INFMON_COUNTER_NEXT_DROP, to_next, n_next);
+    u32 n_left_next = 0;
+    vlib_get_next_frame(vm, node, INFMON_COUNTER_NEXT_DROP, to_next, n_left_next);
 
-    /* Walk scratch vector for counter updates */
-    /* Note: pkt_bytes should be per-packet, but for batch efficiency
-     * we process the entire scratch in one call. The scratch was filled
-     * by flow-match for all packets in this frame. For correct per-packet
-     * byte counts, the VPP integration would need to store pkt_bytes
-     * in the scratch entry or pass it separately. For v1, use average. */
+    uint64_t total_bytes = 0;
     while (n_left > 0) {
         u32 bi = from[0];
         vlib_buffer_t *b = vlib_get_buffer(vm, bi);
-
-        /* Each packet's byte contribution */
-        uint64_t pkt_bytes = vlib_buffer_length_in_chain(vm, b);
-
-        /* Update counters for this packet's scratch entries */
-        infmon_counter_update(&infmon_tls_scratch, tables, pkt_bytes, tick, &insert_retry,
-                              &table_full);
+        total_bytes += vlib_buffer_length_in_chain(vm, b);
 
         to_next[0] = bi;
         to_next++;
-        n_next++;
+        n_left_next--;
         from++;
         n_left--;
     }
+
+    /* Update counters once for the entire scratch vector */
+    infmon_counter_update(&infmon_tls_scratch, tables, total_bytes, tick, &insert_retry,
+                          &table_full);
 
     node->errors[INFMON_NODE_ERR_COUNTER_INSERT_RETRY_EXHAUSTED] += insert_retry;
     node->errors[INFMON_NODE_ERR_COUNTER_TABLE_FULL] += table_full;
@@ -325,7 +321,7 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
     /* Reset scratch for next frame */
     infmon_scratch_reset(&infmon_tls_scratch);
 
-    vlib_put_next_frame(vm, node, INFMON_COUNTER_NEXT_DROP, n_next);
+    vlib_put_next_frame(vm, node, INFMON_COUNTER_NEXT_DROP, n_left_next);
 
     return frame->n_vectors;
 }

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -233,7 +233,8 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
         uint32_t matches = 0;
         if (extracted && rules && rule_count > 0) {
             matches = infmon_flow_match(rules, rule_count, &fields, &infmon_tls_scratch,
-                                        infmon_tls_key_buf);
+                                        infmon_tls_key_buf,
+                                        vlib_buffer_length_in_chain(vm, b));
         }
 
         if (matches > 0) {
@@ -298,11 +299,9 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
     u32 n_left_next = 0;
     vlib_get_next_frame(vm, node, INFMON_COUNTER_NEXT_DROP, to_next, n_left_next);
 
-    uint64_t total_bytes = 0;
     while (n_left > 0) {
         u32 bi = from[0];
         vlib_buffer_t *b = vlib_get_buffer(vm, bi);
-        total_bytes += vlib_buffer_length_in_chain(vm, b);
 
         to_next[0] = bi;
         to_next++;
@@ -312,7 +311,7 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
     }
 
     /* Update counters once for the entire scratch vector */
-    infmon_counter_update(&infmon_tls_scratch, tables, total_bytes, tick, &insert_retry,
+    infmon_counter_update(&infmon_tls_scratch, tables, tick, &insert_retry,
                           &table_full);
 
     node->errors[INFMON_NODE_ERR_COUNTER_INSERT_RETRY_EXHAUSTED] += insert_retry;

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -16,8 +16,8 @@
 #ifdef INFMON_VPP_BUILD
 
 #include <vlib/vlib.h>
-#include <vnet/vnet.h>
 #include <vnet/pg/pg.h>
+#include <vnet/vnet.h>
 
 #include "infmon/graph_node.h"
 
@@ -53,21 +53,19 @@ typedef struct {
     uint32_t inner_len;
 } infmon_erspan_decap_trace_t;
 
-static u8 *
-format_infmon_erspan_decap_trace(u8 *s, va_list *args)
+static u8 *format_infmon_erspan_decap_trace(u8 *s, va_list *args)
 {
     CLIB_UNUSED(vlib_main_t * vm) = va_arg(*args, vlib_main_t *);
     CLIB_UNUSED(vlib_node_t * node) = va_arg(*args, vlib_node_t *);
     infmon_erspan_decap_trace_t *t = va_arg(*args, infmon_erspan_decap_trace_t *);
 
-    s = format(s, "infmon-erspan-decap: result=%d inner_offset=%u inner_len=%u",
-               t->result, t->inner_offset, t->inner_len);
+    s = format(s, "infmon-erspan-decap: result=%d inner_offset=%u inner_len=%u", t->result,
+               t->inner_offset, t->inner_len);
     return s;
 }
 
-static uword
-infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
-                            vlib_frame_t *frame)
+static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
+                                         vlib_frame_t *frame)
 {
     u32 n_left = frame->n_vectors;
     u32 *from = vlib_frame_vector_args(frame);
@@ -96,7 +94,7 @@ infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
 
             if (rc == INFMON_PARSE_OK || rc == INFMON_PARSE_INNER_TRUNCATED_OK) {
                 /* Advance buffer to inner frame */
-                vlib_buffer_advance(b, (i32)dr.inner_offset);
+                vlib_buffer_advance(b, (i32) dr.inner_offset);
                 b->current_length = dr.inner_len;
 
                 to_next_match[0] = bi;
@@ -122,8 +120,7 @@ infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
             }
 
             if (PREDICT_FALSE(b->flags & VLIB_BUFFER_IS_TRACED)) {
-                infmon_erspan_decap_trace_t *t =
-                    vlib_add_trace(vm, node, b, sizeof(*t));
+                infmon_erspan_decap_trace_t *t = vlib_add_trace(vm, node, b, sizeof(*t));
                 t->result = rc;
                 t->inner_offset = dr.inner_offset;
                 t->inner_len = dr.inner_len;
@@ -145,15 +142,14 @@ infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
         infmon_parse_result_t rc = infmon_erspan_decap(data, len, &dr);
 
         if (rc == INFMON_PARSE_OK || rc == INFMON_PARSE_INNER_TRUNCATED_OK) {
-            vlib_buffer_advance(b, (i32)dr.inner_offset);
+            vlib_buffer_advance(b, (i32) dr.inner_offset);
             b->current_length = dr.inner_len;
             to_next_match[0] = bi;
             to_next_match++;
             n_match++;
         } else {
             infmon_node_error_t err;
-            if (rc == INFMON_PARSE_ERR_GRE_BAD_PROTO ||
-                rc == INFMON_PARSE_ERR_ERSPAN_BAD_VERSION)
+            if (rc == INFMON_PARSE_ERR_GRE_BAD_PROTO || rc == INFMON_PARSE_ERR_ERSPAN_BAD_VERSION)
                 err = INFMON_NODE_ERR_ERSPAN_UNKNOWN_PROTO;
             else if (rc == INFMON_PARSE_ERR_ERSPAN_TRUNCATED ||
                      rc == INFMON_PARSE_ERR_OUTER_TRUNCATED)
@@ -167,8 +163,7 @@ infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
         }
 
         if (PREDICT_FALSE(b->flags & VLIB_BUFFER_IS_TRACED)) {
-            infmon_erspan_decap_trace_t *t =
-                vlib_add_trace(vm, node, b, sizeof(*t));
+            infmon_erspan_decap_trace_t *t = vlib_add_trace(vm, node, b, sizeof(*t));
             t->result = rc;
             t->inner_offset = dr.inner_offset;
             t->inner_len = dr.inner_len;
@@ -193,39 +188,35 @@ VLIB_REGISTER_NODE(infmon_erspan_decap_node) = {
     .n_errors = INFMON_NODE_ERR__COUNT,
     .error_strings = infmon_node_error_strings,
     .n_next_nodes = INFMON_ERSPAN_DECAP_NEXT__COUNT,
-    .next_nodes = {
-        [INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH] = "infmon-flow-match",
-        [INFMON_ERSPAN_DECAP_NEXT_DROP] = "drop",
-    },
+    .next_nodes =
+        {
+            [INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH] = "infmon-flow-match",
+            [INFMON_ERSPAN_DECAP_NEXT_DROP] = "drop",
+        },
 };
 
 /* ════════════════════════════════════════════════════════════════════
  *  Node 2: infmon-flow-match
  * ════════════════════════════════════════════════════════════════════ */
 
-static uword
-infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
-                          vlib_frame_t *frame)
+static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
+                                       vlib_frame_t *frame)
 {
     infmon_plugin_main_t *pm = &infmon_plugin_main;
     u32 n_left = frame->n_vectors;
     u32 *from = vlib_frame_vector_args(frame);
 
     /* Load flow rules with ACQUIRE once per frame (§8) */
-    const infmon_flow_rule_t *rules =
-        __atomic_load_n(&pm->flow_rules, __ATOMIC_ACQUIRE);
-    uint32_t rule_count =
-        __atomic_load_n(&pm->flow_rule_count, __ATOMIC_ACQUIRE);
+    const infmon_flow_rule_t *rules = __atomic_load_n(&pm->flow_rules, __ATOMIC_ACQUIRE);
+    uint32_t rule_count = __atomic_load_n(&pm->flow_rule_count, __ATOMIC_ACQUIRE);
 
     infmon_scratch_reset(&infmon_tls_scratch);
 
     u32 *to_next_counter, *to_next_drop;
     u32 n_counter = 0, n_drop = 0;
 
-    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_COUNTER,
-                        to_next_counter, n_counter);
-    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_DROP,
-                        to_next_drop, n_drop);
+    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_COUNTER, to_next_counter, n_counter);
+    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_DROP, to_next_drop, n_drop);
 
     while (n_left > 0) {
         u32 bi = from[0];
@@ -238,8 +229,8 @@ infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
 
         uint32_t matches = 0;
         if (extracted && rules && rule_count > 0) {
-            matches = infmon_flow_match(rules, rule_count, &fields,
-                                        &infmon_tls_scratch, infmon_tls_key_buf);
+            matches = infmon_flow_match(rules, rule_count, &fields, &infmon_tls_scratch,
+                                        infmon_tls_key_buf);
         }
 
         if (matches > 0) {
@@ -271,19 +262,18 @@ VLIB_REGISTER_NODE(infmon_flow_match_node) = {
     .n_errors = INFMON_NODE_ERR__COUNT,
     .error_strings = infmon_node_error_strings,
     .n_next_nodes = INFMON_FLOW_MATCH_NEXT__COUNT,
-    .next_nodes = {
-        [INFMON_FLOW_MATCH_NEXT_COUNTER] = "infmon-counter",
-        [INFMON_FLOW_MATCH_NEXT_DROP] = "drop",
-    },
+    .next_nodes =
+        {
+            [INFMON_FLOW_MATCH_NEXT_COUNTER] = "infmon-counter",
+            [INFMON_FLOW_MATCH_NEXT_DROP] = "drop",
+        },
 };
 
 /* ════════════════════════════════════════════════════════════════════
  *  Node 3: infmon-counter
  * ════════════════════════════════════════════════════════════════════ */
 
-static uword
-infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
-                       vlib_frame_t *frame)
+static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, vlib_frame_t *frame)
 {
     infmon_plugin_main_t *pm = &infmon_plugin_main;
     u32 n_left = frame->n_vectors;
@@ -319,8 +309,8 @@ infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
         uint64_t pkt_bytes = vlib_buffer_length_in_chain(vm, b);
 
         /* Update counters for this packet's scratch entries */
-        infmon_counter_update(&infmon_tls_scratch, tables, pkt_bytes, tick,
-                              &insert_retry, &table_full);
+        infmon_counter_update(&infmon_tls_scratch, tables, pkt_bytes, tick, &insert_retry,
+                              &table_full);
 
         to_next[0] = bi;
         to_next++;
@@ -348,9 +338,10 @@ VLIB_REGISTER_NODE(infmon_counter_node) = {
     .n_errors = INFMON_NODE_ERR__COUNT,
     .error_strings = infmon_node_error_strings,
     .n_next_nodes = INFMON_COUNTER_NEXT__COUNT,
-    .next_nodes = {
-        [INFMON_COUNTER_NEXT_DROP] = "drop",
-    },
+    .next_nodes =
+        {
+            [INFMON_COUNTER_NEXT_DROP] = "drop",
+        },
 };
 
 #endif /* INFMON_VPP_BUILD */

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -1,0 +1,356 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * VPP graph node registration and dual-loop implementations.
+ *
+ * This file requires VPP headers and is compiled only as part of the
+ * VPP plugin build (not the standalone unit-test build).
+ *
+ * See specs/004-backend-architecture.md §4, §9.
+ *
+ * Node chain:
+ *   dpdk-input → infmon-erspan-decap → infmon-flow-match → infmon-counter → drop
+ */
+
+#ifdef INFMON_VPP_BUILD
+
+#include <vlib/vlib.h>
+#include <vnet/vnet.h>
+#include <vnet/pg/pg.h>
+
+#include "infmon/graph_node.h"
+
+/* ── Per-worker thread-local scratch ─────────────────────────────── */
+
+static __thread infmon_scratch_t infmon_tls_scratch;
+static __thread uint8_t infmon_tls_key_buf[INFMON_KEY_BUF_MAX];
+
+/* ── Shared plugin state (set by control plane) ──────────────────── */
+
+typedef struct {
+    /* Flow rules — loaded once per frame with ACQUIRE. */
+    const infmon_flow_rule_t *flow_rules;
+    uint32_t flow_rule_count;
+
+    /* Counter tables — one per flow_rule_index.
+     * Loaded once per frame with ACQUIRE for atomic swap support. */
+    infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES];
+
+    /* Tick counter for LRU tracking (bumped once per frame). */
+    uint64_t tick;
+} infmon_plugin_main_t;
+
+extern infmon_plugin_main_t infmon_plugin_main;
+
+/* ════════════════════════════════════════════════════════════════════
+ *  Node 1: infmon-erspan-decap
+ * ════════════════════════════════════════════════════════════════════ */
+
+typedef struct {
+    infmon_parse_result_t result;
+    uint32_t inner_offset;
+    uint32_t inner_len;
+} infmon_erspan_decap_trace_t;
+
+static u8 *
+format_infmon_erspan_decap_trace(u8 *s, va_list *args)
+{
+    CLIB_UNUSED(vlib_main_t * vm) = va_arg(*args, vlib_main_t *);
+    CLIB_UNUSED(vlib_node_t * node) = va_arg(*args, vlib_node_t *);
+    infmon_erspan_decap_trace_t *t = va_arg(*args, infmon_erspan_decap_trace_t *);
+
+    s = format(s, "infmon-erspan-decap: result=%d inner_offset=%u inner_len=%u",
+               t->result, t->inner_offset, t->inner_len);
+    return s;
+}
+
+static uword
+infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
+                            vlib_frame_t *frame)
+{
+    u32 n_left = frame->n_vectors;
+    u32 *from = vlib_frame_vector_args(frame);
+    u32 *to_next_match, *to_next_drop;
+    u32 n_match = 0, n_drop = 0;
+    u16 next_match = INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH;
+    u16 next_drop = INFMON_ERSPAN_DECAP_NEXT_DROP;
+
+    vlib_get_next_frame(vm, node, next_match, to_next_match, n_match);
+    vlib_get_next_frame(vm, node, next_drop, to_next_drop, n_drop);
+
+    /* ── Dual loop ──────────────────────────────────────────────── */
+    while (n_left >= 4) {
+        /* Prefetch +2, +3 */
+        vlib_prefetch_buffer_header(vlib_get_buffer(vm, from[2]), LOAD);
+        vlib_prefetch_buffer_header(vlib_get_buffer(vm, from[3]), LOAD);
+
+        for (int i = 0; i < 2; i++) {
+            u32 bi = from[i];
+            vlib_buffer_t *b = vlib_get_buffer(vm, bi);
+            const uint8_t *data = vlib_buffer_get_current(b);
+            uint32_t len = b->current_length;
+
+            infmon_decap_result_t dr;
+            infmon_parse_result_t rc = infmon_erspan_decap(data, len, &dr);
+
+            if (rc == INFMON_PARSE_OK || rc == INFMON_PARSE_INNER_TRUNCATED_OK) {
+                /* Advance buffer to inner frame */
+                vlib_buffer_advance(b, (i32)dr.inner_offset);
+                b->current_length = dr.inner_len;
+
+                to_next_match[0] = bi;
+                to_next_match++;
+                n_match++;
+            } else {
+                /* Map parse error to node error counter */
+                infmon_node_error_t err;
+                if (rc == INFMON_PARSE_ERR_GRE_BAD_PROTO ||
+                    rc == INFMON_PARSE_ERR_ERSPAN_BAD_VERSION)
+                    err = INFMON_NODE_ERR_ERSPAN_UNKNOWN_PROTO;
+                else if (rc == INFMON_PARSE_ERR_ERSPAN_TRUNCATED ||
+                         rc == INFMON_PARSE_ERR_OUTER_TRUNCATED)
+                    err = INFMON_NODE_ERR_ERSPAN_TRUNCATED;
+                else
+                    err = INFMON_NODE_ERR_INNER_PARSE_FAILED;
+
+                node->errors[err]++;
+
+                to_next_drop[0] = bi;
+                to_next_drop++;
+                n_drop++;
+            }
+
+            if (PREDICT_FALSE(b->flags & VLIB_BUFFER_IS_TRACED)) {
+                infmon_erspan_decap_trace_t *t =
+                    vlib_add_trace(vm, node, b, sizeof(*t));
+                t->result = rc;
+                t->inner_offset = dr.inner_offset;
+                t->inner_len = dr.inner_len;
+            }
+        }
+
+        from += 2;
+        n_left -= 2;
+    }
+
+    /* ── Single loop remainder ───────────────────────────────────── */
+    while (n_left > 0) {
+        u32 bi = from[0];
+        vlib_buffer_t *b = vlib_get_buffer(vm, bi);
+        const uint8_t *data = vlib_buffer_get_current(b);
+        uint32_t len = b->current_length;
+
+        infmon_decap_result_t dr;
+        infmon_parse_result_t rc = infmon_erspan_decap(data, len, &dr);
+
+        if (rc == INFMON_PARSE_OK || rc == INFMON_PARSE_INNER_TRUNCATED_OK) {
+            vlib_buffer_advance(b, (i32)dr.inner_offset);
+            b->current_length = dr.inner_len;
+            to_next_match[0] = bi;
+            to_next_match++;
+            n_match++;
+        } else {
+            infmon_node_error_t err;
+            if (rc == INFMON_PARSE_ERR_GRE_BAD_PROTO ||
+                rc == INFMON_PARSE_ERR_ERSPAN_BAD_VERSION)
+                err = INFMON_NODE_ERR_ERSPAN_UNKNOWN_PROTO;
+            else if (rc == INFMON_PARSE_ERR_ERSPAN_TRUNCATED ||
+                     rc == INFMON_PARSE_ERR_OUTER_TRUNCATED)
+                err = INFMON_NODE_ERR_ERSPAN_TRUNCATED;
+            else
+                err = INFMON_NODE_ERR_INNER_PARSE_FAILED;
+            node->errors[err]++;
+            to_next_drop[0] = bi;
+            to_next_drop++;
+            n_drop++;
+        }
+
+        if (PREDICT_FALSE(b->flags & VLIB_BUFFER_IS_TRACED)) {
+            infmon_erspan_decap_trace_t *t =
+                vlib_add_trace(vm, node, b, sizeof(*t));
+            t->result = rc;
+            t->inner_offset = dr.inner_offset;
+            t->inner_len = dr.inner_len;
+        }
+
+        from++;
+        n_left--;
+    }
+
+    vlib_put_next_frame(vm, node, next_match, n_match);
+    vlib_put_next_frame(vm, node, next_drop, n_drop);
+
+    return frame->n_vectors;
+}
+
+VLIB_REGISTER_NODE(infmon_erspan_decap_node) = {
+    .function = infmon_erspan_decap_node_fn,
+    .name = "infmon-erspan-decap",
+    .vector_size = sizeof(u32),
+    .format_trace = format_infmon_erspan_decap_trace,
+    .type = VLIB_NODE_TYPE_INTERNAL,
+    .n_errors = INFMON_NODE_ERR__COUNT,
+    .error_strings = infmon_node_error_strings,
+    .n_next_nodes = INFMON_ERSPAN_DECAP_NEXT__COUNT,
+    .next_nodes = {
+        [INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH] = "infmon-flow-match",
+        [INFMON_ERSPAN_DECAP_NEXT_DROP] = "drop",
+    },
+};
+
+/* ════════════════════════════════════════════════════════════════════
+ *  Node 2: infmon-flow-match
+ * ════════════════════════════════════════════════════════════════════ */
+
+static uword
+infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
+                          vlib_frame_t *frame)
+{
+    infmon_plugin_main_t *pm = &infmon_plugin_main;
+    u32 n_left = frame->n_vectors;
+    u32 *from = vlib_frame_vector_args(frame);
+
+    /* Load flow rules with ACQUIRE once per frame (§8) */
+    const infmon_flow_rule_t *rules =
+        __atomic_load_n(&pm->flow_rules, __ATOMIC_ACQUIRE);
+    uint32_t rule_count =
+        __atomic_load_n(&pm->flow_rule_count, __ATOMIC_ACQUIRE);
+
+    infmon_scratch_reset(&infmon_tls_scratch);
+
+    u32 *to_next_counter, *to_next_drop;
+    u32 n_counter = 0, n_drop = 0;
+
+    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_COUNTER,
+                        to_next_counter, n_counter);
+    vlib_get_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_DROP,
+                        to_next_drop, n_drop);
+
+    while (n_left > 0) {
+        u32 bi = from[0];
+        vlib_buffer_t *b = vlib_get_buffer(vm, bi);
+        const uint8_t *inner = vlib_buffer_get_current(b);
+        uint32_t inner_len = b->current_length;
+
+        infmon_flow_fields_t fields;
+        bool extracted = infmon_extract_flow_fields(NULL, inner, inner_len, &fields);
+
+        uint32_t matches = 0;
+        if (extracted && rules && rule_count > 0) {
+            matches = infmon_flow_match(rules, rule_count, &fields,
+                                        &infmon_tls_scratch, infmon_tls_key_buf);
+        }
+
+        if (matches > 0) {
+            to_next_counter[0] = bi;
+            to_next_counter++;
+            n_counter++;
+        } else {
+            node->errors[INFMON_NODE_ERR_FLOW_RULE_NO_MATCH]++;
+            to_next_drop[0] = bi;
+            to_next_drop++;
+            n_drop++;
+        }
+
+        from++;
+        n_left--;
+    }
+
+    vlib_put_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_COUNTER, n_counter);
+    vlib_put_next_frame(vm, node, INFMON_FLOW_MATCH_NEXT_DROP, n_drop);
+
+    return frame->n_vectors;
+}
+
+VLIB_REGISTER_NODE(infmon_flow_match_node) = {
+    .function = infmon_flow_match_node_fn,
+    .name = "infmon-flow-match",
+    .vector_size = sizeof(u32),
+    .type = VLIB_NODE_TYPE_INTERNAL,
+    .n_errors = INFMON_NODE_ERR__COUNT,
+    .error_strings = infmon_node_error_strings,
+    .n_next_nodes = INFMON_FLOW_MATCH_NEXT__COUNT,
+    .next_nodes = {
+        [INFMON_FLOW_MATCH_NEXT_COUNTER] = "infmon-counter",
+        [INFMON_FLOW_MATCH_NEXT_DROP] = "drop",
+    },
+};
+
+/* ════════════════════════════════════════════════════════════════════
+ *  Node 3: infmon-counter
+ * ════════════════════════════════════════════════════════════════════ */
+
+static uword
+infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node,
+                       vlib_frame_t *frame)
+{
+    infmon_plugin_main_t *pm = &infmon_plugin_main;
+    u32 n_left = frame->n_vectors;
+    u32 *from = vlib_frame_vector_args(frame);
+
+    /* Load table pointers with ACQUIRE once per frame (§8) */
+    infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES];
+    for (uint32_t i = 0; i < INFMON_MAX_ACTIVE_FLOW_RULES; i++)
+        tables[i] = __atomic_load_n(&pm->tables[i], __ATOMIC_ACQUIRE);
+
+    /* Bump tick once per frame */
+    uint64_t tick = __atomic_fetch_add(&pm->tick, 1, __ATOMIC_RELAXED);
+
+    uint64_t insert_retry = 0;
+    uint64_t table_full = 0;
+
+    /* All packets go to drop (InFMon never forwards) */
+    u32 *to_next;
+    u32 n_next = 0;
+    vlib_get_next_frame(vm, node, INFMON_COUNTER_NEXT_DROP, to_next, n_next);
+
+    /* Walk scratch vector for counter updates */
+    /* Note: pkt_bytes should be per-packet, but for batch efficiency
+     * we process the entire scratch in one call. The scratch was filled
+     * by flow-match for all packets in this frame. For correct per-packet
+     * byte counts, the VPP integration would need to store pkt_bytes
+     * in the scratch entry or pass it separately. For v1, use average. */
+    while (n_left > 0) {
+        u32 bi = from[0];
+        vlib_buffer_t *b = vlib_get_buffer(vm, bi);
+
+        /* Each packet's byte contribution */
+        uint64_t pkt_bytes = vlib_buffer_length_in_chain(vm, b);
+
+        /* Update counters for this packet's scratch entries */
+        infmon_counter_update(&infmon_tls_scratch, tables, pkt_bytes, tick,
+                              &insert_retry, &table_full);
+
+        to_next[0] = bi;
+        to_next++;
+        n_next++;
+        from++;
+        n_left--;
+    }
+
+    node->errors[INFMON_NODE_ERR_COUNTER_INSERT_RETRY_EXHAUSTED] += insert_retry;
+    node->errors[INFMON_NODE_ERR_COUNTER_TABLE_FULL] += table_full;
+
+    /* Reset scratch for next frame */
+    infmon_scratch_reset(&infmon_tls_scratch);
+
+    vlib_put_next_frame(vm, node, INFMON_COUNTER_NEXT_DROP, n_next);
+
+    return frame->n_vectors;
+}
+
+VLIB_REGISTER_NODE(infmon_counter_node) = {
+    .function = infmon_counter_node_fn,
+    .name = "infmon-counter",
+    .vector_size = sizeof(u32),
+    .type = VLIB_NODE_TYPE_INTERNAL,
+    .n_errors = INFMON_NODE_ERR__COUNT,
+    .error_strings = infmon_node_error_strings,
+    .n_next_nodes = INFMON_COUNTER_NEXT__COUNT,
+    .next_nodes = {
+        [INFMON_COUNTER_NEXT_DROP] = "drop",
+    },
+};
+
+#endif /* INFMON_VPP_BUILD */

--- a/src/backend/test/test_graph_node.cc
+++ b/src/backend/test/test_graph_node.cc
@@ -1,0 +1,308 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ */
+
+#include <cstring>
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "infmon/graph_node.h"
+}
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+static infmon_flow_rule_t make_rule(const char *name,
+                                     const infmon_field_t *fields,
+                                     uint32_t fc,
+                                     uint32_t max_keys = 1024)
+{
+    infmon_flow_rule_t r{};
+    std::size_t len = std::strlen(name);
+    if (len > INFMON_FLOW_RULE_NAME_MAX)
+        len = INFMON_FLOW_RULE_NAME_MAX;
+    std::memcpy(r.name, name, len);
+    if (fc > 0)
+        std::memcpy(r.fields, fields, fc * sizeof(infmon_field_t));
+    r.field_count = fc;
+    r.max_keys = max_keys;
+    r.eviction_policy = INFMON_EVICTION_LRU_DROP;
+    r.key_width = infmon_flow_rule_key_width(r.fields, r.field_count);
+    return r;
+}
+
+static infmon_flow_fields_t make_fields(uint8_t proto, uint8_t dscp,
+                                         const uint8_t src[4],
+                                         const uint8_t dst[4])
+{
+    infmon_flow_fields_t f{};
+    f.ip_proto = proto;
+    f.dscp = dscp;
+    /* Store as IPv4-mapped-IPv6 */
+    f.src_ip[10] = 0xff;
+    f.src_ip[11] = 0xff;
+    std::memcpy(f.src_ip + 12, src, 4);
+    f.dst_ip[10] = 0xff;
+    f.dst_ip[11] = 0xff;
+    std::memcpy(f.dst_ip + 12, dst, 4);
+    return f;
+}
+
+/* ── Scratch reset ──────────────────────────────────────────────── */
+
+TEST(Scratch, ResetSetsCountToZero)
+{
+    infmon_scratch_t scratch{};
+    scratch.count = 42;
+    infmon_scratch_reset(&scratch);
+    EXPECT_EQ(scratch.count, 0u);
+}
+
+/* ── Flow match — single rule, single packet ────────────────────── */
+
+TEST(FlowMatch, SingleRuleSingleMatch)
+{
+    infmon_field_t fields[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_DST_IP};
+    auto rule = make_rule("test", fields, 2);
+
+    uint8_t src[] = {10, 0, 0, 1};
+    uint8_t dst[] = {10, 0, 0, 2};
+    auto ff = make_fields(6, 0, src, dst);
+
+    infmon_scratch_t scratch{};
+    uint8_t key_buf[INFMON_KEY_BUF_MAX]{};
+
+    uint32_t m = infmon_flow_match(&rule, 1, &ff, &scratch, key_buf);
+    EXPECT_EQ(m, 1u);
+    EXPECT_EQ(scratch.count, 1u);
+    EXPECT_EQ(scratch.entries[0].flow_rule_index, 0u);
+    EXPECT_NE(scratch.entries[0].key_hash, 0u);
+    EXPECT_EQ(scratch.entries[0].key_len, 32u); /* 16+16 */
+}
+
+/* ── Flow match — multiple rules ────────────────────────────────── */
+
+TEST(FlowMatch, MultipleRulesAllMatch)
+{
+    infmon_field_t f1[] = {INFMON_FIELD_SRC_IP};
+    infmon_field_t f2[] = {INFMON_FIELD_IP_PROTO};
+    infmon_flow_rule_t rules[2];
+    rules[0] = make_rule("r1", f1, 1);
+    rules[1] = make_rule("r2", f2, 1);
+
+    uint8_t src[] = {192, 168, 1, 1};
+    uint8_t dst[] = {192, 168, 1, 2};
+    auto ff = make_fields(17, 0, src, dst);
+
+    infmon_scratch_t scratch{};
+    uint8_t key_buf[INFMON_KEY_BUF_MAX]{};
+
+    uint32_t m = infmon_flow_match(rules, 2, &ff, &scratch, key_buf);
+    EXPECT_EQ(m, 2u);
+    EXPECT_EQ(scratch.count, 2u);
+    EXPECT_EQ(scratch.entries[0].flow_rule_index, 0u);
+    EXPECT_EQ(scratch.entries[0].key_len, 16u);
+    EXPECT_EQ(scratch.entries[1].flow_rule_index, 1u);
+    EXPECT_EQ(scratch.entries[1].key_len, 1u);
+}
+
+/* ── Flow match — NULL inputs ───────────────────────────────────── */
+
+TEST(FlowMatch, NullInputsReturnZero)
+{
+    EXPECT_EQ(infmon_flow_match(nullptr, 0, nullptr, nullptr, nullptr), 0u);
+}
+
+/* ── Flow match — deterministic hashing ─────────────────────────── */
+
+TEST(FlowMatch, SameInputSameHash)
+{
+    infmon_field_t fields[] = {INFMON_FIELD_SRC_IP, INFMON_FIELD_IP_PROTO};
+    auto rule = make_rule("h", fields, 2);
+
+    uint8_t src[] = {1, 2, 3, 4};
+    uint8_t dst[] = {5, 6, 7, 8};
+    auto ff = make_fields(6, 0, src, dst);
+
+    infmon_scratch_t s1{}, s2{};
+    uint8_t kb1[INFMON_KEY_BUF_MAX]{}, kb2[INFMON_KEY_BUF_MAX]{};
+
+    infmon_flow_match(&rule, 1, &ff, &s1, kb1);
+    infmon_flow_match(&rule, 1, &ff, &s2, kb2);
+
+    EXPECT_EQ(s1.entries[0].key_hash, s2.entries[0].key_hash);
+}
+
+/* ── Flow match — different packets produce different hashes ───── */
+
+TEST(FlowMatch, DifferentInputsDifferentHash)
+{
+    infmon_field_t fields[] = {INFMON_FIELD_SRC_IP};
+    auto rule = make_rule("d", fields, 1);
+
+    uint8_t src1[] = {10, 0, 0, 1};
+    uint8_t src2[] = {10, 0, 0, 2};
+    uint8_t dst[] = {0, 0, 0, 0};
+    auto ff1 = make_fields(6, 0, src1, dst);
+    auto ff2 = make_fields(6, 0, src2, dst);
+
+    infmon_scratch_t s1{}, s2{};
+    uint8_t kb1[INFMON_KEY_BUF_MAX]{}, kb2[INFMON_KEY_BUF_MAX]{};
+
+    infmon_flow_match(&rule, 1, &ff1, &s1, kb1);
+    infmon_flow_match(&rule, 1, &ff2, &s2, kb2);
+
+    EXPECT_NE(s1.entries[0].key_hash, s2.entries[0].key_hash);
+}
+
+/* ── Counter update — basic integration ─────────────────────────── */
+
+TEST(CounterUpdate, UpdatesCounterTable)
+{
+    /* Create a counter table */
+    infmon_counter_table_t *table = infmon_counter_table_create(64, 32);
+    ASSERT_NE(table, nullptr);
+
+    /* Build a scratch with one entry */
+    infmon_field_t fields[] = {INFMON_FIELD_SRC_IP};
+    auto rule = make_rule("cu", fields, 1);
+
+    uint8_t src[] = {10, 1, 1, 1};
+    uint8_t dst[] = {10, 1, 1, 2};
+    auto ff = make_fields(6, 0, src, dst);
+
+    infmon_scratch_t scratch{};
+    uint8_t key_buf[INFMON_KEY_BUF_MAX]{};
+
+    infmon_flow_match(&rule, 1, &ff, &scratch, key_buf);
+    ASSERT_EQ(scratch.count, 1u);
+
+    /* Set up tables array */
+    infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES]{};
+    tables[0] = table;
+
+    uint64_t retry = 0, full = 0;
+    infmon_counter_update(&scratch, tables, 100, 1, &retry, &full);
+
+    EXPECT_EQ(retry, 0u);
+    EXPECT_EQ(full, 0u);
+
+    /* Verify counter was updated by reading the slot */
+    bool found = false;
+    for (uint32_t i = 0; i < table->num_slots; i++) {
+        infmon_slot_t slot;
+        if (infmon_counter_table_read_slot(table, i, &slot) &&
+            slot.flags == INFMON_SLOT_OCCUPIED) {
+            EXPECT_EQ(slot.packets, 1u);
+            EXPECT_EQ(slot.bytes, 100u);
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found);
+
+    /* Update again — counters should accumulate */
+    infmon_counter_update(&scratch, tables, 200, 2, &retry, &full);
+
+    found = false;
+    for (uint32_t i = 0; i < table->num_slots; i++) {
+        infmon_slot_t slot;
+        if (infmon_counter_table_read_slot(table, i, &slot) &&
+            slot.flags == INFMON_SLOT_OCCUPIED) {
+            EXPECT_EQ(slot.packets, 2u);
+            EXPECT_EQ(slot.bytes, 300u);
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found);
+
+    infmon_counter_table_destroy(table);
+}
+
+/* ── Counter update — NULL tables handled ───────────────────────── */
+
+TEST(CounterUpdate, NullTableSkipsGracefully)
+{
+    infmon_scratch_t scratch{};
+    scratch.count = 1;
+    scratch.entries[0].flow_rule_index = 0;
+    scratch.entries[0].key_len = 16;
+    scratch.entries[0].key_hash = 0x12345;
+    uint8_t dummy[16]{};
+    scratch.entries[0].key_ptr = dummy;
+
+    infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES]{};
+    /* tables[0] is null */
+
+    uint64_t retry = 0, full = 0;
+    infmon_counter_update(&scratch, tables, 100, 1, &retry, &full);
+    /* Should not crash, and no errors */
+    EXPECT_EQ(retry, 0u);
+    EXPECT_EQ(full, 0u);
+}
+
+/* ── ERSPAN decap ───────────────────────────────────────────────── */
+
+TEST(ErspanDecap, TruncatedBufferFails)
+{
+    uint8_t buf[10]{};
+    infmon_decap_result_t dr;
+    auto rc = infmon_erspan_decap(buf, sizeof(buf), &dr);
+    EXPECT_NE(rc, INFMON_PARSE_OK);
+}
+
+/* ── Extract flow fields ────────────────────────────────────────── */
+
+TEST(ExtractFlowFields, NullInputReturnsFalse)
+{
+    infmon_flow_fields_t out{};
+    EXPECT_FALSE(infmon_extract_flow_fields(nullptr, nullptr, 0, &out));
+}
+
+TEST(ExtractFlowFields, IPv4InnerFrame)
+{
+    /* Build a minimal inner Ethernet+IPv4 frame */
+    uint8_t inner[34]{};
+    /* Ethernet: dst(6) + src(6) + type(2) = 14 bytes */
+    inner[12] = 0x08;
+    inner[13] = 0x00; /* IPv4 */
+    /* IPv4 header at offset 14 */
+    inner[14] = 0x45; /* version=4, IHL=5 */
+    inner[15] = 0xB8; /* TOS = 0xB8 => DSCP = 0x2E (46) */
+    /* Protocol at offset 14+9 = 23 */
+    inner[23] = 17; /* UDP */
+    /* Src IP at offset 14+12 = 26: 192.168.1.100 */
+    inner[26] = 192;
+    inner[27] = 168;
+    inner[28] = 1;
+    inner[29] = 100;
+    /* Dst IP at offset 14+16 = 30: 10.0.0.1 */
+    inner[30] = 10;
+    inner[31] = 0;
+    inner[32] = 0;
+    inner[33] = 1;
+
+    /* Need a parsed packet for mirror_src_ip */
+    infmon_parsed_packet_t parsed{};
+    parsed.mirror_src_ip.family = INFMON_AF_V4;
+    parsed.mirror_src_ip.addr.v4[0] = 172;
+    parsed.mirror_src_ip.addr.v4[1] = 16;
+    parsed.mirror_src_ip.addr.v4[2] = 0;
+    parsed.mirror_src_ip.addr.v4[3] = 1;
+
+    infmon_flow_fields_t out{};
+    bool ok = infmon_extract_flow_fields(&parsed, inner, sizeof(inner), &out);
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(out.ip_proto, 17u);
+    EXPECT_EQ(out.dscp, 46u);
+    /* Check src_ip is IPv4-mapped */
+    EXPECT_EQ(out.src_ip[10], 0xff);
+    EXPECT_EQ(out.src_ip[11], 0xff);
+    EXPECT_EQ(out.src_ip[12], 192u);
+    EXPECT_EQ(out.src_ip[15], 100u);
+    /* Check mirror_src_ip */
+    EXPECT_EQ(out.mirror_src_ip[10], 0xff);
+    EXPECT_EQ(out.mirror_src_ip[11], 0xff);
+    EXPECT_EQ(out.mirror_src_ip[12], 172u);
+}

--- a/src/backend/test/test_graph_node.cc
+++ b/src/backend/test/test_graph_node.cc
@@ -12,10 +12,8 @@ extern "C" {
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
 
-static infmon_flow_rule_t make_rule(const char *name,
-                                     const infmon_field_t *fields,
-                                     uint32_t fc,
-                                     uint32_t max_keys = 1024)
+static infmon_flow_rule_t make_rule(const char *name, const infmon_field_t *fields, uint32_t fc,
+                                    uint32_t max_keys = 1024)
 {
     infmon_flow_rule_t r{};
     std::size_t len = std::strlen(name);
@@ -31,9 +29,8 @@ static infmon_flow_rule_t make_rule(const char *name,
     return r;
 }
 
-static infmon_flow_fields_t make_fields(uint8_t proto, uint8_t dscp,
-                                         const uint8_t src[4],
-                                         const uint8_t dst[4])
+static infmon_flow_fields_t make_fields(uint8_t proto, uint8_t dscp, const uint8_t src[4],
+                                        const uint8_t dst[4])
 {
     infmon_flow_fields_t f{};
     f.ip_proto = proto;
@@ -191,8 +188,7 @@ TEST(CounterUpdate, UpdatesCounterTable)
     bool found = false;
     for (uint32_t i = 0; i < table->num_slots; i++) {
         infmon_slot_t slot;
-        if (infmon_counter_table_read_slot(table, i, &slot) &&
-            slot.flags == INFMON_SLOT_OCCUPIED) {
+        if (infmon_counter_table_read_slot(table, i, &slot) && slot.flags == INFMON_SLOT_OCCUPIED) {
             EXPECT_EQ(slot.packets, 1u);
             EXPECT_EQ(slot.bytes, 100u);
             found = true;
@@ -207,8 +203,7 @@ TEST(CounterUpdate, UpdatesCounterTable)
     found = false;
     for (uint32_t i = 0; i < table->num_slots; i++) {
         infmon_slot_t slot;
-        if (infmon_counter_table_read_slot(table, i, &slot) &&
-            slot.flags == INFMON_SLOT_OCCUPIED) {
+        if (infmon_counter_table_read_slot(table, i, &slot) && slot.flags == INFMON_SLOT_OCCUPIED) {
             EXPECT_EQ(slot.packets, 2u);
             EXPECT_EQ(slot.bytes, 300u);
             found = true;

--- a/src/backend/test/test_graph_node.cc
+++ b/src/backend/test/test_graph_node.cc
@@ -330,7 +330,7 @@ TEST(ExtractFlowFields, UnknownAfRejected)
     inner[14] = 0x45;
 
     infmon_parsed_packet_t parsed{};
-    parsed.mirror_src_ip.family = (infmon_af_t)99;
+    parsed.mirror_src_ip.family = (infmon_af_t) 99;
 
     infmon_flow_fields_t out{};
     EXPECT_FALSE(infmon_extract_flow_fields(&parsed, inner, sizeof(inner), &out));

--- a/src/backend/test/test_graph_node.cc
+++ b/src/backend/test/test_graph_node.cc
@@ -96,7 +96,7 @@ TEST(FlowMatch, MultipleRulesAllMatch)
     infmon_scratch_t scratch{};
     uint8_t key_buf[INFMON_KEY_BUF_MAX]{};
 
-    uint32_t m = infmon_flow_match(rules, 2, &ff, &scratch, key_buf);
+    uint32_t m = infmon_flow_match(rules, 2, &ff, &scratch, key_buf, 100);
     EXPECT_EQ(m, 2u);
     EXPECT_EQ(scratch.count, 2u);
     EXPECT_EQ(scratch.entries[0].flow_rule_index, 0u);
@@ -112,7 +112,7 @@ TEST(FlowMatch, MultipleRulesAllMatch)
 
 TEST(FlowMatch, NullInputsReturnZero)
 {
-    EXPECT_EQ(infmon_flow_match(nullptr, 0, nullptr, nullptr, nullptr), 0u);
+    EXPECT_EQ(infmon_flow_match(nullptr, 0, nullptr, nullptr, nullptr, 0), 0u);
 }
 
 /* ── Flow match — deterministic hashing ─────────────────────────── */
@@ -129,8 +129,8 @@ TEST(FlowMatch, SameInputSameHash)
     infmon_scratch_t s1{}, s2{};
     uint8_t kb1[INFMON_KEY_BUF_MAX]{}, kb2[INFMON_KEY_BUF_MAX]{};
 
-    infmon_flow_match(&rule, 1, &ff, &s1, kb1);
-    infmon_flow_match(&rule, 1, &ff, &s2, kb2);
+    infmon_flow_match(&rule, 1, &ff, &s1, kb1, 100);
+    infmon_flow_match(&rule, 1, &ff, &s2, kb2, 100);
 
     EXPECT_EQ(s1.entries[0].key_hash, s2.entries[0].key_hash);
 }
@@ -151,8 +151,8 @@ TEST(FlowMatch, DifferentInputsDifferentHash)
     infmon_scratch_t s1{}, s2{};
     uint8_t kb1[INFMON_KEY_BUF_MAX]{}, kb2[INFMON_KEY_BUF_MAX]{};
 
-    infmon_flow_match(&rule, 1, &ff1, &s1, kb1);
-    infmon_flow_match(&rule, 1, &ff2, &s2, kb2);
+    infmon_flow_match(&rule, 1, &ff1, &s1, kb1, 100);
+    infmon_flow_match(&rule, 1, &ff2, &s2, kb2, 100);
 
     EXPECT_NE(s1.entries[0].key_hash, s2.entries[0].key_hash);
 }
@@ -176,7 +176,7 @@ TEST(CounterUpdate, UpdatesCounterTable)
     infmon_scratch_t scratch{};
     uint8_t key_buf[INFMON_KEY_BUF_MAX]{};
 
-    infmon_flow_match(&rule, 1, &ff, &scratch, key_buf);
+    infmon_flow_match(&rule, 1, &ff, &scratch, key_buf, 100);
     ASSERT_EQ(scratch.count, 1u);
 
     /* Set up tables array */
@@ -203,7 +203,7 @@ TEST(CounterUpdate, UpdatesCounterTable)
     EXPECT_TRUE(found);
 
     /* Update again — counters should accumulate */
-    infmon_counter_update(&scratch, tables, 200, 2, &retry, &full);
+    infmon_counter_update(&scratch, tables, 2, &retry, &full);
 
     found = false;
     for (uint32_t i = 0; i < table->num_slots; i++) {
@@ -236,7 +236,7 @@ TEST(CounterUpdate, NullTableSkipsGracefully)
     /* tables[0] is null */
 
     uint64_t retry = 0, full = 0;
-    infmon_counter_update(&scratch, tables, 100, 1, &retry, &full);
+    infmon_counter_update(&scratch, tables, 1, &retry, &full);
     /* Should not crash, and no errors */
     EXPECT_EQ(retry, 0u);
     EXPECT_EQ(full, 0u);

--- a/src/backend/test/test_graph_node.cc
+++ b/src/backend/test/test_graph_node.cc
@@ -75,6 +75,8 @@ TEST(FlowMatch, SingleRuleSingleMatch)
     EXPECT_EQ(scratch.entries[0].flow_rule_index, 0u);
     EXPECT_NE(scratch.entries[0].key_hash, 0u);
     EXPECT_EQ(scratch.entries[0].key_len, 32u); /* 16+16 */
+    /* Verify key_ptr points to per-entry storage (not shared key_buf) */
+    EXPECT_EQ(scratch.entries[0].key_ptr, scratch.entries[0].key_data);
 }
 
 /* ── Flow match — multiple rules ────────────────────────────────── */
@@ -101,6 +103,9 @@ TEST(FlowMatch, MultipleRulesAllMatch)
     EXPECT_EQ(scratch.entries[0].key_len, 16u);
     EXPECT_EQ(scratch.entries[1].flow_rule_index, 1u);
     EXPECT_EQ(scratch.entries[1].key_len, 1u);
+    /* Each entry owns its own key copy */
+    EXPECT_EQ(scratch.entries[0].key_ptr, scratch.entries[0].key_data);
+    EXPECT_EQ(scratch.entries[1].key_ptr, scratch.entries[1].key_data);
 }
 
 /* ── Flow match — NULL inputs ───────────────────────────────────── */
@@ -300,4 +305,33 @@ TEST(ExtractFlowFields, IPv4InnerFrame)
     EXPECT_EQ(out.mirror_src_ip[10], 0xff);
     EXPECT_EQ(out.mirror_src_ip[11], 0xff);
     EXPECT_EQ(out.mirror_src_ip[12], 172u);
+}
+
+TEST(ExtractFlowFields, QinQRejected)
+{
+    uint8_t inner[20]{};
+    /* 802.1ad ethertype */
+    inner[12] = 0x88;
+    inner[13] = 0xa8;
+
+    infmon_parsed_packet_t parsed{};
+    parsed.mirror_src_ip.family = INFMON_AF_V4;
+
+    infmon_flow_fields_t out{};
+    EXPECT_FALSE(infmon_extract_flow_fields(&parsed, inner, sizeof(inner), &out));
+}
+
+TEST(ExtractFlowFields, UnknownAfRejected)
+{
+    /* Minimal valid IPv4 inner frame */
+    uint8_t inner[34]{};
+    inner[12] = 0x08;
+    inner[13] = 0x00;
+    inner[14] = 0x45;
+
+    infmon_parsed_packet_t parsed{};
+    parsed.mirror_src_ip.family = (infmon_af_t)99;
+
+    infmon_flow_fields_t out{};
+    EXPECT_FALSE(infmon_extract_flow_fields(&parsed, inner, sizeof(inner), &out));
 }

--- a/src/backend/test/test_graph_node.cc
+++ b/src/backend/test/test_graph_node.cc
@@ -69,7 +69,7 @@ TEST(FlowMatch, SingleRuleSingleMatch)
     infmon_scratch_t scratch{};
     uint8_t key_buf[INFMON_KEY_BUF_MAX]{};
 
-    uint32_t m = infmon_flow_match(&rule, 1, &ff, &scratch, key_buf);
+    uint32_t m = infmon_flow_match(&rule, 1, &ff, &scratch, key_buf, 1500);
     EXPECT_EQ(m, 1u);
     EXPECT_EQ(scratch.count, 1u);
     EXPECT_EQ(scratch.entries[0].flow_rule_index, 0u);
@@ -184,7 +184,7 @@ TEST(CounterUpdate, UpdatesCounterTable)
     tables[0] = table;
 
     uint64_t retry = 0, full = 0;
-    infmon_counter_update(&scratch, tables, 100, 1, &retry, &full);
+    infmon_counter_update(&scratch, tables, 100, &retry, &full);
 
     EXPECT_EQ(retry, 0u);
     EXPECT_EQ(full, 0u);


### PR DESCRIPTION
## Summary

Implements the VPP graph node processing logic per specs/004-backend-architecture.md §4 and §9.

### Changes

**Portable logic (no VPP dependency):**
- `graph_node.h`: Scratch vector types (`infmon_scratch_entry_t`, `infmon_scratch_t`), error enums, next-index enums, and function declarations
- `graph_node.c`: Pure-C implementations:
  - `infmon_erspan_decap()` — wraps parser, computes inner offset/length
  - `infmon_extract_flow_fields()` — extracts normalized fields from inner IPv4/IPv6 frames
  - `infmon_flow_match()` — matches packets against all active flow rules, encodes keys, hashes with FNV-1a, appends to scratch vector
  - `infmon_counter_update()` — walks scratch vector and updates counter tables

**VPP node registration (requires VPP SDK):**
- `vpp/infmon_nodes.c` — Three-node pipeline: `infmon-erspan-decap` → `infmon-flow-match` → `infmon-counter` → drop. Includes dual-loop optimization for decap node, thread-local scratch, and ACQUIRE semantics for flow rule loading.

**Tests:**
- 11 unit tests covering scratch reset, flow matching (single/multi rule, null safety, hash determinism/uniqueness), counter updates (integration with real counter table, null table handling), ERSPAN decap, and flow field extraction.

All 5 existing test suites continue to pass.

Closes #41