### PR TITLE
feat: add snapshot_and_clear with atomic table swap and epoch-based RCU

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -63,6 +63,20 @@ target_link_libraries(test_counter_table PRIVATE infmon_counter_table GTest::gte
 target_include_directories(test_counter_table PRIVATE include)
 add_test(NAME counter_table COMMAND test_counter_table)
 
+# --- Snapshot library (atomic table swap + epoch-based RCU) ---
+add_library(infmon_snapshot STATIC
+    src/snapshot.c
+)
+target_include_directories(infmon_snapshot PUBLIC include)
+target_link_libraries(infmon_snapshot PUBLIC infmon_counter_table)
+
+add_executable(test_snapshot
+    test/test_snapshot.cc
+)
+target_link_libraries(test_snapshot PRIVATE infmon_snapshot infmon_counter_table GTest::gtest GTest::gtest_main pthread)
+target_include_directories(test_snapshot PRIVATE include)
+add_test(NAME snapshot COMMAND test_snapshot)
+
 if(ENABLE_FUZZER)
     add_executable(fuzz_erspan_parser
         test/fuzz_erspan_parser.cc

--- a/src/backend/include/infmon/snapshot.h
+++ b/src/backend/include/infmon/snapshot.h
@@ -1,0 +1,183 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * snapshot_and_clear — atomic table swap with epoch-based RCU retirement.
+ * See specs/004-backend-architecture.md §7.2
+ */
+
+#ifndef INFMON_SNAPSHOT_H
+#define INFMON_SNAPSHOT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "infmon/counter_table.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ── Constants ───────────────────────────────────────────────────── */
+
+/** Maximum number of worker threads tracked for RCU. */
+#define INFMON_MAX_WORKERS 32
+
+/** Maximum number of tables pending retirement at any time. */
+#define INFMON_MAX_RETIRED 16
+
+/** Default grace period in nanoseconds (5 seconds). */
+#define INFMON_RETIRE_GRACE_NS ((uint64_t)5000000000ULL)
+
+/* ── Per-worker epoch counter ────────────────────────────────────── */
+
+/**
+ * Cache-line-aligned epoch counter.  Each worker bumps its own epoch
+ * once per dispatch loop iteration with RELEASE ordering; the control
+ * thread reads all worker epochs with ACQUIRE to detect quiescence.
+ */
+typedef struct {
+    uint64_t epoch;
+    uint8_t _pad[56]; /* pad to 64 B to avoid false sharing */
+} __attribute__((aligned(64))) infmon_worker_epoch_t;
+
+/* ── Retired table descriptor ────────────────────────────────────── */
+
+typedef struct {
+    infmon_counter_table_t *table;      /** The retired table. */
+    uint64_t swap_epoch;                /** Global epoch at time of swap. */
+    uint64_t swap_timestamp_ns;         /** Wall-clock timestamp of swap. */
+    uint32_t flow_rule_index;           /** Which flow_rule this belonged to. */
+    bool pending;                       /** true if still awaiting retirement. */
+} infmon_retired_table_t;
+
+/* ── Snapshot manager ────────────────────────────────────────────── */
+
+/**
+ * The snapshot manager owns:
+ *   - per-worker epoch counters,
+ *   - a ring of retired tables awaiting grace-period expiry,
+ *   - a global epoch counter bumped on each swap.
+ *
+ * Thread safety:
+ *   - Workers call infmon_worker_epoch_bump() from the data path (no lock).
+ *   - The control thread calls infmon_snapshot_and_clear() and
+ *     infmon_retire_poll() (serialised — only one control thread).
+ */
+typedef struct {
+    infmon_worker_epoch_t worker_epochs[INFMON_MAX_WORKERS];
+    uint32_t num_workers;
+
+    uint64_t global_epoch;              /** Bumped on each swap. */
+
+    infmon_retired_table_t retired[INFMON_MAX_RETIRED];
+    uint32_t retired_count;             /** Number of pending entries. */
+
+    uint64_t grace_ns;                  /** Configurable grace window. */
+
+    /* Callback for getting wall-clock nanoseconds (injectable for testing). */
+    uint64_t (*clock_ns)(void);
+} infmon_snapshot_mgr_t;
+
+/* ── Snapshot result ─────────────────────────────────────────────── */
+
+typedef enum {
+    INFMON_SNAP_OK = 0,
+    INFMON_SNAP_ALLOC_FAILED,           /** Could not allocate replacement table. */
+    INFMON_SNAP_TOO_MANY_RETIRED,       /** Retired ring is full. */
+    INFMON_SNAP_INVALID_INDEX,          /** flow_rule_index out of range. */
+    INFMON_SNAP_NULL_TABLE,             /** No table installed at that index. */
+} infmon_snap_result_t;
+
+typedef struct {
+    infmon_snap_result_t result;
+    infmon_counter_table_t *retired_table;   /** The old table (generation G). */
+    uint64_t retired_generation;             /** Generation of the retired table. */
+} infmon_snap_reply_t;
+
+/* ── Lifecycle ───────────────────────────────────────────────────── */
+
+/**
+ * Initialise a snapshot manager.
+ *
+ * @param mgr          Manager to initialise.
+ * @param num_workers  Number of worker threads.
+ * @param grace_ns     Grace period in nanoseconds (0 = use default).
+ * @param clock_ns     Wall-clock function (NULL = use clock_gettime).
+ */
+void infmon_snapshot_mgr_init(infmon_snapshot_mgr_t *mgr, uint32_t num_workers,
+                              uint64_t grace_ns, uint64_t (*clock_ns)(void));
+
+/**
+ * Destroy the snapshot manager.  Frees any retired tables still pending.
+ */
+void infmon_snapshot_mgr_destroy(infmon_snapshot_mgr_t *mgr);
+
+/* ── Worker-side (data path) ─────────────────────────────────────── */
+
+/**
+ * Bump the calling worker's epoch.  Must be called once per dispatch
+ * loop iteration.  The worker_id must be in [0, num_workers).
+ */
+static inline void infmon_worker_epoch_bump(infmon_snapshot_mgr_t *mgr, uint32_t worker_id)
+{
+    __atomic_fetch_add(&mgr->worker_epochs[worker_id].epoch, 1, __ATOMIC_RELEASE);
+}
+
+/**
+ * Read a worker's published epoch (for control thread use).
+ */
+static inline uint64_t infmon_worker_epoch_read(const infmon_snapshot_mgr_t *mgr,
+                                                 uint32_t worker_id)
+{
+    return __atomic_load_n(&mgr->worker_epochs[worker_id].epoch, __ATOMIC_ACQUIRE);
+}
+
+/* ── Control-plane operations ────────────────────────────────────── */
+
+/**
+ * Perform an atomic snapshot_and_clear on one flow_rule's counter table.
+ *
+ * 1. Allocates a new empty table with the same dimensions.
+ * 2. Sets generation = G+1 and epoch_ns on the new table.
+ * 3. Atomically swaps the table pointer in tables[flow_rule_index].
+ * 4. Enqueues the old table for RCU retirement.
+ *
+ * @param mgr              Snapshot manager.
+ * @param tables           Pointer to the tables array (e.g. pm->tables).
+ * @param flow_rule_index  Index of the flow_rule to snapshot.
+ * @param max_flow_rules   Size of the tables array.
+ * @param max_key_width    Key width for the new table (same as old).
+ * @param reply            Output: result + retired table info.
+ */
+void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr,
+                               infmon_counter_table_t **tables,
+                               uint32_t flow_rule_index,
+                               uint32_t max_flow_rules,
+                               uint32_t max_key_width,
+                               infmon_snap_reply_t *reply);
+
+/**
+ * Poll for retired tables whose grace period has expired.
+ * Frees any that are safe to reclaim.
+ *
+ * @param mgr  Snapshot manager.
+ * @return Number of tables freed this call.
+ */
+uint32_t infmon_retire_poll(infmon_snapshot_mgr_t *mgr);
+
+/**
+ * Check whether all workers have advanced past a given epoch.
+ *
+ * @param mgr    Snapshot manager.
+ * @param epoch  The epoch to check against.
+ * @return true if every worker's epoch > epoch.
+ */
+bool infmon_all_workers_past(const infmon_snapshot_mgr_t *mgr, uint64_t epoch);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INFMON_SNAPSHOT_H */

--- a/src/backend/include/infmon/snapshot.h
+++ b/src/backend/include/infmon/snapshot.h
@@ -28,7 +28,7 @@ extern "C" {
 #define INFMON_MAX_RETIRED 16
 
 /** Default grace period in nanoseconds (5 seconds). */
-#define INFMON_RETIRE_GRACE_NS ((uint64_t)5000000000ULL)
+#define INFMON_RETIRE_GRACE_NS ((uint64_t) 5000000000ULL)
 
 /* ── Per-worker epoch counter ────────────────────────────────────── */
 
@@ -45,11 +45,11 @@ typedef struct {
 /* ── Retired table descriptor ────────────────────────────────────── */
 
 typedef struct {
-    infmon_counter_table_t *table;      /** The retired table. */
-    uint64_t swap_epoch;                /** Global epoch at time of swap. */
-    uint64_t swap_timestamp_ns;         /** Wall-clock timestamp of swap. */
-    uint32_t flow_rule_index;           /** Which flow_rule this belonged to. */
-    bool pending;                       /** true if still awaiting retirement. */
+    infmon_counter_table_t *table; /** The retired table. */
+    uint64_t swap_epoch;           /** Global epoch at time of swap. */
+    uint64_t swap_timestamp_ns;    /** Wall-clock timestamp of swap. */
+    uint32_t flow_rule_index;      /** Which flow_rule this belonged to. */
+    bool pending;                  /** true if still awaiting retirement. */
 } infmon_retired_table_t;
 
 /* ── Snapshot manager ────────────────────────────────────────────── */
@@ -69,12 +69,12 @@ typedef struct {
     infmon_worker_epoch_t worker_epochs[INFMON_MAX_WORKERS];
     uint32_t num_workers;
 
-    uint64_t global_epoch;              /** Bumped on each swap. */
+    uint64_t global_epoch; /** Bumped on each swap. */
 
     infmon_retired_table_t retired[INFMON_MAX_RETIRED];
-    uint32_t retired_count;             /** Number of pending entries. */
+    uint32_t retired_count; /** Number of pending entries. */
 
-    uint64_t grace_ns;                  /** Configurable grace window. */
+    uint64_t grace_ns; /** Configurable grace window. */
 
     /* Callback for getting wall-clock nanoseconds (injectable for testing). */
     uint64_t (*clock_ns)(void);
@@ -84,16 +84,16 @@ typedef struct {
 
 typedef enum {
     INFMON_SNAP_OK = 0,
-    INFMON_SNAP_ALLOC_FAILED,           /** Could not allocate replacement table. */
-    INFMON_SNAP_TOO_MANY_RETIRED,       /** Retired ring is full. */
-    INFMON_SNAP_INVALID_INDEX,          /** flow_rule_index out of range. */
-    INFMON_SNAP_NULL_TABLE,             /** No table installed at that index. */
+    INFMON_SNAP_ALLOC_FAILED,     /** Could not allocate replacement table. */
+    INFMON_SNAP_TOO_MANY_RETIRED, /** Retired ring is full. */
+    INFMON_SNAP_INVALID_INDEX,    /** flow_rule_index out of range. */
+    INFMON_SNAP_NULL_TABLE,       /** No table installed at that index. */
 } infmon_snap_result_t;
 
 typedef struct {
     infmon_snap_result_t result;
-    infmon_counter_table_t *retired_table;   /** The old table (generation G). */
-    uint64_t retired_generation;             /** Generation of the retired table. */
+    infmon_counter_table_t *retired_table; /** The old table (generation G). */
+    uint64_t retired_generation;           /** Generation of the retired table. */
 } infmon_snap_reply_t;
 
 /* ── Lifecycle ───────────────────────────────────────────────────── */
@@ -106,8 +106,8 @@ typedef struct {
  * @param grace_ns     Grace period in nanoseconds (0 = use default).
  * @param clock_ns     Wall-clock function (NULL = use clock_gettime).
  */
-void infmon_snapshot_mgr_init(infmon_snapshot_mgr_t *mgr, uint32_t num_workers,
-                              uint64_t grace_ns, uint64_t (*clock_ns)(void));
+void infmon_snapshot_mgr_init(infmon_snapshot_mgr_t *mgr, uint32_t num_workers, uint64_t grace_ns,
+                              uint64_t (*clock_ns)(void));
 
 /**
  * Destroy the snapshot manager.  Frees any retired tables still pending.
@@ -129,7 +129,7 @@ static inline void infmon_worker_epoch_bump(infmon_snapshot_mgr_t *mgr, uint32_t
  * Read a worker's published epoch (for control thread use).
  */
 static inline uint64_t infmon_worker_epoch_read(const infmon_snapshot_mgr_t *mgr,
-                                                 uint32_t worker_id)
+                                                uint32_t worker_id)
 {
     return __atomic_load_n(&mgr->worker_epochs[worker_id].epoch, __ATOMIC_ACQUIRE);
 }
@@ -151,12 +151,9 @@ static inline uint64_t infmon_worker_epoch_read(const infmon_snapshot_mgr_t *mgr
  * @param max_key_width    Key width for the new table (same as old).
  * @param reply            Output: result + retired table info.
  */
-void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr,
-                               infmon_counter_table_t **tables,
-                               uint32_t flow_rule_index,
-                               uint32_t max_flow_rules,
-                               uint32_t max_key_width,
-                               infmon_snap_reply_t *reply);
+void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_t **tables,
+                               uint32_t flow_rule_index, uint32_t max_flow_rules,
+                               uint32_t max_key_width, infmon_snap_reply_t *reply);
 
 /**
  * Poll for retired tables whose grace period has expired.

--- a/src/backend/include/infmon/snapshot.h
+++ b/src/backend/include/infmon/snapshot.h
@@ -9,10 +9,10 @@
 #ifndef INFMON_SNAPSHOT_H
 #define INFMON_SNAPSHOT_H
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <assert.h>
 
 #include "infmon/counter_table.h"
 

--- a/src/backend/include/infmon/snapshot.h
+++ b/src/backend/include/infmon/snapshot.h
@@ -12,6 +12,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <assert.h>
 
 #include "infmon/counter_table.h"
 
@@ -39,7 +40,7 @@ extern "C" {
  */
 typedef struct {
     uint64_t epoch;
-    uint8_t _pad[56]; /* pad to 64 B to avoid false sharing */
+    uint8_t pad[64 - sizeof(uint64_t)]; /* pad to 64 B to avoid false sharing */
 } __attribute__((aligned(64))) infmon_worker_epoch_t;
 
 /* ── Retired table descriptor ────────────────────────────────────── */
@@ -122,7 +123,10 @@ void infmon_snapshot_mgr_destroy(infmon_snapshot_mgr_t *mgr);
  */
 static inline void infmon_worker_epoch_bump(infmon_snapshot_mgr_t *mgr, uint32_t worker_id)
 {
-    __atomic_fetch_add(&mgr->worker_epochs[worker_id].epoch, 1, __ATOMIC_RELEASE);
+    assert(worker_id < mgr->num_workers);
+    /* Single-writer: relaxed load + release store avoids locked RMW. */
+    uint64_t e = __atomic_load_n(&mgr->worker_epochs[worker_id].epoch, __ATOMIC_RELAXED);
+    __atomic_store_n(&mgr->worker_epochs[worker_id].epoch, e + 1, __ATOMIC_RELEASE);
 }
 
 /**
@@ -131,6 +135,7 @@ static inline void infmon_worker_epoch_bump(infmon_snapshot_mgr_t *mgr, uint32_t
 static inline uint64_t infmon_worker_epoch_read(const infmon_snapshot_mgr_t *mgr,
                                                 uint32_t worker_id)
 {
+    assert(worker_id < mgr->num_workers);
     return __atomic_load_n(&mgr->worker_epochs[worker_id].epoch, __ATOMIC_ACQUIRE);
 }
 

--- a/src/backend/include/infmon/snapshot.h
+++ b/src/backend/include/infmon/snapshot.h
@@ -46,11 +46,11 @@ typedef struct {
 /* ── Retired table descriptor ────────────────────────────────────── */
 
 typedef struct {
-    infmon_counter_table_t *table; /** The retired table. */
-    uint64_t swap_epoch;           /** Global epoch at time of swap. */
-    uint64_t swap_timestamp_ns;    /** Wall-clock timestamp of swap. */
-    uint32_t flow_rule_index;      /** Which flow_rule this belonged to. */
-    bool pending;                  /** true if still awaiting retirement. */
+    infmon_counter_table_t *table; /**< The retired table. */
+    uint64_t swap_epoch;           /**< Global epoch at time of swap. */
+    uint64_t swap_timestamp_ns;    /**< Wall-clock timestamp of swap. */
+    uint32_t flow_rule_index;      /**< Which flow_rule this belonged to. */
+    bool pending;                  /**< true if still awaiting retirement. */
 } infmon_retired_table_t;
 
 /* ── Snapshot manager ────────────────────────────────────────────── */
@@ -65,17 +65,20 @@ typedef struct {
  *   - Workers call infmon_worker_epoch_bump() from the data path (no lock).
  *   - The control thread calls infmon_snapshot_and_clear() and
  *     infmon_retire_poll() (serialised — only one control thread).
+ *
+ * @note This struct is >3KB due to cache-line-padded worker epochs.
+ *       Do not stack-allocate; use heap allocation or static/BSS placement.
  */
 typedef struct {
     infmon_worker_epoch_t worker_epochs[INFMON_MAX_WORKERS];
     uint32_t num_workers;
 
-    uint64_t global_epoch; /** Bumped on each swap. */
+    uint64_t global_epoch; /**< Bumped on each swap. */
 
     infmon_retired_table_t retired[INFMON_MAX_RETIRED];
-    uint32_t retired_count; /** Number of pending entries. */
+    uint32_t retired_count; /**< Number of pending entries. */
 
-    uint64_t grace_ns; /** Configurable grace window. */
+    uint64_t grace_ns; /**< Configurable grace window. */
 
     /* Callback for getting wall-clock nanoseconds (injectable for testing). */
     uint64_t (*clock_ns)(void);
@@ -85,16 +88,16 @@ typedef struct {
 
 typedef enum {
     INFMON_SNAP_OK = 0,
-    INFMON_SNAP_ALLOC_FAILED,     /** Could not allocate replacement table. */
-    INFMON_SNAP_TOO_MANY_RETIRED, /** Retired ring is full. */
-    INFMON_SNAP_INVALID_INDEX,    /** flow_rule_index out of range. */
-    INFMON_SNAP_NULL_TABLE,       /** No table installed at that index. */
+    INFMON_SNAP_ALLOC_FAILED,     /**< Could not allocate replacement table. */
+    INFMON_SNAP_TOO_MANY_RETIRED, /**< Retired ring is full. */
+    INFMON_SNAP_INVALID_INDEX,    /**< flow_rule_index out of range. */
+    INFMON_SNAP_NULL_TABLE,       /**< No table installed at that index. */
 } infmon_snap_result_t;
 
 typedef struct {
     infmon_snap_result_t result;
-    infmon_counter_table_t *retired_table; /** The old table (generation G). */
-    uint64_t retired_generation;           /** Generation of the retired table. */
+    infmon_counter_table_t *retired_table; /**< The old table (generation G). */
+    uint64_t retired_generation;           /**< Generation of the retired table. */
 } infmon_snap_reply_t;
 
 /* ── Lifecycle ───────────────────────────────────────────────────── */

--- a/src/backend/src/snapshot.c
+++ b/src/backend/src/snapshot.c
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * snapshot_and_clear implementation — see specs/004-backend-architecture.md §7.2
+ */
+
+#include "infmon/snapshot.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* ── Default clock ───────────────────────────────────────────────── */
+
+static uint64_t default_clock_ns(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+/* ── Lifecycle ───────────────────────────────────────────────────── */
+
+void infmon_snapshot_mgr_init(infmon_snapshot_mgr_t *mgr, uint32_t num_workers,
+                              uint64_t grace_ns, uint64_t (*clock_ns)(void))
+{
+    memset(mgr, 0, sizeof(*mgr));
+
+    if (num_workers > INFMON_MAX_WORKERS)
+        num_workers = INFMON_MAX_WORKERS;
+
+    mgr->num_workers = num_workers;
+    mgr->global_epoch = 0;
+    mgr->retired_count = 0;
+    mgr->grace_ns = (grace_ns > 0) ? grace_ns : INFMON_RETIRE_GRACE_NS;
+    mgr->clock_ns = clock_ns ? clock_ns : default_clock_ns;
+}
+
+void infmon_snapshot_mgr_destroy(infmon_snapshot_mgr_t *mgr)
+{
+    if (!mgr)
+        return;
+
+    /* Free any retired tables still pending */
+    for (uint32_t i = 0; i < INFMON_MAX_RETIRED; i++) {
+        if (mgr->retired[i].pending && mgr->retired[i].table) {
+            infmon_counter_table_destroy(mgr->retired[i].table);
+            mgr->retired[i].table = NULL;
+            mgr->retired[i].pending = false;
+        }
+    }
+    mgr->retired_count = 0;
+}
+
+/* ── Quiescence check ────────────────────────────────────────────── */
+
+bool infmon_all_workers_past(const infmon_snapshot_mgr_t *mgr, uint64_t epoch)
+{
+    for (uint32_t i = 0; i < mgr->num_workers; i++) {
+        if (infmon_worker_epoch_read(mgr, i) <= epoch)
+            return false;
+    }
+    return true;
+}
+
+/* ── Snapshot and clear ──────────────────────────────────────────── */
+
+void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr,
+                               infmon_counter_table_t **tables,
+                               uint32_t flow_rule_index,
+                               uint32_t max_flow_rules,
+                               uint32_t max_key_width,
+                               infmon_snap_reply_t *reply)
+{
+    memset(reply, 0, sizeof(*reply));
+
+    /* Validate index */
+    if (flow_rule_index >= max_flow_rules) {
+        reply->result = INFMON_SNAP_INVALID_INDEX;
+        return;
+    }
+
+    /* Get the current table */
+    infmon_counter_table_t *old_table =
+        __atomic_load_n(&tables[flow_rule_index], __ATOMIC_ACQUIRE);
+
+    if (!old_table) {
+        reply->result = INFMON_SNAP_NULL_TABLE;
+        return;
+    }
+
+    /* Check retired ring capacity */
+    if (mgr->retired_count >= INFMON_MAX_RETIRED) {
+        reply->result = INFMON_SNAP_TOO_MANY_RETIRED;
+        return;
+    }
+
+    /* Allocate new empty table with same dimensions */
+    infmon_counter_table_t *new_table =
+        infmon_counter_table_create(old_table->num_slots, max_key_width);
+
+    if (!new_table) {
+        reply->result = INFMON_SNAP_ALLOC_FAILED;
+        return;
+    }
+
+    /* Set new table metadata */
+    uint64_t new_gen = old_table->generation + 1;
+    new_table->generation = new_gen;
+    new_table->epoch_ns = mgr->clock_ns();
+
+    /* Bump global epoch for this swap */
+    uint64_t swap_epoch = ++mgr->global_epoch;
+
+    /*
+     * Atomic pointer swap: RELEASE ensures the new table's contents
+     * (zeroed slots, metadata) are visible before any worker observes
+     * the new pointer.  Workers load with ACQUIRE once per frame.
+     */
+    __atomic_store_n(&tables[flow_rule_index], new_table, __ATOMIC_RELEASE);
+
+    /* Enqueue old table for retirement */
+    for (uint32_t i = 0; i < INFMON_MAX_RETIRED; i++) {
+        if (!mgr->retired[i].pending) {
+            mgr->retired[i].table = old_table;
+            mgr->retired[i].swap_epoch = swap_epoch;
+            mgr->retired[i].swap_timestamp_ns = mgr->clock_ns();
+            mgr->retired[i].flow_rule_index = flow_rule_index;
+            mgr->retired[i].pending = true;
+            mgr->retired_count++;
+            break;
+        }
+    }
+
+    /* Fill reply */
+    reply->result = INFMON_SNAP_OK;
+    reply->retired_table = old_table;
+    reply->retired_generation = old_table->generation;
+}
+
+/* ── Retire poll ─────────────────────────────────────────────────── */
+
+uint32_t infmon_retire_poll(infmon_snapshot_mgr_t *mgr)
+{
+    uint32_t freed = 0;
+    uint64_t now = mgr->clock_ns();
+
+    for (uint32_t i = 0; i < INFMON_MAX_RETIRED; i++) {
+        if (!mgr->retired[i].pending)
+            continue;
+
+        infmon_retired_table_t *rt = &mgr->retired[i];
+
+        /* Two conditions for safe reclamation:
+         * 1. All workers have advanced past the swap epoch.
+         * 2. Grace period has elapsed since the swap.
+         */
+        if (!infmon_all_workers_past(mgr, rt->swap_epoch))
+            continue;
+
+        if (now - rt->swap_timestamp_ns < mgr->grace_ns)
+            continue;
+
+        /* Safe to free */
+        infmon_counter_table_destroy(rt->table);
+        rt->table = NULL;
+        rt->pending = false;
+        mgr->retired_count--;
+        freed++;
+    }
+
+    return freed;
+}

--- a/src/backend/src/snapshot.c
+++ b/src/backend/src/snapshot.c
@@ -161,7 +161,7 @@ uint32_t infmon_retire_poll(infmon_snapshot_mgr_t *mgr)
         if (!infmon_all_workers_past(mgr, rt->swap_epoch))
             continue;
 
-        if (now - rt->swap_timestamp_ns < mgr->grace_ns)
+        if (now <= rt->swap_timestamp_ns || (now - rt->swap_timestamp_ns) < mgr->grace_ns)
             continue;
 
         /* Safe to free */

--- a/src/backend/src/snapshot.c
+++ b/src/backend/src/snapshot.c
@@ -17,13 +17,13 @@ static uint64_t default_clock_ns(void)
 {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+    return (uint64_t) ts.tv_sec * 1000000000ULL + (uint64_t) ts.tv_nsec;
 }
 
 /* ── Lifecycle ───────────────────────────────────────────────────── */
 
-void infmon_snapshot_mgr_init(infmon_snapshot_mgr_t *mgr, uint32_t num_workers,
-                              uint64_t grace_ns, uint64_t (*clock_ns)(void))
+void infmon_snapshot_mgr_init(infmon_snapshot_mgr_t *mgr, uint32_t num_workers, uint64_t grace_ns,
+                              uint64_t (*clock_ns)(void))
 {
     memset(mgr, 0, sizeof(*mgr));
 
@@ -66,12 +66,9 @@ bool infmon_all_workers_past(const infmon_snapshot_mgr_t *mgr, uint64_t epoch)
 
 /* ── Snapshot and clear ──────────────────────────────────────────── */
 
-void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr,
-                               infmon_counter_table_t **tables,
-                               uint32_t flow_rule_index,
-                               uint32_t max_flow_rules,
-                               uint32_t max_key_width,
-                               infmon_snap_reply_t *reply)
+void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_t **tables,
+                               uint32_t flow_rule_index, uint32_t max_flow_rules,
+                               uint32_t max_key_width, infmon_snap_reply_t *reply)
 {
     memset(reply, 0, sizeof(*reply));
 
@@ -82,8 +79,7 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr,
     }
 
     /* Get the current table */
-    infmon_counter_table_t *old_table =
-        __atomic_load_n(&tables[flow_rule_index], __ATOMIC_ACQUIRE);
+    infmon_counter_table_t *old_table = __atomic_load_n(&tables[flow_rule_index], __ATOMIC_ACQUIRE);
 
     if (!old_table) {
         reply->result = INFMON_SNAP_NULL_TABLE;

--- a/src/backend/src/snapshot.c
+++ b/src/backend/src/snapshot.c
@@ -7,6 +7,7 @@
 
 #include "infmon/snapshot.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -27,8 +28,7 @@ void infmon_snapshot_mgr_init(infmon_snapshot_mgr_t *mgr, uint32_t num_workers, 
 {
     memset(mgr, 0, sizeof(*mgr));
 
-    if (num_workers > INFMON_MAX_WORKERS)
-        num_workers = INFMON_MAX_WORKERS;
+    assert(num_workers <= INFMON_MAX_WORKERS && "num_workers exceeds INFMON_MAX_WORKERS");
 
     mgr->num_workers = num_workers;
     mgr->global_epoch = 0;
@@ -104,9 +104,13 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
     /* Set new table metadata */
     uint64_t new_gen = old_table->generation + 1;
     new_table->generation = new_gen;
-    new_table->epoch_ns = mgr->clock_ns();
 
-    /* Bump global epoch for this swap */
+    /* Capture wall-clock once for both new table and retired entry. */
+    uint64_t now = mgr->clock_ns();
+    new_table->epoch_ns = now;
+
+    /* Bump global epoch for this swap.
+     * NOT thread-safe: caller must serialize (single control thread). */
     uint64_t swap_epoch = ++mgr->global_epoch;
 
     /*
@@ -121,13 +125,15 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
         if (!mgr->retired[i].pending) {
             mgr->retired[i].table = old_table;
             mgr->retired[i].swap_epoch = swap_epoch;
-            mgr->retired[i].swap_timestamp_ns = mgr->clock_ns();
+            mgr->retired[i].swap_timestamp_ns = now;
             mgr->retired[i].flow_rule_index = flow_rule_index;
             mgr->retired[i].pending = true;
             mgr->retired_count++;
             break;
         }
     }
+    /* Should be unreachable: retired_count was checked above */
+    /* (If we exit the loop without break, something is out of sync.) */
 
     /* Fill reply */
     reply->result = INFMON_SNAP_OK;

--- a/src/backend/test/test_snapshot.cc
+++ b/src/backend/test/test_snapshot.cc
@@ -255,6 +255,8 @@ TEST_F(SnapshotTest, RetiredRingFull)
     }
 
     /* Next swap should fail with TOO_MANY_RETIRED */
+    infmon_counter_table_destroy(tables[0]);
+    tables[0] = nullptr;
     install_table(0); /* tables[0] was swapped above, so it's a fresh table */
     infmon_snap_reply_t reply{};
     infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
@@ -305,10 +307,12 @@ TEST_F(SnapshotTest, ConcurrentEpochBumps)
 
         advance_clock_ns(INFMON_RETIRE_GRACE_NS + 1);
         /* Poll until freed — workers are bumping so this should eventually succeed */
-        for (int attempt = 0; attempt < 100; attempt++) {
+        int attempt;
+        for (attempt = 0; attempt < 100; attempt++) {
             if (infmon_retire_poll(&mgr) > 0)
                 break;
         }
+        ASSERT_LT(attempt, 100) << "retire_poll never freed the table";
     }
 
     stop.store(true);

--- a/src/backend/test/test_snapshot.cc
+++ b/src/backend/test/test_snapshot.cc
@@ -6,6 +6,7 @@
  */
 
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <gtest/gtest.h>
 #include <thread>
@@ -311,6 +312,7 @@ TEST_F(SnapshotTest, ConcurrentEpochBumps)
         for (attempt = 0; attempt < 100; attempt++) {
             if (infmon_retire_poll(&mgr) > 0)
                 break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
         ASSERT_LT(attempt, 100) << "retire_poll never freed the table";
     }

--- a/src/backend/test/test_snapshot.cc
+++ b/src/backend/test/test_snapshot.cc
@@ -5,15 +5,15 @@
  * Tests for snapshot_and_clear — see specs/004-backend-architecture.md §7.2
  */
 
+#include <atomic>
+#include <cstring>
 #include <gtest/gtest.h>
 #include <thread>
-#include <atomic>
 #include <vector>
-#include <cstring>
 
 extern "C" {
-#include "infmon/snapshot.h"
 #include "infmon/counter_table.h"
+#include "infmon/snapshot.h"
 }
 
 /* ── Test helpers ────────────────────────────────────────────────── */
@@ -34,8 +34,9 @@ static void advance_clock_ns(uint64_t delta)
 #define MAX_FLOW_RULES 64
 #define MAX_KEY_WIDTH 32
 
-class SnapshotTest : public ::testing::Test {
-protected:
+class SnapshotTest : public ::testing::Test
+{
+  protected:
     infmon_snapshot_mgr_t mgr{};
     infmon_counter_table_t *tables[MAX_FLOW_RULES]{};
 
@@ -120,7 +121,7 @@ TEST_F(SnapshotTest, SequentialSwaps)
         ASSERT_EQ(tables[0]->generation, gen + 1);
 
         /* Advance workers past the swap epoch (need epoch > swap_epoch) */
-        for (int bump = 0; bump <= (int)gen + 1; bump++)
+        for (int bump = 0; bump <= (int) gen + 1; bump++)
             for (uint32_t w = 0; w < mgr.num_workers; w++)
                 infmon_worker_epoch_bump(&mgr, w);
 

--- a/src/backend/test/test_snapshot.cc
+++ b/src/backend/test/test_snapshot.cc
@@ -1,0 +1,426 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Riff
+ *
+ * Tests for snapshot_and_clear — see specs/004-backend-architecture.md §7.2
+ */
+
+#include <gtest/gtest.h>
+#include <thread>
+#include <atomic>
+#include <vector>
+#include <cstring>
+
+extern "C" {
+#include "infmon/snapshot.h"
+#include "infmon/counter_table.h"
+}
+
+/* ── Test helpers ────────────────────────────────────────────────── */
+
+static std::atomic<uint64_t> g_fake_clock_ns{1000000000ULL}; /* 1 second */
+
+static uint64_t fake_clock_ns(void)
+{
+    return g_fake_clock_ns.load(std::memory_order_relaxed);
+}
+
+static void advance_clock_ns(uint64_t delta)
+{
+    g_fake_clock_ns.fetch_add(delta, std::memory_order_relaxed);
+}
+
+/* Max flow rules (matches graph_node.h) */
+#define MAX_FLOW_RULES 64
+#define MAX_KEY_WIDTH 32
+
+class SnapshotTest : public ::testing::Test {
+protected:
+    infmon_snapshot_mgr_t mgr{};
+    infmon_counter_table_t *tables[MAX_FLOW_RULES]{};
+
+    void SetUp() override
+    {
+        g_fake_clock_ns.store(1000000000ULL);
+        infmon_snapshot_mgr_init(&mgr, 4, INFMON_RETIRE_GRACE_NS, fake_clock_ns);
+    }
+
+    void TearDown() override
+    {
+        infmon_snapshot_mgr_destroy(&mgr);
+        for (uint32_t i = 0; i < MAX_FLOW_RULES; i++) {
+            if (tables[i]) {
+                infmon_counter_table_destroy(tables[i]);
+                tables[i] = nullptr;
+            }
+        }
+    }
+
+    /* Install a table at the given index with some data */
+    void install_table(uint32_t idx, uint32_t max_keys = 1024)
+    {
+        tables[idx] = infmon_counter_table_create(max_keys, MAX_KEY_WIDTH);
+        ASSERT_NE(tables[idx], nullptr);
+    }
+
+    /* Insert a key into a table and return whether it succeeded */
+    bool insert_key(uint32_t table_idx, uint64_t hash, uint64_t pkt_bytes)
+    {
+        uint8_t key[8];
+        memcpy(key, &hash, sizeof(key));
+        return infmon_counter_table_update(tables[table_idx], hash, key, 8, pkt_bytes, 1);
+    }
+};
+
+/* ── Basic snapshot ──────────────────────────────────────────────── */
+
+TEST_F(SnapshotTest, BasicSwap)
+{
+    install_table(0);
+
+    /* Insert some data into the table */
+    ASSERT_TRUE(insert_key(0, 0xAAAA, 100));
+    ASSERT_TRUE(insert_key(0, 0xBBBB, 200));
+
+    infmon_counter_table_t *original = tables[0];
+    ASSERT_EQ(original->generation, 0u);
+    ASSERT_EQ(original->occupied_count, 2u);
+
+    /* Perform snapshot */
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+    ASSERT_EQ(reply.retired_table, original);
+    ASSERT_EQ(reply.retired_generation, 0u);
+
+    /* New table is empty with generation = 1 */
+    ASSERT_NE(tables[0], original);
+    ASSERT_EQ(tables[0]->generation, 1u);
+    ASSERT_EQ(tables[0]->occupied_count, 0u);
+
+    /* Old table data is still intact (immutable post-swap) */
+    ASSERT_EQ(original->occupied_count, 2u);
+}
+
+/* ── Multiple sequential snapshots ───────────────────────────────── */
+
+TEST_F(SnapshotTest, SequentialSwaps)
+{
+    install_table(0);
+
+    /* Advance workers past each epoch and poll to free retired tables */
+    for (uint32_t gen = 0; gen < 5; gen++) {
+        insert_key(0, 0x1000 + gen, 64);
+
+        infmon_snap_reply_t reply{};
+        infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+        ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+        ASSERT_EQ(reply.retired_generation, gen);
+        ASSERT_EQ(tables[0]->generation, gen + 1);
+
+        /* Advance workers past the swap epoch (need epoch > swap_epoch) */
+        for (int bump = 0; bump <= (int)gen + 1; bump++)
+            for (uint32_t w = 0; w < mgr.num_workers; w++)
+                infmon_worker_epoch_bump(&mgr, w);
+
+        /* Advance clock past grace period */
+        advance_clock_ns(INFMON_RETIRE_GRACE_NS + 1);
+
+        /* Poll to free retired tables */
+        uint32_t freed = infmon_retire_poll(&mgr);
+        ASSERT_EQ(freed, 1u);
+    }
+}
+
+/* ── Generation tracking ─────────────────────────────────────────── */
+
+TEST_F(SnapshotTest, GenerationIncrement)
+{
+    install_table(0);
+    tables[0]->generation = 42;
+
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+    ASSERT_EQ(reply.retired_generation, 42u);
+    ASSERT_EQ(tables[0]->generation, 43u);
+}
+
+/* ── New table has epoch_ns set ──────────────────────────────────── */
+
+TEST_F(SnapshotTest, EpochNsSet)
+{
+    install_table(0);
+
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+    ASSERT_GT(tables[0]->epoch_ns, 0u);
+}
+
+/* ── Error: invalid index ────────────────────────────────────────── */
+
+TEST_F(SnapshotTest, InvalidIndex)
+{
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, MAX_FLOW_RULES, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_INVALID_INDEX);
+}
+
+/* ── Error: null table ───────────────────────────────────────────── */
+
+TEST_F(SnapshotTest, NullTable)
+{
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_NULL_TABLE);
+}
+
+/* ── Retired table is not freed before grace period ──────────────── */
+
+TEST_F(SnapshotTest, GracePeriodRespected)
+{
+    install_table(0);
+    insert_key(0, 0xDEAD, 512);
+
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+    ASSERT_EQ(mgr.retired_count, 1u);
+
+    /* Advance workers but NOT the clock */
+    for (uint32_t w = 0; w < mgr.num_workers; w++) {
+        infmon_worker_epoch_bump(&mgr, w);
+        infmon_worker_epoch_bump(&mgr, w);
+    }
+
+    uint32_t freed = infmon_retire_poll(&mgr);
+    ASSERT_EQ(freed, 0u); /* Grace period not elapsed */
+    ASSERT_EQ(mgr.retired_count, 1u);
+
+    /* Now advance clock */
+    advance_clock_ns(INFMON_RETIRE_GRACE_NS + 1);
+    freed = infmon_retire_poll(&mgr);
+    ASSERT_EQ(freed, 1u);
+    ASSERT_EQ(mgr.retired_count, 0u);
+}
+
+/* ── Workers must advance past swap epoch ────────────────────────── */
+
+TEST_F(SnapshotTest, WorkersMustAdvance)
+{
+    install_table(0);
+
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+
+    /* Advance clock but NOT workers */
+    advance_clock_ns(INFMON_RETIRE_GRACE_NS + 1);
+
+    uint32_t freed = infmon_retire_poll(&mgr);
+    ASSERT_EQ(freed, 0u); /* Workers haven't advanced */
+
+    /* Advance only some workers */
+    infmon_worker_epoch_bump(&mgr, 0);
+    infmon_worker_epoch_bump(&mgr, 0);
+    infmon_worker_epoch_bump(&mgr, 1);
+    infmon_worker_epoch_bump(&mgr, 1);
+    freed = infmon_retire_poll(&mgr);
+    ASSERT_EQ(freed, 0u); /* Not all workers */
+
+    /* Advance remaining workers */
+    infmon_worker_epoch_bump(&mgr, 2);
+    infmon_worker_epoch_bump(&mgr, 2);
+    infmon_worker_epoch_bump(&mgr, 3);
+    infmon_worker_epoch_bump(&mgr, 3);
+    freed = infmon_retire_poll(&mgr);
+    ASSERT_EQ(freed, 1u);
+}
+
+/* ── Retired ring full ───────────────────────────────────────────── */
+
+TEST_F(SnapshotTest, RetiredRingFull)
+{
+    /* Fill the retired ring */
+    for (uint32_t i = 0; i < INFMON_MAX_RETIRED; i++) {
+        install_table(i);
+        infmon_snap_reply_t reply{};
+        infmon_snapshot_and_clear(&mgr, tables, i, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+        ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+    }
+
+    /* Next swap should fail with TOO_MANY_RETIRED */
+    install_table(0); /* tables[0] was swapped above, so it's a fresh table */
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_TOO_MANY_RETIRED);
+}
+
+/* ── all_workers_past helper ─────────────────────────────────────── */
+
+TEST_F(SnapshotTest, AllWorkersPast)
+{
+    ASSERT_FALSE(infmon_all_workers_past(&mgr, 0));
+
+    for (uint32_t w = 0; w < mgr.num_workers; w++)
+        infmon_worker_epoch_bump(&mgr, w);
+
+    ASSERT_TRUE(infmon_all_workers_past(&mgr, 0));
+    ASSERT_FALSE(infmon_all_workers_past(&mgr, 1));
+
+    for (uint32_t w = 0; w < mgr.num_workers; w++)
+        infmon_worker_epoch_bump(&mgr, w);
+
+    ASSERT_TRUE(infmon_all_workers_past(&mgr, 1));
+}
+
+/* ── Concurrent workers bumping epochs during snapshot ────────────── */
+
+TEST_F(SnapshotTest, ConcurrentEpochBumps)
+{
+    install_table(0);
+    insert_key(0, 0xCAFE, 128);
+
+    /* Start worker threads that continuously bump epochs */
+    std::atomic<bool> stop{false};
+    std::vector<std::thread> workers;
+    for (uint32_t w = 0; w < mgr.num_workers; w++) {
+        workers.emplace_back([this, w, &stop]() {
+            while (!stop.load(std::memory_order_relaxed)) {
+                infmon_worker_epoch_bump(&mgr, w);
+            }
+        });
+    }
+
+    /* Perform several snapshots while workers are running */
+    for (int i = 0; i < 10; i++) {
+        infmon_snap_reply_t reply{};
+        infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+        ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+
+        advance_clock_ns(INFMON_RETIRE_GRACE_NS + 1);
+        /* Poll until freed — workers are bumping so this should eventually succeed */
+        for (int attempt = 0; attempt < 100; attempt++) {
+            if (infmon_retire_poll(&mgr) > 0)
+                break;
+        }
+    }
+
+    stop.store(true);
+    for (auto &t : workers)
+        t.join();
+
+    /* Clean up any remaining retired tables */
+    advance_clock_ns(INFMON_RETIRE_GRACE_NS + 1);
+    infmon_retire_poll(&mgr);
+}
+
+/* ── Atomic pointer swap is visible to reader thread ─────────────── */
+
+TEST_F(SnapshotTest, AtomicSwapVisibility)
+{
+    install_table(0);
+    infmon_counter_table_t *original = tables[0];
+
+    std::atomic<bool> swapped{false};
+    std::atomic<infmon_counter_table_t *> observed{nullptr};
+
+    /* Reader thread: spin until it sees a different table pointer */
+    std::thread reader([this, original, &swapped, &observed]() {
+        while (!swapped.load(std::memory_order_acquire)) {
+            /* nothing */
+        }
+        /* After swap flag is set, load the table pointer with ACQUIRE */
+        infmon_counter_table_t *t = __atomic_load_n(&tables[0], __ATOMIC_ACQUIRE);
+        observed.store(t, std::memory_order_release);
+    });
+
+    /* Perform snapshot (writes with RELEASE) */
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+
+    swapped.store(true, std::memory_order_release);
+    reader.join();
+
+    /* Reader must see the new table, not the old one */
+    ASSERT_NE(observed.load(), nullptr);
+    ASSERT_NE(observed.load(), original);
+    ASSERT_EQ(observed.load(), tables[0]);
+}
+
+/* ── Zero-worker edge case ───────────────────────────────────────── */
+
+TEST_F(SnapshotTest, ZeroWorkers)
+{
+    infmon_snapshot_mgr_t mgr0{};
+    infmon_snapshot_mgr_init(&mgr0, 0, INFMON_RETIRE_GRACE_NS, fake_clock_ns);
+
+    /* With 0 workers, all_workers_past should always be true */
+    ASSERT_TRUE(infmon_all_workers_past(&mgr0, 0));
+    ASSERT_TRUE(infmon_all_workers_past(&mgr0, 999));
+
+    install_table(0);
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr0, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+
+    /* Should be freeable after grace period only */
+    advance_clock_ns(INFMON_RETIRE_GRACE_NS + 1);
+    uint32_t freed = infmon_retire_poll(&mgr0);
+    ASSERT_EQ(freed, 1u);
+
+    infmon_snapshot_mgr_destroy(&mgr0);
+}
+
+/* ── Destroy frees pending retired tables ────────────────────────── */
+
+TEST_F(SnapshotTest, DestroyFreesPending)
+{
+    install_table(0);
+
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+    ASSERT_EQ(mgr.retired_count, 1u);
+
+    /* Destroy should free the retired table without crashing */
+    infmon_snapshot_mgr_destroy(&mgr);
+    ASSERT_EQ(mgr.retired_count, 0u);
+
+    /* Re-init for TearDown */
+    infmon_snapshot_mgr_init(&mgr, 4, INFMON_RETIRE_GRACE_NS, fake_clock_ns);
+}
+
+/* ── Multiple flow rules can be snapshotted independently ────────── */
+
+TEST_F(SnapshotTest, MultipleFlowRules)
+{
+    install_table(0);
+    install_table(1);
+    install_table(2);
+
+    insert_key(0, 0xAAAA, 100);
+    insert_key(1, 0xBBBB, 200);
+    insert_key(2, 0xCCCC, 300);
+
+    /* Snapshot flow_rule 1 only */
+    infmon_snap_reply_t reply{};
+    infmon_snapshot_and_clear(&mgr, tables, 1, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+
+    /* flow_rule 0 and 2 untouched */
+    ASSERT_EQ(tables[0]->occupied_count, 1u);
+    ASSERT_EQ(tables[2]->occupied_count, 1u);
+
+    /* flow_rule 1 has a fresh empty table */
+    ASSERT_EQ(tables[1]->occupied_count, 0u);
+    ASSERT_EQ(tables[1]->generation, 1u);
+
+    /* Retired table has the old data */
+    ASSERT_EQ(reply.retired_table->occupied_count, 1u);
+}


### PR DESCRIPTION
## Summary

Implements the `snapshot_and_clear` operation from spec 004 §7.2 — the export primitive that atomically swaps counter tables with zero worker stall.

### What's included

- **`infmon_snapshot_mgr_t`** — manages per-worker epoch counters (cache-line aligned to avoid false sharing) and a ring of up to 16 retired tables awaiting grace-period expiry
- **`infmon_snapshot_and_clear()`** — allocates a new empty counter table (generation G+1), atomically swaps the pointer with `__atomic_store_n(..., RELEASE)` (workers load with `ACQUIRE` once per frame), and enqueues the old table for RCU retirement
- **`infmon_retire_poll()`** — reclaims retired tables after both conditions are met: (1) all workers have advanced their epoch past the swap epoch, and (2) the configurable grace window (default 5s) has elapsed
- **`infmon_worker_epoch_bump()`** — inline function called by each worker once per dispatch loop iteration

### Key design properties (per §7.2)

- **Zero worker stall** — no locks, no barriers, no `vlib_worker_thread_barrier_*` on the data path
- **No reset bit** — new table starts at zero because it's freshly allocated, not because anyone zeroed shared memory
- **No lost packets** — backend keeps counting on the new table from the very next frame
- **Internally consistent snapshots** — retired table is immutable post-swap, readable without seqlocks
- **Injectable clock** — deterministic testing with fake wall-clock

### Tests

15 gtest cases covering:
- Basic swap, sequential swaps, generation tracking, epoch_ns
- Error paths: invalid index, null table, retired ring full
- Grace period enforcement, worker epoch advancement requirements
- Concurrent epoch bumps with std::thread workers
- Atomic pointer visibility across threads
- Zero-worker edge case, destroy cleanup, multi-flow-rule independence

All existing tests continue to pass (5/5 suites green).

Closes #42