### PR TITLE
feat: add infmon_status API message with per-worker health/error counters

### DIFF
--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -13,6 +13,7 @@
 
 #include "infmon/counter_table.h"
 #include "infmon/flow_rule.h"
+#include "infmon/graph_node.h"
 #include "infmon/snapshot.h"
 #include "infmon/stats_segment.h"
 
@@ -48,6 +49,9 @@ typedef struct {
     infmon_counter_table_t *tables[INFMON_FLOW_RULE_SET_MAX];
     /* Per-rule UUID, indexed in parallel with tables[]. */
     infmon_flow_rule_id_t flow_rule_ids[INFMON_FLOW_RULE_SET_MAX];
+    /* Per-worker status counters (set by caller, read by infmon_api_status). */
+    infmon_worker_counters_t *worker_counters; /**< Array of worker_count elements. */
+    uint32_t worker_count;                     /**< Number of workers. */
 } infmon_api_ctx_t;
 
 /* ── Snapshot reply ──────────────────────────────────────────────── */
@@ -145,6 +149,34 @@ infmon_api_result_t infmon_api_flow_rule_get_by_name(const infmon_api_ctx_t *ctx
 infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
                                                   infmon_flow_rule_id_t flow_rule_id,
                                                   infmon_api_snap_reply_t *reply);
+
+/* ── Status ─────────────────────────────────────────────────────── */
+
+/**
+ * Result of infmon_api_status().
+ *
+ * On success, @p workers points to the internal worker_counters array
+ * (valid as long as the context is alive) and @p worker_count is set.
+ * The caller must NOT free the workers pointer.
+ */
+typedef struct {
+    infmon_api_result_t result;
+    const infmon_worker_counters_t *workers; /**< Points into ctx->worker_counters. */
+    uint32_t worker_count;
+} infmon_api_status_reply_t;
+
+/**
+ * Retrieve per-worker error/health counters.
+ *
+ * Populates @p reply with a pointer to the internal worker_counters
+ * array and the worker count.  The counters are a live snapshot — they
+ * may continue to be updated by worker threads after this call returns.
+ *
+ * @return INFMON_API_OK on success.
+ * @return INFMON_API_ERR_INTERNAL if @p ctx, @p reply, or worker_counters is NULL.
+ */
+infmon_api_result_t infmon_api_status(const infmon_api_ctx_t *ctx,
+                                      infmon_api_status_reply_t *reply);
 
 #ifdef __cplusplus
 }

