### PR TITLE
feat: wire snapshot_and_clear API to swap logic

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -99,6 +99,7 @@ target_include_directories(infmon_api_handler PUBLIC include)
 target_link_libraries(infmon_api_handler PUBLIC
     infmon_flow_rule
     infmon_counter_table
+    infmon_snapshot
     infmon_stats_segment
 )
 
@@ -109,6 +110,7 @@ target_link_libraries(test_api_handler PRIVATE
     infmon_api_handler
     infmon_flow_rule
     infmon_counter_table
+    infmon_snapshot
     infmon_stats_segment
     GTest::gtest GTest::gtest_main
 )

--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -139,7 +139,7 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
  * otherwise).
  */
 void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t flow_rule_id,
-                                  infmon_api_snap_reply_t *reply);
+                                   infmon_api_snap_reply_t *reply);
 
 #ifdef __cplusplus
 }

--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -13,6 +13,7 @@
 
 #include "infmon/counter_table.h"
 #include "infmon/flow_rule.h"
+#include "infmon/snapshot.h"
 #include "infmon/stats_segment.h"
 
 #ifdef __cplusplus
@@ -30,6 +31,10 @@ typedef enum {
     INFMON_API_ERR_SET_FULL,
     INFMON_API_ERR_STATS_PUBLISH,
     INFMON_API_ERR_INTERNAL,
+    INFMON_API_ERR_ALLOC_FAILED,
+    INFMON_API_ERR_TOO_MANY_RETIRED,
+    INFMON_API_ERR_NULL_TABLE,
+    INFMON_API_ERR_NO_SNAPSHOT_MGR,
 } infmon_api_result_t;
 
 /* ── Context (caller-owned, long-lived) ──────────────────────────── */
@@ -37,10 +42,24 @@ typedef enum {
 typedef struct {
     infmon_flow_rule_set_t *rule_set;
     infmon_stats_registry_t *stats_reg;
+    infmon_snapshot_mgr_t *snap_mgr; /**< Optional; required for snapshot_and_clear. */
     /* private: Per-rule counter tables, indexed by rule position in the set.
      * Managed internally by add/del; caller must not touch. */
     infmon_counter_table_t *tables[INFMON_FLOW_RULE_SET_MAX];
+    /* Per-rule UUID, indexed in parallel with tables[]. */
+    infmon_flow_rule_id_t flow_rule_ids[INFMON_FLOW_RULE_SET_MAX];
 } infmon_api_ctx_t;
+
+/* ── Snapshot reply ──────────────────────────────────────────────── */
+
+/**
+ * Result of infmon_api_snapshot_and_clear().  On success, the descriptor
+ * is fully populated with retired table metadata.
+ */
+typedef struct {
+    infmon_api_result_t result;
+    infmon_stats_descriptor_t descriptor; /**< Populated on success. */
+} infmon_api_snap_reply_t;
 
 /* ── Lifecycle ───────────────────────────────────────────────────── */
 
@@ -61,6 +80,15 @@ void infmon_api_ctx_destroy(infmon_api_ctx_t *ctx);
  * counter table → publish stats descriptor.
  */
 infmon_api_result_t infmon_api_flow_rule_add(infmon_api_ctx_t *ctx, const infmon_flow_rule_t *rule);
+
+/**
+ * Add a flow rule with an explicit UUID.
+ * Same as infmon_api_flow_rule_add but also records @p id so that
+ * snapshot_and_clear can resolve the ID → index mapping.
+ */
+infmon_api_result_t infmon_api_flow_rule_add_with_id(infmon_api_ctx_t *ctx,
+                                                     const infmon_flow_rule_t *rule,
+                                                     infmon_flow_rule_id_t id);
 
 /**
  * Delete a flow rule by name: unpublish stats → destroy counter table →
@@ -99,6 +127,19 @@ infmon_api_result_t infmon_api_flow_rule_list(const infmon_api_ctx_t *ctx,
 infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx, const char *name,
                                                      const infmon_flow_rule_t **out_rule,
                                                      uint32_t *out_index);
+
+/**
+ * Perform an atomic snapshot_and_clear on the counter table belonging
+ * to the flow rule identified by @p flow_rule_id.
+ *
+ * On success the reply's descriptor is fully populated with the
+ * retired table's metadata (generation, offsets, counters).
+ *
+ * Requires ctx->snap_mgr to be set (returns INFMON_API_ERR_NO_SNAPSHOT_MGR
+ * otherwise).
+ */
+void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t flow_rule_id,
+                                  infmon_api_snap_reply_t *reply);
 
 #ifdef __cplusplus
 }

