### PR TITLE
feat(api): add infmon_flow_rule_list and infmon_flow_rule_get handlers (W10c)

### DIFF
--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -68,6 +68,31 @@ infmon_api_result_t infmon_api_flow_rule_add(infmon_api_ctx_t *ctx, const infmon
  */
 infmon_api_result_t infmon_api_flow_rule_del(infmon_api_ctx_t *ctx, const char *name);
 
+/**
+ * Callback invoked once per active flow rule during infmon_api_flow_rule_list().
+ * @p rule  points into the rule set (valid only for the duration of the callback).
+ * @p index is the rule's position in the set.
+ * @p user  is the opaque pointer passed to infmon_api_flow_rule_list().
+ */
+typedef void (*infmon_api_flow_rule_list_cb_t)(const infmon_flow_rule_t *rule, uint32_t index,
+                                               void *user);
+
+/**
+ * Enumerate all active flow rules, invoking @p cb once per rule.
+ * Returns INFMON_API_OK on success, or an error if @p ctx is NULL.
+ */
+infmon_api_result_t infmon_api_flow_rule_list(const infmon_api_ctx_t *ctx,
+                                              infmon_api_flow_rule_list_cb_t cb, void *user);
+
+/**
+ * Retrieve a single flow rule by name.
+ * On success, *out_rule points into the rule set (valid until next add/rm)
+ * and *out_index holds the rule's position.
+ */
+infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx, const char *name,
+                                                     const infmon_flow_rule_t **out_rule,
+                                                     uint32_t *out_index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -91,6 +91,10 @@ infmon_api_result_t infmon_api_flow_rule_list(const infmon_api_ctx_t *ctx,
  * Retrieve a single flow rule by name.
  * On success, *out_rule points into the rule set (valid until next add/rm)
  * and *out_index holds the rule's position.
+ *
+ * @return INFMON_API_OK on success.
+ * @return INFMON_API_ERR_INVALID_RULE if @p ctx or @p name is NULL.
+ * @return INFMON_API_ERR_NOT_FOUND if no rule with @p name exists.
  */
 infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx, const char *name,
                                                      const infmon_flow_rule_t **out_rule,

--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -70,8 +70,8 @@ infmon_api_result_t infmon_api_flow_rule_del(infmon_api_ctx_t *ctx, const char *
 
 /**
  * Callback invoked once per active flow rule during infmon_api_flow_rule_list().
- * @p rule  points into the rule set (valid only for the duration of the callback).
- * @p index is the rule's position in the set.
+ * @p rule  points into the rule set (valid until the next add/rm operation).
+ * @p index is the rule's position in the set (dense, 0..count-1).
  * @p user  is the opaque pointer passed to infmon_api_flow_rule_list().
  */
 typedef void (*infmon_api_flow_rule_list_cb_t)(const infmon_flow_rule_t *rule, uint32_t index,
@@ -79,6 +79,9 @@ typedef void (*infmon_api_flow_rule_list_cb_t)(const infmon_flow_rule_t *rule, u
 
 /**
  * Enumerate all active flow rules, invoking @p cb once per rule.
+ * The rule set must not be modified during iteration (no re-entrant
+ * add/del from within the callback).
+ * @p cb may be NULL (no-op, returns INFMON_API_OK immediately).
  * Returns INFMON_API_OK on success, or an error if @p ctx is NULL.
  */
 infmon_api_result_t infmon_api_flow_rule_list(const infmon_api_ctx_t *ctx,

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -138,3 +138,39 @@ infmon_api_result_t infmon_api_flow_rule_del(infmon_api_ctx_t *ctx, const char *
 
     return INFMON_API_OK;
 }
+
+infmon_api_result_t infmon_api_flow_rule_list(const infmon_api_ctx_t *ctx,
+                                              infmon_api_flow_rule_list_cb_t cb, void *user)
+{
+    if (!ctx)
+        return INFMON_API_ERR_INVALID_RULE;
+
+    uint32_t n = infmon_flow_rule_count(ctx->rule_set);
+    for (uint32_t i = 0; i < n; i++) {
+        const infmon_flow_rule_t *r = infmon_flow_rule_get(ctx->rule_set, i);
+        if (r && cb)
+            cb(r, i, user);
+    }
+    return INFMON_API_OK;
+}
+
+infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx, const char *name,
+                                                     const infmon_flow_rule_t **out_rule,
+                                                     uint32_t *out_index)
+{
+    if (!ctx || !name)
+        return INFMON_API_ERR_INVALID_RULE;
+
+    uint32_t n = infmon_flow_rule_count(ctx->rule_set);
+    for (uint32_t i = 0; i < n; i++) {
+        const infmon_flow_rule_t *r = infmon_flow_rule_get(ctx->rule_set, i);
+        if (r && strcmp(r->name, name) == 0) {
+            if (out_rule)
+                *out_rule = r;
+            if (out_index)
+                *out_index = i;
+            return INFMON_API_OK;
+        }
+    }
+    return INFMON_API_ERR_NOT_FOUND;
+}

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -39,7 +39,7 @@ static uint32_t find_rule_index(const infmon_flow_rule_set_t *set, const char *n
     uint32_t n = infmon_flow_rule_count(set);
     for (uint32_t i = 0; i < n; i++) {
         const infmon_flow_rule_t *r = infmon_flow_rule_get(set, i);
-        if (r && r->name && strcmp(r->name, name) == 0)
+        if (r && strcmp(r->name, name) == 0)
             return i;
     }
     return (uint32_t) -1;
@@ -173,7 +173,7 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
     uint32_t n = infmon_flow_rule_count(ctx->rule_set);
     for (uint32_t i = 0; i < n; i++) {
         const infmon_flow_rule_t *r = infmon_flow_rule_get(ctx->rule_set, i);
-        if (r && r->name && strcmp(r->name, name) == 0) {
+        if (r && strcmp(r->name, name) == 0) {
             if (out_rule)
                 *out_rule = r;
             if (out_index)

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -39,7 +39,7 @@ static uint32_t find_rule_index(const infmon_flow_rule_set_t *set, const char *n
     uint32_t n = infmon_flow_rule_count(set);
     for (uint32_t i = 0; i < n; i++) {
         const infmon_flow_rule_t *r = infmon_flow_rule_get(set, i);
-        if (r && strcmp(r->name, name) == 0)
+        if (r && r->name && strcmp(r->name, name) == 0)
             return i;
     }
     return (uint32_t) -1;
@@ -142,13 +142,22 @@ infmon_api_result_t infmon_api_flow_rule_del(infmon_api_ctx_t *ctx, const char *
 infmon_api_result_t infmon_api_flow_rule_list(const infmon_api_ctx_t *ctx,
                                               infmon_api_flow_rule_list_cb_t cb, void *user)
 {
+    /* ERR_INVALID_RULE is reused for null-ctx: no dedicated "invalid context"
+     * code yet — the rule is the primary domain object, so this is the closest
+     * semantic match.  Same applies to get_by_name with null name. */
     if (!ctx)
         return INFMON_API_ERR_INVALID_RULE;
 
+    if (!cb)
+        return INFMON_API_OK;
+
+    /* The rule set is dense (add appends, rm compacts), so
+     * infmon_flow_rule_get() should not return NULL for i < count.
+     * The NULL guard is purely defensive. */
     uint32_t n = infmon_flow_rule_count(ctx->rule_set);
     for (uint32_t i = 0; i < n; i++) {
         const infmon_flow_rule_t *r = infmon_flow_rule_get(ctx->rule_set, i);
-        if (r && cb)
+        if (r)
             cb(r, i, user);
     }
     return INFMON_API_OK;
@@ -164,7 +173,7 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
     uint32_t n = infmon_flow_rule_count(ctx->rule_set);
     for (uint32_t i = 0; i < n; i++) {
         const infmon_flow_rule_t *r = infmon_flow_rule_get(ctx->rule_set, i);
-        if (r && strcmp(r->name, name) == 0) {
+        if (r && r->name && strcmp(r->name, name) == 0) {
             if (out_rule)
                 *out_rule = r;
             if (out_index)

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -238,7 +238,7 @@ TEST_F(ApiHandlerTest, ListAfterDeleteReflectsRemoval)
 
     /* Verify rule_bb shifted to index 0 after deletion. */
     const infmon_flow_rule_t *found = nullptr;
-    uint32_t idx = (uint32_t)-1;
+    uint32_t idx = (uint32_t) -1;
     EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "rule_bb", &found, &idx), INFMON_API_OK);
     EXPECT_EQ(idx, 0u);
     ASSERT_NE(found, nullptr);

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -5,9 +5,9 @@
 
 #include <cstdio>
 #include <cstring>
+#include <gtest/gtest.h>
 #include <string>
 #include <vector>
-#include <gtest/gtest.h>
 
 extern "C" {
 #include "infmon/api_handler.h"
@@ -214,8 +214,7 @@ TEST_F(ApiHandlerTest, GetByNameNullOutputs)
     ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r), INFMON_API_OK);
 
     /* Both out params NULL — should still return OK without crashing. */
-    EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "rule_zz", nullptr, nullptr),
-              INFMON_API_OK);
+    EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "rule_zz", nullptr, nullptr), INFMON_API_OK);
 }
 
 TEST_F(ApiHandlerTest, ListAfterDeleteReflectsRemoval)

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -5,6 +5,8 @@
 
 #include <cstdio>
 #include <cstring>
+#include <string>
+#include <vector>
 #include <gtest/gtest.h>
 
 extern "C" {
@@ -122,4 +124,116 @@ TEST_F(ApiHandlerTest, AddSetFull)
     /* Next add should fail with SET_FULL. */
     infmon_flow_rule_t overflow = make_rule("overflow");
     EXPECT_EQ(infmon_api_flow_rule_add(&ctx_, &overflow), INFMON_API_ERR_SET_FULL);
+}
+
+/* ── W10c: flow_rule_list / flow_rule_get tests ──────────────────── */
+
+struct ListEntry {
+    std::string name;
+    uint32_t index;
+};
+
+static void list_cb(const infmon_flow_rule_t *rule, uint32_t index, void *user)
+{
+    auto *vec = static_cast<std::vector<ListEntry> *>(user);
+    vec->push_back({rule->name, index});
+}
+
+TEST_F(ApiHandlerTest, ListEmptyReturnsOk)
+{
+    std::vector<ListEntry> entries;
+    EXPECT_EQ(infmon_api_flow_rule_list(&ctx_, list_cb, &entries), INFMON_API_OK);
+    EXPECT_TRUE(entries.empty());
+}
+
+TEST_F(ApiHandlerTest, ListMultipleRules)
+{
+    infmon_flow_rule_t r1 = make_rule("rule_aa");
+    infmon_flow_rule_t r2 = make_rule("rule_bb");
+    infmon_flow_rule_t r3 = make_rule("rule_cc");
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r1), INFMON_API_OK);
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r2), INFMON_API_OK);
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r3), INFMON_API_OK);
+
+    std::vector<ListEntry> entries;
+    EXPECT_EQ(infmon_api_flow_rule_list(&ctx_, list_cb, &entries), INFMON_API_OK);
+    ASSERT_EQ(entries.size(), 3u);
+    EXPECT_EQ(entries[0].name, "rule_aa");
+    EXPECT_EQ(entries[0].index, 0u);
+    EXPECT_EQ(entries[1].name, "rule_bb");
+    EXPECT_EQ(entries[1].index, 1u);
+    EXPECT_EQ(entries[2].name, "rule_cc");
+    EXPECT_EQ(entries[2].index, 2u);
+}
+
+TEST_F(ApiHandlerTest, ListNullCtxReturnsError)
+{
+    EXPECT_EQ(infmon_api_flow_rule_list(nullptr, list_cb, nullptr), INFMON_API_ERR_INVALID_RULE);
+}
+
+TEST_F(ApiHandlerTest, ListNullCallbackDoesNotCrash)
+{
+    infmon_flow_rule_t r = make_rule("rule_xx");
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r), INFMON_API_OK);
+    EXPECT_EQ(infmon_api_flow_rule_list(&ctx_, nullptr, nullptr), INFMON_API_OK);
+}
+
+TEST_F(ApiHandlerTest, GetByNameFound)
+{
+    infmon_flow_rule_t r1 = make_rule("rule_aa");
+    infmon_flow_rule_t r2 = make_rule("rule_bb");
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r1), INFMON_API_OK);
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r2), INFMON_API_OK);
+
+    const infmon_flow_rule_t *found = nullptr;
+    uint32_t idx = (uint32_t) -1;
+    EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "rule_bb", &found, &idx), INFMON_API_OK);
+    ASSERT_NE(found, nullptr);
+    EXPECT_STREQ(found->name, "rule_bb");
+    EXPECT_EQ(idx, 1u);
+    EXPECT_EQ(found->field_count, 2u);
+}
+
+TEST_F(ApiHandlerTest, GetByNameNotFound)
+{
+    EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "no_such", nullptr, nullptr),
+              INFMON_API_ERR_NOT_FOUND);
+}
+
+TEST_F(ApiHandlerTest, GetByNameNullInputs)
+{
+    EXPECT_EQ(infmon_api_flow_rule_get_by_name(nullptr, "x", nullptr, nullptr),
+              INFMON_API_ERR_INVALID_RULE);
+    EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, nullptr, nullptr, nullptr),
+              INFMON_API_ERR_INVALID_RULE);
+}
+
+TEST_F(ApiHandlerTest, GetByNameNullOutputs)
+{
+    infmon_flow_rule_t r = make_rule("rule_zz");
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r), INFMON_API_OK);
+
+    /* Both out params NULL — should still return OK without crashing. */
+    EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "rule_zz", nullptr, nullptr),
+              INFMON_API_OK);
+}
+
+TEST_F(ApiHandlerTest, ListAfterDeleteReflectsRemoval)
+{
+    infmon_flow_rule_t r1 = make_rule("rule_aa");
+    infmon_flow_rule_t r2 = make_rule("rule_bb");
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r1), INFMON_API_OK);
+    ASSERT_EQ(infmon_api_flow_rule_add(&ctx_, &r2), INFMON_API_OK);
+
+    ASSERT_EQ(infmon_api_flow_rule_del(&ctx_, "rule_aa"), INFMON_API_OK);
+
+    std::vector<ListEntry> entries;
+    EXPECT_EQ(infmon_api_flow_rule_list(&ctx_, list_cb, &entries), INFMON_API_OK);
+    ASSERT_EQ(entries.size(), 1u);
+    EXPECT_EQ(entries[0].name, "rule_bb");
+    EXPECT_EQ(entries[0].index, 0u);
+
+    /* get should also reflect removal. */
+    EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "rule_aa", nullptr, nullptr),
+              INFMON_API_ERR_NOT_FOUND);
 }

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -235,4 +235,12 @@ TEST_F(ApiHandlerTest, ListAfterDeleteReflectsRemoval)
     /* get should also reflect removal. */
     EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "rule_aa", nullptr, nullptr),
               INFMON_API_ERR_NOT_FOUND);
+
+    /* Verify rule_bb shifted to index 0 after deletion. */
+    const infmon_flow_rule_t *found = nullptr;
+    uint32_t idx = (uint32_t)-1;
+    EXPECT_EQ(infmon_api_flow_rule_get_by_name(&ctx_, "rule_bb", &found, &idx), INFMON_API_OK);
+    EXPECT_EQ(idx, 0u);
+    ASSERT_NE(found, nullptr);
+    EXPECT_STREQ(found->name, "rule_bb");
 }


### PR DESCRIPTION
## Summary
Add two new API handler functions for flow rule enumeration and retrieval:
- `infmon_api_flow_rule_list()`: enumerate active flow rules via callback
- `infmon_api_flow_rule_get_by_name()`: retrieve a single rule by name and return pointer + index

The .api wire schema already had the message definitions from the initial API schema commit. This PR adds the C handler implementations and 9 new tests.

## Tests
All 16 api_handler tests pass (7 existing + 9 new):
- ListEmptyReturnsOk, ListMultipleRules, ListNullCtxReturnsError, ListNullCallbackDoesNotCrash
- GetByNameFound, GetByNameNotFound, GetByNameNullInputs, GetByNameNullOutputs
- ListAfterDeleteReflectsRemoval

Closes #46