--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -169,8 +169,10 @@ typedef struct {
  * Retrieve per-worker error/health counters.
  *
  * Populates @p reply with a pointer to the internal worker_counters
- * array and the worker count.  The counters are a live snapshot — they
+ * array and the worker count.  The counters are a live view — they
  * may continue to be updated by worker threads after this call returns.
+ * The caller sees the latest values but does not get a point-in-time
+ * snapshot; use memcpy on the returned array if a frozen copy is needed.
  *
  * @return INFMON_API_OK on success.
  * @return INFMON_API_ERR_INTERNAL if @p ctx, @p reply, or worker_counters is NULL.

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -16,6 +16,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "infmon/counter_table.h"
 #include "infmon/erspan_parser.h"
@@ -48,6 +49,39 @@ typedef enum {
 extern const char *infmon_node_error_names[];
 extern const char *infmon_node_error_strings[];
 
+/* ── Per-worker status counters (§11, exposed via infmon_status) ─── */
+
+/**
+ * Per-worker health/error counters.  One instance per VPP worker thread.
+ * In production these live in VPP's thread-local storage; for unit tests
+ * they are allocated as a flat array indexed by worker_id.
+ *
+ * All counters are monotonically increasing (never reset except on
+ * plugin teardown).  The infmon_status API message reads them and
+ * returns a snapshot.
+ */
+typedef struct {
+    uint32_t worker_id;
+    uint64_t packets_seen;                    /**< Total packets entering infmon-erspan-decap. */
+    uint64_t erspan_unknown_proto;            /**< Outer header parsed, ERSPAN type unrecognised. */
+    uint64_t erspan_truncated;                /**< Buffer too short for declared ERSPAN header. */
+    uint64_t inner_parse_failed;              /**< Inner L2/L3/L4 parse error after decap. */
+    uint64_t flow_rule_no_match;              /**< Packet matched zero flow rules. */
+    uint64_t counter_insert_retry_exhausted;  /**< CAS retries exceeded INFMON_INSERT_RETRY. */
+    uint64_t counter_table_full;              /**< Table reached max_keys_per_flow_rule. */
+} infmon_worker_counters_t;
+
+/**
+ * Initialise a worker-counters struct (zero all fields, set worker_id).
+ */
+static inline void infmon_worker_counters_init(infmon_worker_counters_t *wc, uint32_t worker_id)
+{
+    if (!wc)
+        return;
+    memset(wc, 0, sizeof(*wc));
+    wc->worker_id = worker_id;
+}
+
 /* ── Next-index enum for each node ───────────────────────────────── */
 
 typedef enum {
@@ -79,8 +113,10 @@ typedef struct {
 } infmon_buffer_opaque_t;
 
 /* Compile-time check: must fit in vlib_buffer opaque2 (64 bytes) */
+#ifndef __cplusplus
 _Static_assert(sizeof(infmon_buffer_opaque_t) <= 64,
                "infmon_buffer_opaque_t exceeds VLIB_BUFFER_OPAQUE2_SIZE (64 bytes)");
+#endif
 
 /* -- Atomic flow-rule reference (TOCTOU-safe) */
 

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -110,6 +110,14 @@ static inline void infmon_worker_counters_init(infmon_worker_counters_t *wc, uin
 {
     if (!wc)
         return;
+    /*
+     * memset on _Atomic uint64_t is technically UB per C11 §7.17.2.1
+     * (atomic objects should be initialised via atomic_init()).  We rely on
+     * the pragmatic assumption that _Atomic uint64_t has the same
+     * representation as uint64_t (true on GCC/Clang x86-64/aarch64) and
+     * that init is always single-threaded (no concurrent access during
+     * worker bring-up).
+     */
     memset(wc, 0, sizeof(*wc));
     wc->worker_id = worker_id;
 }

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -18,6 +18,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#ifndef __cplusplus
+#include <stdatomic.h>
+#endif
+
 #include "infmon/counter_table.h"
 #include "infmon/erspan_parser.h"
 #include "infmon/flow_rule.h"
@@ -51,6 +55,18 @@ extern const char *infmon_node_error_strings[];
 
 /* ── Per-worker status counters (§11, exposed via infmon_status) ─── */
 
+/*
+ * Counter fields are written by VPP worker threads and read by the API
+ * thread, so they must be atomic to avoid data races (UB under C11/C++11).
+ * In C we use _Atomic; in C++ test builds we keep plain uint64_t because
+ * the tests are single-threaded (no real race).
+ */
+#ifdef __cplusplus
+#define INFMON_COUNTER_U64 uint64_t
+#else
+#define INFMON_COUNTER_U64 _Atomic uint64_t
+#endif
+
 /**
  * Per-worker health/error counters.  One instance per VPP worker thread.
  * In production these live in VPP's thread-local storage; for unit tests
@@ -62,13 +78,13 @@ extern const char *infmon_node_error_strings[];
  */
 typedef struct {
     uint32_t worker_id;
-    uint64_t packets_seen;                   /**< Total packets entering infmon-erspan-decap. */
-    uint64_t erspan_unknown_proto;           /**< Outer header parsed, ERSPAN type unrecognised. */
-    uint64_t erspan_truncated;               /**< Buffer too short for declared ERSPAN header. */
-    uint64_t inner_parse_failed;             /**< Inner L2/L3/L4 parse error after decap. */
-    uint64_t flow_rule_no_match;             /**< Packet matched zero flow rules. */
-    uint64_t counter_insert_retry_exhausted; /**< CAS retries exceeded INFMON_INSERT_RETRY. */
-    uint64_t counter_table_full;             /**< Table reached max_keys_per_flow_rule. */
+    INFMON_COUNTER_U64 packets_seen;                   /**< Total packets entering infmon-erspan-decap. */
+    INFMON_COUNTER_U64 erspan_unknown_proto;           /**< Outer header parsed, ERSPAN type unrecognised. */
+    INFMON_COUNTER_U64 erspan_truncated;               /**< Buffer too short for declared ERSPAN header. */
+    INFMON_COUNTER_U64 inner_parse_failed;             /**< Inner L2/L3/L4 parse error after decap. */
+    INFMON_COUNTER_U64 flow_rule_no_match;             /**< Packet matched zero flow rules. */
+    INFMON_COUNTER_U64 counter_insert_retry_exhausted; /**< CAS retries exceeded INFMON_INSERT_RETRY. */
+    INFMON_COUNTER_U64 counter_table_full;             /**< Table reached max_keys_per_flow_rule. */
 } infmon_worker_counters_t;
 
 /**
@@ -113,7 +129,10 @@ typedef struct {
 } infmon_buffer_opaque_t;
 
 /* Compile-time check: must fit in vlib_buffer opaque2 (64 bytes) */
-#ifndef __cplusplus
+#ifdef __cplusplus
+static_assert(sizeof(infmon_buffer_opaque_t) <= 64,
+              "infmon_buffer_opaque_t exceeds VLIB_BUFFER_OPAQUE2_SIZE (64 bytes)");
+#else
 _Static_assert(sizeof(infmon_buffer_opaque_t) <= 64,
                "infmon_buffer_opaque_t exceeds VLIB_BUFFER_OPAQUE2_SIZE (64 bytes)");
 #endif

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -78,6 +78,7 @@ extern const char *infmon_node_error_strings[];
  */
 typedef struct {
     uint32_t worker_id;
+    uint32_t _pad;                                     /**< Explicit padding for 8-byte alignment. */
     INFMON_COUNTER_U64 packets_seen;                   /**< Total packets entering infmon-erspan-decap. */
     INFMON_COUNTER_U64 erspan_unknown_proto;           /**< Outer header parsed, ERSPAN type unrecognised. */
     INFMON_COUNTER_U64 erspan_truncated;               /**< Buffer too short for declared ERSPAN header. */

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -89,6 +89,20 @@ typedef struct {
     INFMON_COUNTER_U64 counter_table_full; /**< Table reached max_keys_per_flow_rule. */
 } infmon_worker_counters_t;
 
+/*
+ * Cross-language size guard: _Atomic qualifiers must not change the struct
+ * layout between C and C++ translation units (see review discussion on
+ * potential ABI mismatch with exotic targets).
+ */
+#define INFMON_WORKER_COUNTERS_EXPECTED_SIZE 64 /* 4 + 4 + 7*8 = 64 */
+#ifdef __cplusplus
+static_assert(sizeof(infmon_worker_counters_t) == INFMON_WORKER_COUNTERS_EXPECTED_SIZE,
+              "infmon_worker_counters_t size mismatch between C and C++ — check _Atomic padding");
+#else
+_Static_assert(sizeof(infmon_worker_counters_t) == INFMON_WORKER_COUNTERS_EXPECTED_SIZE,
+               "infmon_worker_counters_t size mismatch — check _Atomic padding");
+#endif
+
 /**
  * Initialise a worker-counters struct (zero all fields, set worker_id).
  */

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -85,7 +85,7 @@ typedef struct {
     INFMON_COUNTER_U64 inner_parse_failed;   /**< Inner L2/L3/L4 parse error after decap. */
     INFMON_COUNTER_U64 flow_rule_no_match;   /**< Packet matched zero flow rules. */
     INFMON_COUNTER_U64
-        counter_insert_retry_exhausted;    /**< CAS retries exceeded INFMON_INSERT_RETRY. */
+    counter_insert_retry_exhausted;        /**< CAS retries exceeded INFMON_INSERT_RETRY. */
     INFMON_COUNTER_U64 counter_table_full; /**< Table reached max_keys_per_flow_rule. */
 } infmon_worker_counters_t;
 

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -78,14 +78,15 @@ extern const char *infmon_node_error_strings[];
  */
 typedef struct {
     uint32_t worker_id;
-    uint32_t _pad;                                     /**< Explicit padding for 8-byte alignment. */
-    INFMON_COUNTER_U64 packets_seen;                   /**< Total packets entering infmon-erspan-decap. */
-    INFMON_COUNTER_U64 erspan_unknown_proto;           /**< Outer header parsed, ERSPAN type unrecognised. */
-    INFMON_COUNTER_U64 erspan_truncated;               /**< Buffer too short for declared ERSPAN header. */
-    INFMON_COUNTER_U64 inner_parse_failed;             /**< Inner L2/L3/L4 parse error after decap. */
-    INFMON_COUNTER_U64 flow_rule_no_match;             /**< Packet matched zero flow rules. */
-    INFMON_COUNTER_U64 counter_insert_retry_exhausted; /**< CAS retries exceeded INFMON_INSERT_RETRY. */
-    INFMON_COUNTER_U64 counter_table_full;             /**< Table reached max_keys_per_flow_rule. */
+    uint32_t _pad;                           /**< Explicit padding for 8-byte alignment. */
+    INFMON_COUNTER_U64 packets_seen;         /**< Total packets entering infmon-erspan-decap. */
+    INFMON_COUNTER_U64 erspan_unknown_proto; /**< Outer header parsed, ERSPAN type unrecognised. */
+    INFMON_COUNTER_U64 erspan_truncated;     /**< Buffer too short for declared ERSPAN header. */
+    INFMON_COUNTER_U64 inner_parse_failed;   /**< Inner L2/L3/L4 parse error after decap. */
+    INFMON_COUNTER_U64 flow_rule_no_match;   /**< Packet matched zero flow rules. */
+    INFMON_COUNTER_U64
+        counter_insert_retry_exhausted;    /**< CAS retries exceeded INFMON_INSERT_RETRY. */
+    INFMON_COUNTER_U64 counter_table_full; /**< Table reached max_keys_per_flow_rule. */
 } infmon_worker_counters_t;
 
 /**

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -62,13 +62,13 @@ extern const char *infmon_node_error_strings[];
  */
 typedef struct {
     uint32_t worker_id;
-    uint64_t packets_seen;                    /**< Total packets entering infmon-erspan-decap. */
-    uint64_t erspan_unknown_proto;            /**< Outer header parsed, ERSPAN type unrecognised. */
-    uint64_t erspan_truncated;                /**< Buffer too short for declared ERSPAN header. */
-    uint64_t inner_parse_failed;              /**< Inner L2/L3/L4 parse error after decap. */
-    uint64_t flow_rule_no_match;              /**< Packet matched zero flow rules. */
-    uint64_t counter_insert_retry_exhausted;  /**< CAS retries exceeded INFMON_INSERT_RETRY. */
-    uint64_t counter_table_full;              /**< Table reached max_keys_per_flow_rule. */
+    uint64_t packets_seen;                   /**< Total packets entering infmon-erspan-decap. */
+    uint64_t erspan_unknown_proto;           /**< Outer header parsed, ERSPAN type unrecognised. */
+    uint64_t erspan_truncated;               /**< Buffer too short for declared ERSPAN header. */
+    uint64_t inner_parse_failed;             /**< Inner L2/L3/L4 parse error after decap. */
+    uint64_t flow_rule_no_match;             /**< Packet matched zero flow rules. */
+    uint64_t counter_insert_retry_exhausted; /**< CAS retries exceeded INFMON_INSERT_RETRY. */
+    uint64_t counter_table_full;             /**< Table reached max_keys_per_flow_rule. */
 } infmon_worker_counters_t;
 
 /**

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -326,8 +326,7 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
 
 /* ── Status ──────────────────────────────────────────────────────── */
 
-infmon_api_result_t infmon_api_status(const infmon_api_ctx_t *ctx,
-                                      infmon_api_status_reply_t *reply)
+infmon_api_result_t infmon_api_status(const infmon_api_ctx_t *ctx, infmon_api_status_reply_t *reply)
 {
     if (!reply)
         return INFMON_API_ERR_INTERNAL;

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -323,3 +323,29 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
 
     return INFMON_API_OK;
 }
+
+/* ── Status ──────────────────────────────────────────────────────── */
+
+infmon_api_result_t infmon_api_status(const infmon_api_ctx_t *ctx,
+                                      infmon_api_status_reply_t *reply)
+{
+    if (!reply)
+        return INFMON_API_ERR_INTERNAL;
+
+    memset(reply, 0, sizeof(*reply));
+
+    if (!ctx) {
+        reply->result = INFMON_API_ERR_INTERNAL;
+        return INFMON_API_ERR_INTERNAL;
+    }
+
+    if (!ctx->worker_counters || ctx->worker_count == 0) {
+        reply->result = INFMON_API_ERR_INTERNAL;
+        return INFMON_API_ERR_INTERNAL;
+    }
+
+    reply->workers = ctx->worker_counters;
+    reply->worker_count = ctx->worker_count;
+    reply->result = INFMON_API_OK;
+    return INFMON_API_OK;
+}

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -7,6 +7,8 @@
 
 #include <string.h>
 
+#include "infmon/snapshot.h" /* INFMON_MAX_WORKERS */
+
 /* ── Helpers ─────────────────────────────────────────────────────── */
 
 /** Map flow-rule CRUD result to API result. */
@@ -344,6 +346,11 @@ infmon_api_result_t infmon_api_status(const infmon_api_ctx_t *ctx, infmon_api_st
     }
 
     if (ctx->worker_count == 0) {
+        reply->result = INFMON_API_ERR_INTERNAL;
+        return INFMON_API_ERR_INTERNAL;
+    }
+
+    if (ctx->worker_count > INFMON_MAX_WORKERS) {
         reply->result = INFMON_API_ERR_INTERNAL;
         return INFMON_API_ERR_INTERNAL;
     }

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -338,7 +338,12 @@ infmon_api_result_t infmon_api_status(const infmon_api_ctx_t *ctx, infmon_api_st
         return INFMON_API_ERR_INTERNAL;
     }
 
-    if (!ctx->worker_counters || ctx->worker_count == 0) {
+    if (!ctx->worker_counters) {
+        reply->result = INFMON_API_ERR_INTERNAL;
+        return INFMON_API_ERR_INTERNAL;
+    }
+
+    if (ctx->worker_count == 0) {
         reply->result = INFMON_API_ERR_INTERNAL;
         return INFMON_API_ERR_INTERNAL;
     }

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -491,6 +491,19 @@ TEST_F(ApiHandlerTest, StatusNoWorkersReturnsError)
     EXPECT_EQ(reply.result, INFMON_API_ERR_INTERNAL);
 }
 
+TEST_F(ApiHandlerTest, StatusValidPointerZeroCountReturnsError)
+{
+    /* worker_counters is valid but worker_count is 0 — distinct failure mode. */
+    infmon_worker_counters_t wc;
+    infmon_worker_counters_init(&wc, 0);
+    ctx_.worker_counters = &wc;
+    ctx_.worker_count = 0;
+
+    infmon_api_status_reply_t reply;
+    EXPECT_EQ(infmon_api_status(&ctx_, &reply), INFMON_API_ERR_INTERNAL);
+    EXPECT_EQ(reply.result, INFMON_API_ERR_INTERNAL);
+}
+
 TEST_F(ApiHandlerTest, StatusSingleWorkerZeroCounters)
 {
     infmon_worker_counters_t wc;

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -542,6 +542,19 @@ TEST_F(ApiHandlerTest, WorkerCountersInitSetsWorkerIdOnly)
     EXPECT_EQ(wc.counter_table_full, 0u);
 }
 
+TEST_F(ApiHandlerTest, StatusExceedsMaxWorkersReturnsError)
+{
+    /* worker_count > INFMON_MAX_WORKERS should be rejected. */
+    infmon_worker_counters_t wc;
+    infmon_worker_counters_init(&wc, 0);
+    ctx_.worker_counters = &wc;
+    ctx_.worker_count = INFMON_MAX_WORKERS + 1;
+
+    infmon_api_status_reply_t reply;
+    EXPECT_EQ(infmon_api_status(&ctx_, &reply), INFMON_API_ERR_INTERNAL);
+    EXPECT_EQ(reply.result, INFMON_API_ERR_INTERNAL);
+}
+
 TEST_F(ApiHandlerTest, WorkerCountersInitNullNoOp)
 {
     /* Should not crash. */

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -424,3 +424,113 @@ TEST_F(ApiHandlerSnapTest, SnapshotAndClearReturnType)
     EXPECT_EQ(rc, INFMON_API_OK);
     EXPECT_EQ(rc, reply.result);
 }
+
+/* ── W10e: infmon_status tests ──────────────────────────────────── */
+
+TEST_F(ApiHandlerTest, StatusBasic)
+{
+    /* Set up 2 workers with known counter values. */
+    infmon_worker_counters_t workers[2];
+    infmon_worker_counters_init(&workers[0], 0);
+    infmon_worker_counters_init(&workers[1], 1);
+
+    workers[0].packets_seen = 100;
+    workers[0].erspan_unknown_proto = 1;
+    workers[0].erspan_truncated = 2;
+    workers[0].inner_parse_failed = 3;
+    workers[0].flow_rule_no_match = 10;
+    workers[0].counter_insert_retry_exhausted = 0;
+    workers[0].counter_table_full = 0;
+
+    workers[1].packets_seen = 200;
+    workers[1].erspan_unknown_proto = 0;
+    workers[1].erspan_truncated = 0;
+    workers[1].inner_parse_failed = 0;
+    workers[1].flow_rule_no_match = 5;
+    workers[1].counter_insert_retry_exhausted = 1;
+    workers[1].counter_table_full = 2;
+
+    ctx_.worker_counters = workers;
+    ctx_.worker_count = 2;
+
+    infmon_api_status_reply_t reply;
+    infmon_api_result_t rc = infmon_api_status(&ctx_, &reply);
+    EXPECT_EQ(rc, INFMON_API_OK);
+    EXPECT_EQ(reply.result, INFMON_API_OK);
+    ASSERT_EQ(reply.worker_count, 2u);
+    ASSERT_NE(reply.workers, nullptr);
+
+    EXPECT_EQ(reply.workers[0].worker_id, 0u);
+    EXPECT_EQ(reply.workers[0].packets_seen, 100u);
+    EXPECT_EQ(reply.workers[0].erspan_unknown_proto, 1u);
+    EXPECT_EQ(reply.workers[0].flow_rule_no_match, 10u);
+
+    EXPECT_EQ(reply.workers[1].worker_id, 1u);
+    EXPECT_EQ(reply.workers[1].packets_seen, 200u);
+    EXPECT_EQ(reply.workers[1].counter_insert_retry_exhausted, 1u);
+    EXPECT_EQ(reply.workers[1].counter_table_full, 2u);
+}
+
+TEST_F(ApiHandlerTest, StatusNullCtxReturnsError)
+{
+    infmon_api_status_reply_t reply;
+    EXPECT_EQ(infmon_api_status(nullptr, &reply), INFMON_API_ERR_INTERNAL);
+    EXPECT_EQ(reply.result, INFMON_API_ERR_INTERNAL);
+}
+
+TEST_F(ApiHandlerTest, StatusNullReplyReturnsError)
+{
+    EXPECT_EQ(infmon_api_status(&ctx_, nullptr), INFMON_API_ERR_INTERNAL);
+}
+
+TEST_F(ApiHandlerTest, StatusNoWorkersReturnsError)
+{
+    /* ctx_ has worker_counters = NULL, worker_count = 0 by default. */
+    infmon_api_status_reply_t reply;
+    EXPECT_EQ(infmon_api_status(&ctx_, &reply), INFMON_API_ERR_INTERNAL);
+    EXPECT_EQ(reply.result, INFMON_API_ERR_INTERNAL);
+}
+
+TEST_F(ApiHandlerTest, StatusSingleWorkerZeroCounters)
+{
+    infmon_worker_counters_t wc;
+    infmon_worker_counters_init(&wc, 42);
+
+    ctx_.worker_counters = &wc;
+    ctx_.worker_count = 1;
+
+    infmon_api_status_reply_t reply;
+    EXPECT_EQ(infmon_api_status(&ctx_, &reply), INFMON_API_OK);
+    ASSERT_EQ(reply.worker_count, 1u);
+    EXPECT_EQ(reply.workers[0].worker_id, 42u);
+    EXPECT_EQ(reply.workers[0].packets_seen, 0u);
+    EXPECT_EQ(reply.workers[0].erspan_unknown_proto, 0u);
+    EXPECT_EQ(reply.workers[0].erspan_truncated, 0u);
+    EXPECT_EQ(reply.workers[0].inner_parse_failed, 0u);
+    EXPECT_EQ(reply.workers[0].flow_rule_no_match, 0u);
+    EXPECT_EQ(reply.workers[0].counter_insert_retry_exhausted, 0u);
+    EXPECT_EQ(reply.workers[0].counter_table_full, 0u);
+}
+
+TEST_F(ApiHandlerTest, WorkerCountersInitSetsWorkerIdOnly)
+{
+    infmon_worker_counters_t wc;
+    /* Fill with garbage first. */
+    memset(&wc, 0xFF, sizeof(wc));
+    infmon_worker_counters_init(&wc, 7);
+
+    EXPECT_EQ(wc.worker_id, 7u);
+    EXPECT_EQ(wc.packets_seen, 0u);
+    EXPECT_EQ(wc.erspan_unknown_proto, 0u);
+    EXPECT_EQ(wc.erspan_truncated, 0u);
+    EXPECT_EQ(wc.inner_parse_failed, 0u);
+    EXPECT_EQ(wc.flow_rule_no_match, 0u);
+    EXPECT_EQ(wc.counter_insert_retry_exhausted, 0u);
+    EXPECT_EQ(wc.counter_table_full, 0u);
+}
+
+TEST_F(ApiHandlerTest, WorkerCountersInitNullNoOp)
+{
+    /* Should not crash. */
+    infmon_worker_counters_init(nullptr, 0);
+}


### PR DESCRIPTION
## Summary

Implements the `infmon_status` API message that exposes per-worker health and error counters, as specified in issue #48.

### Changes

- **`graph_node.h`**: Added `infmon_worker_counters_t` struct with `worker_id`, `packets_seen`, and 6 error counters matching `infmon_node_error_t` enum values. Added `infmon_worker_counters_init()` inline initializer. Guarded `_Static_assert` for C++ compatibility.
- **`api_handler.h`**: Added `worker_counters`/`worker_count` fields to `infmon_api_ctx_t`. Added `infmon_api_status_reply_t` struct and `infmon_api_status()` declaration.
- **`api_handler.c`**: Implemented `infmon_api_status()` with NULL/empty validation, returning pointers into the ctx's worker_counters array.
- **`test_api_handler.cc`**: Added 7 tests covering basic multi-worker status, null ctx/reply, no workers, single worker zero counters, init semantics, and null-safe init.

### Test Plan
- All 8 test suites pass (including 7 new status API tests)

Closes #48