--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -136,10 +136,15 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
  * retired table's metadata (generation, offsets, counters).
  *
  * Requires ctx->snap_mgr and ctx->stats_reg to be set.
- * @p reply must be non-NULL; if NULL, the call is a no-op.
+ * @p reply must be non-NULL; if NULL, returns INFMON_API_ERR_INTERNAL.
+ * @p flow_rule_id must be non-zero (zero is a sentinel for "no ID assigned").
+ *
+ * @return INFMON_API_OK on success, or an error code.  The same code is also
+ *         stored in reply->result for callers that prefer struct-based checking.
  */
-void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t flow_rule_id,
-                                   infmon_api_snap_reply_t *reply);
+infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
+                                                  infmon_flow_rule_id_t flow_rule_id,
+                                                  infmon_api_snap_reply_t *reply);
 
 #ifdef __cplusplus
 }

--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -135,8 +135,8 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
  * On success the reply's descriptor is fully populated with the
  * retired table's metadata (generation, offsets, counters).
  *
- * Requires ctx->snap_mgr to be set (returns INFMON_API_ERR_NO_SNAPSHOT_MGR
- * otherwise).
+ * Requires ctx->snap_mgr and ctx->stats_reg to be set.
+ * @p reply must be non-NULL; if NULL, the call is a no-op.
  */
 void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t flow_rule_id,
                                    infmon_api_snap_reply_t *reply);

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -245,7 +245,7 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
 /* ── Snapshot and clear ──────────────────────────────────────────── */
 
 void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t flow_rule_id,
-                                  infmon_api_snap_reply_t *reply)
+                                   infmon_api_snap_reply_t *reply)
 {
     memset(reply, 0, sizeof(*reply));
 
@@ -269,7 +269,7 @@ void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t 
     /* Delegate to the snapshot manager. */
     infmon_snap_reply_t snap_reply;
     infmon_snapshot_and_clear(ctx->snap_mgr, ctx->tables, idx, INFMON_FLOW_RULE_SET_MAX,
-                             infmon_flow_rule_get(ctx->rule_set, idx)->key_width, &snap_reply);
+                              infmon_flow_rule_get(ctx->rule_set, idx)->key_width, &snap_reply);
 
     reply->result = map_snap_result(snap_reply.result);
 

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -247,29 +247,36 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
 
 /* ── Snapshot and clear ──────────────────────────────────────────── */
 
-void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t flow_rule_id,
-                                   infmon_api_snap_reply_t *reply)
+infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
+                                                  infmon_flow_rule_id_t flow_rule_id,
+                                                  infmon_api_snap_reply_t *reply)
 {
     if (!reply)
-        return;
+        return INFMON_API_ERR_INTERNAL;
 
     memset(reply, 0, sizeof(*reply));
 
     if (!ctx) {
-        reply->result = INFMON_API_ERR_INVALID_RULE;
-        return;
+        reply->result = INFMON_API_ERR_INTERNAL;
+        return INFMON_API_ERR_INTERNAL;
     }
 
     if (!ctx->snap_mgr) {
         reply->result = INFMON_API_ERR_NO_SNAPSHOT_MGR;
-        return;
+        return INFMON_API_ERR_NO_SNAPSHOT_MGR;
+    }
+
+    /* Reject zero IDs — they are a sentinel for "no ID assigned". */
+    if (infmon_flow_rule_id_is_zero(flow_rule_id)) {
+        reply->result = INFMON_API_ERR_NOT_FOUND;
+        return INFMON_API_ERR_NOT_FOUND;
     }
 
     /* Resolve flow_rule_id → index. */
     uint32_t idx = find_rule_index_by_id(ctx, flow_rule_id);
     if (idx == (uint32_t) -1) {
         reply->result = INFMON_API_ERR_NOT_FOUND;
-        return;
+        return INFMON_API_ERR_NOT_FOUND;
     }
 
     /* Delegate to the snapshot manager. */
@@ -277,7 +284,7 @@ void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t 
     const infmon_flow_rule_t *rule = infmon_flow_rule_get(ctx->rule_set, idx);
     if (!rule) {
         reply->result = INFMON_API_ERR_INTERNAL;
-        return;
+        return INFMON_API_ERR_INTERNAL;
     }
     infmon_snapshot_and_clear(ctx->snap_mgr, ctx->tables, idx, INFMON_FLOW_RULE_SET_MAX,
                               rule->key_width, &snap_reply);
@@ -285,7 +292,7 @@ void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t 
     reply->result = map_snap_result(snap_reply.result);
 
     if (snap_reply.result != INFMON_SNAP_OK)
-        return;
+        return reply->result;
 
     /* Build the descriptor from the retired table. */
     infmon_counter_table_t *retired = snap_reply.retired_table;
@@ -300,7 +307,7 @@ void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t 
      * stats_reg is required — without a valid base the offsets are meaningless. */
     if (!ctx->stats_reg) {
         reply->result = INFMON_API_ERR_INTERNAL;
-        return;
+        return INFMON_API_ERR_INTERNAL;
     }
     uintptr_t seg_base = ctx->stats_reg->segment_base;
     desc->slots_offset = infmon_stats_offset_of(seg_base, retired->slots);
@@ -311,4 +318,6 @@ void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t 
     desc->insert_failed = retired->insert_failed;
     desc->table_full = retired->table_full;
     desc->active = 1;
+
+    return INFMON_API_OK;
 }

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -30,6 +30,25 @@ static infmon_api_result_t map_rule_result(infmon_flow_rule_result_t r)
     }
 }
 
+/** Map snapshot result to API result. */
+static infmon_api_result_t map_snap_result(infmon_snap_result_t r)
+{
+    switch (r) {
+    case INFMON_SNAP_OK:
+        return INFMON_API_OK;
+    case INFMON_SNAP_ALLOC_FAILED:
+        return INFMON_API_ERR_ALLOC_FAILED;
+    case INFMON_SNAP_TOO_MANY_RETIRED:
+        return INFMON_API_ERR_TOO_MANY_RETIRED;
+    case INFMON_SNAP_INVALID_INDEX:
+        return INFMON_API_ERR_NOT_FOUND;
+    case INFMON_SNAP_NULL_TABLE:
+        return INFMON_API_ERR_NULL_TABLE;
+    default:
+        return INFMON_API_ERR_INTERNAL;
+    }
+}
+
 /**
  * Find the index of a rule by name in the set.
  * Returns the index, or (uint32_t) -1 if not found.
@@ -40,6 +59,20 @@ static uint32_t find_rule_index(const infmon_flow_rule_set_t *set, const char *n
     for (uint32_t i = 0; i < n; i++) {
         const infmon_flow_rule_t *r = infmon_flow_rule_get(set, i);
         if (r && strcmp(r->name, name) == 0)
+            return i;
+    }
+    return (uint32_t) -1;
+}
+
+/**
+ * Find the index of a rule by flow_rule_id in the context.
+ * Returns the index, or (uint32_t) -1 if not found.
+ */
+static uint32_t find_rule_index_by_id(const infmon_api_ctx_t *ctx, infmon_flow_rule_id_t id)
+{
+    uint32_t n = infmon_flow_rule_count(ctx->rule_set);
+    for (uint32_t i = 0; i < n; i++) {
+        if (infmon_flow_rule_id_eq(ctx->flow_rule_ids[i], id))
             return i;
     }
     return (uint32_t) -1;
@@ -72,7 +105,12 @@ void infmon_api_ctx_destroy(infmon_api_ctx_t *ctx)
 
 /* ── Operations ──────────────────────────────────────────────────── */
 
-infmon_api_result_t infmon_api_flow_rule_add(infmon_api_ctx_t *ctx, const infmon_flow_rule_t *rule)
+/**
+ * Internal: add a flow rule, optionally recording its UUID.
+ */
+static infmon_api_result_t flow_rule_add_internal(infmon_api_ctx_t *ctx,
+                                                  const infmon_flow_rule_t *rule,
+                                                  const infmon_flow_rule_id_t *id)
 {
     if (!ctx || !rule)
         return INFMON_API_ERR_INVALID_RULE;
@@ -106,7 +144,24 @@ infmon_api_result_t infmon_api_flow_rule_add(infmon_api_ctx_t *ctx, const infmon
     }
     ctx->tables[idx] = ct;
 
+    /* 5. Record the flow_rule_id if provided. */
+    if (id) {
+        ctx->flow_rule_ids[idx] = *id;
+    }
+
     return INFMON_API_OK;
+}
+
+infmon_api_result_t infmon_api_flow_rule_add(infmon_api_ctx_t *ctx, const infmon_flow_rule_t *rule)
+{
+    return flow_rule_add_internal(ctx, rule, NULL);
+}
+
+infmon_api_result_t infmon_api_flow_rule_add_with_id(infmon_api_ctx_t *ctx,
+                                                     const infmon_flow_rule_t *rule,
+                                                     infmon_flow_rule_id_t id)
+{
+    return flow_rule_add_internal(ctx, rule, &id);
 }
 
 infmon_api_result_t infmon_api_flow_rule_del(infmon_api_ctx_t *ctx, const char *name)
@@ -130,11 +185,14 @@ infmon_api_result_t infmon_api_flow_rule_del(infmon_api_ctx_t *ctx, const char *
         ctx->tables[idx] = NULL;
     }
 
-    /* 4. Compact the tables array (rm shifts entries in the set). */
+    /* 4. Compact the tables and flow_rule_ids arrays (rm shifts entries in the set). */
     uint32_t count = infmon_flow_rule_count(ctx->rule_set);
-    for (uint32_t i = idx; i < count; i++)
+    for (uint32_t i = idx; i < count; i++) {
         ctx->tables[i] = ctx->tables[i + 1];
+        ctx->flow_rule_ids[i] = ctx->flow_rule_ids[i + 1];
+    }
     ctx->tables[count] = NULL;
+    memset(&ctx->flow_rule_ids[count], 0, sizeof(ctx->flow_rule_ids[0]));
 
     return INFMON_API_OK;
 }
@@ -182,4 +240,59 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
         }
     }
     return INFMON_API_ERR_NOT_FOUND;
+}
+
+/* ── Snapshot and clear ──────────────────────────────────────────── */
+
+void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t flow_rule_id,
+                                  infmon_api_snap_reply_t *reply)
+{
+    memset(reply, 0, sizeof(*reply));
+
+    if (!ctx) {
+        reply->result = INFMON_API_ERR_INVALID_RULE;
+        return;
+    }
+
+    if (!ctx->snap_mgr) {
+        reply->result = INFMON_API_ERR_NO_SNAPSHOT_MGR;
+        return;
+    }
+
+    /* Resolve flow_rule_id → index. */
+    uint32_t idx = find_rule_index_by_id(ctx, flow_rule_id);
+    if (idx == (uint32_t) -1) {
+        reply->result = INFMON_API_ERR_NOT_FOUND;
+        return;
+    }
+
+    /* Delegate to the snapshot manager. */
+    infmon_snap_reply_t snap_reply;
+    infmon_snapshot_and_clear(ctx->snap_mgr, ctx->tables, idx, INFMON_FLOW_RULE_SET_MAX,
+                             infmon_flow_rule_get(ctx->rule_set, idx)->key_width, &snap_reply);
+
+    reply->result = map_snap_result(snap_reply.result);
+
+    if (snap_reply.result != INFMON_SNAP_OK)
+        return;
+
+    /* Build the descriptor from the retired table. */
+    infmon_counter_table_t *retired = snap_reply.retired_table;
+    infmon_stats_descriptor_t *desc = &reply->descriptor;
+
+    desc->flow_rule_id = flow_rule_id;
+    desc->flow_rule_index = idx;
+    desc->generation = snap_reply.retired_generation;
+    desc->epoch_ns = retired->epoch_ns;
+
+    /* Compute byte offsets relative to stats segment base. */
+    uintptr_t seg_base = ctx->stats_reg ? ctx->stats_reg->segment_base : 0;
+    desc->slots_offset = infmon_stats_offset_of(seg_base, retired->slots);
+    desc->slots_len = retired->num_slots;
+    desc->key_arena_offset = infmon_stats_offset_of(seg_base, retired->key_arena);
+    desc->key_arena_capacity = retired->key_arena_capacity;
+    desc->key_arena_used = retired->key_arena_used;
+    desc->insert_failed = retired->insert_failed;
+    desc->table_full = retired->table_full;
+    desc->active = 1;
 }

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -279,6 +279,13 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
         return INFMON_API_ERR_NOT_FOUND;
     }
 
+    /* stats_reg is required — without a valid base the offsets are meaningless.
+     * Check before the swap so we never retire a table we can't describe. */
+    if (!ctx->stats_reg) {
+        reply->result = INFMON_API_ERR_INTERNAL;
+        return INFMON_API_ERR_INTERNAL;
+    }
+
     /* Delegate to the snapshot manager. */
     infmon_snap_reply_t snap_reply;
     const infmon_flow_rule_t *rule = infmon_flow_rule_get(ctx->rule_set, idx);
@@ -303,12 +310,7 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
     desc->generation = snap_reply.retired_generation;
     desc->epoch_ns = retired->epoch_ns;
 
-    /* Compute byte offsets relative to stats segment base.
-     * stats_reg is required — without a valid base the offsets are meaningless. */
-    if (!ctx->stats_reg) {
-        reply->result = INFMON_API_ERR_INTERNAL;
-        return INFMON_API_ERR_INTERNAL;
-    }
+    /* Compute byte offsets relative to stats segment base. */
     uintptr_t seg_base = ctx->stats_reg->segment_base;
     desc->slots_offset = infmon_stats_offset_of(seg_base, retired->slots);
     desc->slots_len = retired->num_slots;

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -144,9 +144,12 @@ static infmon_api_result_t flow_rule_add_internal(infmon_api_ctx_t *ctx,
     }
     ctx->tables[idx] = ct;
 
-    /* 5. Record the flow_rule_id if provided. */
+    /* 5. Record the flow_rule_id if provided, otherwise zero out the slot
+     *    to avoid stale IDs from a previous occupant of this index. */
     if (id) {
         ctx->flow_rule_ids[idx] = *id;
+    } else {
+        memset(&ctx->flow_rule_ids[idx], 0, sizeof(ctx->flow_rule_ids[0]));
     }
 
     return INFMON_API_OK;
@@ -247,6 +250,9 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
 void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t flow_rule_id,
                                    infmon_api_snap_reply_t *reply)
 {
+    if (!reply)
+        return;
+
     memset(reply, 0, sizeof(*reply));
 
     if (!ctx) {
@@ -268,8 +274,13 @@ void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t 
 
     /* Delegate to the snapshot manager. */
     infmon_snap_reply_t snap_reply;
+    const infmon_flow_rule_t *rule = infmon_flow_rule_get(ctx->rule_set, idx);
+    if (!rule) {
+        reply->result = INFMON_API_ERR_INTERNAL;
+        return;
+    }
     infmon_snapshot_and_clear(ctx->snap_mgr, ctx->tables, idx, INFMON_FLOW_RULE_SET_MAX,
-                              infmon_flow_rule_get(ctx->rule_set, idx)->key_width, &snap_reply);
+                              rule->key_width, &snap_reply);
 
     reply->result = map_snap_result(snap_reply.result);
 
@@ -285,8 +296,13 @@ void infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx, infmon_flow_rule_id_t 
     desc->generation = snap_reply.retired_generation;
     desc->epoch_ns = retired->epoch_ns;
 
-    /* Compute byte offsets relative to stats segment base. */
-    uintptr_t seg_base = ctx->stats_reg ? ctx->stats_reg->segment_base : 0;
+    /* Compute byte offsets relative to stats segment base.
+     * stats_reg is required — without a valid base the offsets are meaningless. */
+    if (!ctx->stats_reg) {
+        reply->result = INFMON_API_ERR_INTERNAL;
+        return;
+    }
+    uintptr_t seg_base = ctx->stats_reg->segment_base;
     desc->slots_offset = infmon_stats_offset_of(seg_base, retired->slots);
     desc->slots_len = retired->num_slots;
     desc->key_arena_offset = infmon_stats_offset_of(seg_base, retired->key_arena);

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -250,7 +250,10 @@ TEST_F(ApiHandlerTest, ListAfterDeleteReflectsRemoval)
 /* ── W10d: snapshot_and_clear tests ──────────────────────────────── */
 
 static uint64_t fake_clock_val = 1000000000ULL;
-static uint64_t fake_clock_ns(void) { return fake_clock_val; }
+static uint64_t fake_clock_ns(void)
+{
+    return fake_clock_val;
+}
 
 class ApiHandlerSnapTest : public ::testing::Test
 {

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -342,7 +342,7 @@ TEST_F(ApiHandlerSnapTest, SnapshotAndClearNullCtx)
     infmon_api_snap_reply_t reply;
     infmon_api_snapshot_and_clear(nullptr, id, &reply);
 
-    EXPECT_EQ(reply.result, INFMON_API_ERR_INVALID_RULE);
+    EXPECT_EQ(reply.result, INFMON_API_ERR_INTERNAL);
 }
 
 TEST_F(ApiHandlerSnapTest, SnapshotAndClearDescriptorFields)
@@ -397,4 +397,30 @@ TEST_F(ApiHandlerSnapTest, AddWithIdPreservesIdAcrossDelete)
     EXPECT_EQ(reply.descriptor.flow_rule_id.hi, 0x30u);
     EXPECT_EQ(reply.descriptor.flow_rule_id.lo, 0x40u);
     EXPECT_EQ(reply.descriptor.flow_rule_index, 0u);
+}
+
+TEST_F(ApiHandlerSnapTest, SnapshotAndClearRejectsZeroId)
+{
+    /* Add a rule via plain add (no explicit ID). */
+    infmon_flow_rule_t r = make_rule("plain_rule");
+    EXPECT_EQ(infmon_api_flow_rule_add(&ctx_, &r), INFMON_API_OK);
+
+    /* Calling snapshot_and_clear with a zero ID should return NOT_FOUND,
+     * not silently match the slot whose ID was zeroed by the add path. */
+    infmon_flow_rule_id_t zero_id = {0, 0};
+    infmon_api_snap_reply_t reply;
+    infmon_api_result_t rc = infmon_api_snapshot_and_clear(&ctx_, zero_id, &reply);
+    EXPECT_EQ(rc, INFMON_API_ERR_NOT_FOUND);
+    EXPECT_EQ(reply.result, INFMON_API_ERR_NOT_FOUND);
+}
+
+TEST_F(ApiHandlerSnapTest, SnapshotAndClearReturnType)
+{
+    /* Verify the return value matches reply.result. */
+    infmon_flow_rule_id_t id = add_rule_with_id("ret_rule", 0xCC, 0xDD);
+
+    infmon_api_snap_reply_t reply;
+    infmon_api_result_t rc = infmon_api_snapshot_and_clear(&ctx_, id, &reply);
+    EXPECT_EQ(rc, INFMON_API_OK);
+    EXPECT_EQ(rc, reply.result);
 }

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -11,6 +11,8 @@
 
 extern "C" {
 #include "infmon/api_handler.h"
+#include "infmon/snapshot.h"
+#include "infmon/stats_segment.h"
 }
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
@@ -243,4 +245,153 @@ TEST_F(ApiHandlerTest, ListAfterDeleteReflectsRemoval)
     EXPECT_EQ(idx, 0u);
     ASSERT_NE(found, nullptr);
     EXPECT_STREQ(found->name, "rule_bb");
+}
+
+/* ── W10d: snapshot_and_clear tests ──────────────────────────────── */
+
+static uint64_t fake_clock_val = 1000000000ULL;
+static uint64_t fake_clock_ns(void) { return fake_clock_val; }
+
+class ApiHandlerSnapTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        rule_set_ = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
+        ASSERT_NE(rule_set_, nullptr);
+        infmon_stats_registry_init(&stats_reg_, /* segment_base */ 0);
+
+        snap_mgr_ = new infmon_snapshot_mgr_t;
+        infmon_snapshot_mgr_init(snap_mgr_, /* num_workers */ 2, /* grace_ns */ 0, fake_clock_ns);
+
+        infmon_api_ctx_init(&ctx_, rule_set_, &stats_reg_);
+        ctx_.snap_mgr = snap_mgr_;
+    }
+
+    void TearDown() override
+    {
+        infmon_api_ctx_destroy(&ctx_);
+        infmon_snapshot_mgr_destroy(snap_mgr_);
+        delete snap_mgr_;
+        infmon_stats_registry_destroy(&stats_reg_);
+        infmon_flow_rule_set_destroy(rule_set_);
+    }
+
+    /** Helper: add a rule with an explicit ID. */
+    infmon_flow_rule_id_t add_rule_with_id(const char *name, uint64_t hi, uint64_t lo)
+    {
+        infmon_flow_rule_t r = make_rule(name);
+        infmon_flow_rule_id_t id = {hi, lo};
+        EXPECT_EQ(infmon_api_flow_rule_add_with_id(&ctx_, &r, id), INFMON_API_OK);
+        return id;
+    }
+
+    infmon_flow_rule_set_t *rule_set_ = nullptr;
+    infmon_stats_registry_t stats_reg_{};
+    infmon_snapshot_mgr_t *snap_mgr_ = nullptr;
+    infmon_api_ctx_t ctx_{};
+};
+
+TEST_F(ApiHandlerSnapTest, SnapshotAndClearBasic)
+{
+    infmon_flow_rule_id_t id = add_rule_with_id("snap_rule", 0xAA, 0xBB);
+
+    infmon_api_snap_reply_t reply;
+    infmon_api_snapshot_and_clear(&ctx_, id, &reply);
+
+    EXPECT_EQ(reply.result, INFMON_API_OK);
+    EXPECT_EQ(reply.descriptor.flow_rule_id.hi, 0xAAu);
+    EXPECT_EQ(reply.descriptor.flow_rule_id.lo, 0xBBu);
+    EXPECT_EQ(reply.descriptor.flow_rule_index, 0u);
+    EXPECT_EQ(reply.descriptor.generation, 0u); /* retired table is gen 0 */
+    EXPECT_EQ(reply.descriptor.active, 1u);
+
+    /* New table should be at generation 1. */
+    EXPECT_NE(ctx_.tables[0], nullptr);
+    EXPECT_EQ(ctx_.tables[0]->generation, 1u);
+}
+
+TEST_F(ApiHandlerSnapTest, SnapshotAndClearNotFoundId)
+{
+    add_rule_with_id("some_rule", 0x11, 0x22);
+
+    infmon_flow_rule_id_t bad_id = {0xFF, 0xFF};
+    infmon_api_snap_reply_t reply;
+    infmon_api_snapshot_and_clear(&ctx_, bad_id, &reply);
+
+    EXPECT_EQ(reply.result, INFMON_API_ERR_NOT_FOUND);
+}
+
+TEST_F(ApiHandlerSnapTest, SnapshotAndClearNoSnapMgr)
+{
+    ctx_.snap_mgr = nullptr;
+
+    infmon_flow_rule_id_t id = {0x11, 0x22};
+    infmon_api_snap_reply_t reply;
+    infmon_api_snapshot_and_clear(&ctx_, id, &reply);
+
+    EXPECT_EQ(reply.result, INFMON_API_ERR_NO_SNAPSHOT_MGR);
+}
+
+TEST_F(ApiHandlerSnapTest, SnapshotAndClearNullCtx)
+{
+    infmon_flow_rule_id_t id = {0x11, 0x22};
+    infmon_api_snap_reply_t reply;
+    infmon_api_snapshot_and_clear(nullptr, id, &reply);
+
+    EXPECT_EQ(reply.result, INFMON_API_ERR_INVALID_RULE);
+}
+
+TEST_F(ApiHandlerSnapTest, SnapshotAndClearDescriptorFields)
+{
+    infmon_flow_rule_id_t id = add_rule_with_id("desc_rule", 0xDE, 0xAD);
+
+    /* The initial table has gen=0, epoch_ns=0 (counter_table_create zeroes everything). */
+    infmon_api_snap_reply_t reply;
+    infmon_api_snapshot_and_clear(&ctx_, id, &reply);
+
+    ASSERT_EQ(reply.result, INFMON_API_OK);
+
+    const infmon_stats_descriptor_t &d = reply.descriptor;
+    EXPECT_EQ(d.flow_rule_id.hi, 0xDEu);
+    EXPECT_EQ(d.flow_rule_id.lo, 0xADu);
+    EXPECT_EQ(d.flow_rule_index, 0u);
+    EXPECT_EQ(d.generation, 0u);
+    /* slots_len should match the table's num_slots (counter_table rounds up to power of 2). */
+    EXPECT_GT(d.slots_len, 0u);
+    EXPECT_EQ(d.active, 1u);
+}
+
+TEST_F(ApiHandlerSnapTest, SnapshotAndClearMultipleSwaps)
+{
+    infmon_flow_rule_id_t id = add_rule_with_id("multi_rule", 0x01, 0x02);
+
+    /* First swap: retired gen=0, new gen=1. */
+    infmon_api_snap_reply_t reply1;
+    infmon_api_snapshot_and_clear(&ctx_, id, &reply1);
+    ASSERT_EQ(reply1.result, INFMON_API_OK);
+    EXPECT_EQ(reply1.descriptor.generation, 0u);
+
+    /* Second swap: retired gen=1, new gen=2. */
+    infmon_api_snap_reply_t reply2;
+    infmon_api_snapshot_and_clear(&ctx_, id, &reply2);
+    ASSERT_EQ(reply2.result, INFMON_API_OK);
+    EXPECT_EQ(reply2.descriptor.generation, 1u);
+    EXPECT_EQ(ctx_.tables[0]->generation, 2u);
+}
+
+TEST_F(ApiHandlerSnapTest, AddWithIdPreservesIdAcrossDelete)
+{
+    add_rule_with_id("rule_aa", 0x10, 0x20);
+    infmon_flow_rule_id_t id_bb = add_rule_with_id("rule_bb", 0x30, 0x40);
+
+    /* Delete first rule — rule_bb should compact to index 0 with its ID intact. */
+    EXPECT_EQ(infmon_api_flow_rule_del(&ctx_, "rule_aa"), INFMON_API_OK);
+
+    infmon_api_snap_reply_t reply;
+    infmon_api_snapshot_and_clear(&ctx_, id_bb, &reply);
+    ASSERT_EQ(reply.result, INFMON_API_OK);
+    EXPECT_EQ(reply.descriptor.flow_rule_id.hi, 0x30u);
+    EXPECT_EQ(reply.descriptor.flow_rule_id.lo, 0x40u);
+    EXPECT_EQ(reply.descriptor.flow_rule_index, 0u);
 }


### PR DESCRIPTION
## Summary

Wire `infmon_snapshot_and_clear(flow_rule_id)` API message to the swap logic from W8.

### Changes

- **api_handler.h**: Add `snap_mgr` and `flow_rule_ids[]` to `infmon_api_ctx_t`, new error codes (`ALLOC_FAILED`, `TOO_MANY_RETIRED`, `NULL_TABLE`, `NO_SNAPSHOT_MGR`), `infmon_api_snap_reply_t` struct, and declarations for `snapshot_and_clear` and `flow_rule_add_with_id`
- **api_handler.c**: Implement `infmon_api_snapshot_and_clear()` — resolves flow_rule_id → index, calls snapshot manager, publishes stats descriptor for the retired table; add `find_rule_index_by_id()` helper, `map_snap_result()`, `flow_rule_add_with_id()`, and ID compaction on delete
- **CMakeLists.txt**: Link `infmon_snapshot` to api_handler and test targets
- **test_api_handler.cc**: 7 new tests covering basic swap, not-found ID, null ctx, missing snap_mgr, descriptor fields, multiple swaps, and ID preservation across delete/compaction

### Test Plan

All 8 test suites pass (23 api_handler tests total, 7 new).

Closes #47