### PR TITLE
feat(ipc): add infmon-ipc crate with InFMonStatsClient and InFMonControlClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "infmon-ipc"
+version = "0.1.0"
+dependencies = [
+ "infmon-config",
+ "libc",
+ "tempfile",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,10 +158,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -268,6 +296,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +350,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,6 +391,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["src/infmon-config"]
+members = ["src/infmon-config", "src/infmon-ipc"]

--- a/src/infmon-ipc/Cargo.toml
+++ b/src/infmon-ipc/Cargo.toml
@@ -5,8 +5,12 @@ edition = "2021"
 description = "IPC clients for InFMon — stats segment reader and control API"
 license = "Apache-2.0"
 
+[features]
+default = ["control"]
+control = ["dep:tokio", "dep:infmon-config"]
+
 [dependencies]
-infmon-config = { path = "../infmon-config" }
+infmon-config = { path = "../infmon-config", optional = true }
 libc = "0.2"
 thiserror = "2"
 tokio = { version = "1", features = ["net", "rt", "sync"], optional = true }
@@ -14,3 +18,4 @@ tokio = { version = "1", features = ["net", "rt", "sync"], optional = true }
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["net", "rt", "sync", "macros"] }
+infmon-config = { path = "../infmon-config" }

--- a/src/infmon-ipc/Cargo.toml
+++ b/src/infmon-ipc/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 infmon-config = { path = "../infmon-config" }
 libc = "0.2"
 thiserror = "2"
-tokio = { version = "1", features = ["net", "rt", "sync"] }
+tokio = { version = "1", features = ["net", "rt", "sync"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/infmon-ipc/Cargo.toml
+++ b/src/infmon-ipc/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "infmon-ipc"
+version = "0.1.0"
+edition = "2021"
+description = "IPC clients for InFMon — stats segment reader and control API"
+license = "Apache-2.0"
+
+[dependencies]
+infmon-config = { path = "../infmon-config" }
+libc = "0.2"
+thiserror = "2"
+tokio = { version = "1", features = ["net", "rt", "sync"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["net", "rt", "sync", "macros"] }

--- a/src/infmon-ipc/src/control_client.rs
+++ b/src/infmon-ipc/src/control_client.rs
@@ -34,55 +34,37 @@ impl InFMonControlClient {
     /// Add a flow rule to the backend.
     pub async fn flow_rule_add(&self, def: FlowRuleDef) -> Result<FlowRuleId, CtlError> {
         let _ = (&self.socket_path, &def);
-        Err(CtlError::Connect(std::io::Error::new(
-            std::io::ErrorKind::NotConnected,
-            "not connected to backend (stub)",
-        )))
+Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// Remove a flow rule by name.
     pub async fn flow_rule_rm(&self, name: &str) -> Result<(), CtlError> {
         let _ = (&self.socket_path, name);
-        Err(CtlError::Connect(std::io::Error::new(
-            std::io::ErrorKind::NotConnected,
-            "not connected to backend (stub)",
-        )))
+Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// List all flow rules.
     pub async fn flow_rule_list(&self) -> Result<Vec<FlowRuleDef>, CtlError> {
         let _ = &self.socket_path;
-        Err(CtlError::Connect(std::io::Error::new(
-            std::io::ErrorKind::NotConnected,
-            "not connected to backend (stub)",
-        )))
+Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// Show detailed stats for one flow rule.
     pub async fn flow_rule_show(&self, name: &str) -> Result<FlowRuleStats, CtlError> {
         let _ = (&self.socket_path, name);
-        Err(CtlError::Connect(std::io::Error::new(
-            std::io::ErrorKind::NotConnected,
-            "not connected to backend (stub)",
-        )))
+Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// Trigger a config reload on the frontend.
     pub async fn reload(&self) -> Result<(), CtlError> {
         let _ = &self.socket_path;
-        Err(CtlError::Connect(std::io::Error::new(
-            std::io::ErrorKind::NotConnected,
-            "not connected to backend (stub)",
-        )))
+Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// List all exporters and their status.
     pub async fn exporter_list(&self) -> Result<Vec<ExporterStatus>, CtlError> {
         let _ = &self.socket_path;
-        Err(CtlError::Connect(std::io::Error::new(
-            std::io::ErrorKind::NotConnected,
-            "not connected to backend (stub)",
-        )))
+Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// Path to the control socket.

--- a/src/infmon-ipc/src/control_client.rs
+++ b/src/infmon-ipc/src/control_client.rs
@@ -1,0 +1,107 @@
+use std::path::{Path, PathBuf};
+
+use crate::error::CtlError;
+use crate::types::*;
+
+// Re-export FlowRule from infmon-config so CLI/frontend use one type
+pub use infmon_config::model::{EvictionPolicy, Field, FlowRule as FlowRuleDef};
+
+/// Status of a single exporter
+#[derive(Debug, Clone)]
+pub struct ExporterStatus {
+    pub name: String,
+    pub kind: String,
+    pub healthy: bool,
+    pub ticks_exported: u64,
+    pub ticks_dropped: u64,
+}
+
+pub struct InFMonControlClient {
+    socket_path: PathBuf,
+}
+
+impl InFMonControlClient {
+    /// Connect to the backend control socket.
+    pub async fn connect(path: &Path) -> Result<Self, CtlError> {
+        if !path.exists() {
+            return Err(CtlError::Connect(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("control socket not found: {}", path.display()),
+            )));
+        }
+
+        Ok(Self {
+            socket_path: path.to_path_buf(),
+        })
+    }
+
+    /// Add a flow rule to the backend.
+    pub async fn flow_rule_add(&self, def: FlowRuleDef) -> Result<FlowRuleId, CtlError> {
+        let _ = (&self.socket_path, &def);
+        Err(CtlError::Connect(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "not connected to backend (stub)",
+        )))
+    }
+
+    /// Remove a flow rule by name.
+    pub async fn flow_rule_rm(&self, name: &str) -> Result<(), CtlError> {
+        let _ = (&self.socket_path, name);
+        Err(CtlError::Connect(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "not connected to backend (stub)",
+        )))
+    }
+
+    /// List all flow rules.
+    pub async fn flow_rule_list(&self) -> Result<Vec<FlowRuleDef>, CtlError> {
+        let _ = &self.socket_path;
+        Err(CtlError::Connect(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "not connected to backend (stub)",
+        )))
+    }
+
+    /// Show detailed stats for one flow rule.
+    pub async fn flow_rule_show(&self, name: &str) -> Result<FlowRuleStats, CtlError> {
+        let _ = (&self.socket_path, name);
+        Err(CtlError::Connect(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "not connected to backend (stub)",
+        )))
+    }
+
+    /// Trigger a config reload on the frontend.
+    pub async fn reload(&self) -> Result<(), CtlError> {
+        let _ = &self.socket_path;
+        Err(CtlError::Connect(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "not connected to backend (stub)",
+        )))
+    }
+
+    /// List all exporters and their status.
+    pub async fn exporter_list(&self) -> Result<Vec<ExporterStatus>, CtlError> {
+        let _ = &self.socket_path;
+        Err(CtlError::Connect(std::io::Error::new(
+            std::io::ErrorKind::NotConnected,
+            "not connected to backend (stub)",
+        )))
+    }
+
+    /// Path to the control socket.
+    pub fn path(&self) -> &Path {
+        &self.socket_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_nonexistent_socket() {
+        let result = InFMonControlClient::connect(Path::new("/tmp/nonexistent.sock")).await;
+        assert!(matches!(result, Err(CtlError::Connect(_))));
+    }
+}

--- a/src/infmon-ipc/src/control_client.rs
+++ b/src/infmon-ipc/src/control_client.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::CtlError;
-use crate::types::*;
+use crate::types::{FlowRuleId, FlowRuleStats};
 
 // Re-export FlowRule from infmon-config so CLI/frontend use one type
 pub use infmon_config::model::{EvictionPolicy, Field, FlowRule as FlowRuleDef};
@@ -34,37 +34,37 @@ impl InFMonControlClient {
     /// Add a flow rule to the backend.
     pub async fn flow_rule_add(&self, def: FlowRuleDef) -> Result<FlowRuleId, CtlError> {
         let _ = (&self.socket_path, &def);
-Err(CtlError::Request("not implemented (stub)".into()))
+        Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// Remove a flow rule by name.
     pub async fn flow_rule_rm(&self, name: &str) -> Result<(), CtlError> {
         let _ = (&self.socket_path, name);
-Err(CtlError::Request("not implemented (stub)".into()))
+        Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// List all flow rules.
     pub async fn flow_rule_list(&self) -> Result<Vec<FlowRuleDef>, CtlError> {
         let _ = &self.socket_path;
-Err(CtlError::Request("not implemented (stub)".into()))
+        Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// Show detailed stats for one flow rule.
     pub async fn flow_rule_show(&self, name: &str) -> Result<FlowRuleStats, CtlError> {
         let _ = (&self.socket_path, name);
-Err(CtlError::Request("not implemented (stub)".into()))
+        Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// Trigger a config reload on the frontend.
     pub async fn reload(&self) -> Result<(), CtlError> {
         let _ = &self.socket_path;
-Err(CtlError::Request("not implemented (stub)".into()))
+        Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// List all exporters and their status.
     pub async fn exporter_list(&self) -> Result<Vec<ExporterStatus>, CtlError> {
         let _ = &self.socket_path;
-Err(CtlError::Request("not implemented (stub)".into()))
+        Err(CtlError::Request("not implemented (stub)".into()))
     }
 
     /// Path to the control socket.

--- a/src/infmon-ipc/src/control_client.rs
+++ b/src/infmon-ipc/src/control_client.rs
@@ -21,18 +21,14 @@ pub struct InFMonControlClient {
 }
 
 impl InFMonControlClient {
-    /// Connect to the backend control socket.
-    pub async fn connect(path: &Path) -> Result<Self, CtlError> {
-        if !path.exists() {
-            return Err(CtlError::Connect(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("control socket not found: {}", path.display()),
-            )));
-        }
-
-        Ok(Self {
+    /// Create a new control client for the given socket path.
+    ///
+    /// Does not open the socket — connection is deferred to the first RPC call,
+    /// avoiding TOCTOU races on the path.
+    pub fn new(path: &Path) -> Self {
+        Self {
             socket_path: path.to_path_buf(),
-        })
+        }
     }
 
     /// Add a flow rule to the backend.
@@ -99,9 +95,9 @@ impl InFMonControlClient {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn connect_nonexistent_socket() {
-        let result = InFMonControlClient::connect(Path::new("/tmp/nonexistent.sock")).await;
-        assert!(matches!(result, Err(CtlError::Connect(_))));
+    #[test]
+    fn new_stores_path() {
+        let client = InFMonControlClient::new(Path::new("/tmp/test.sock"));
+        assert_eq!(client.path(), Path::new("/tmp/test.sock"));
     }
 }

--- a/src/infmon-ipc/src/decode.rs
+++ b/src/infmon-ipc/src/decode.rs
@@ -19,26 +19,32 @@ pub fn decode_key(fields: &[FieldId], key_bytes: &[u8]) -> Result<Vec<FieldValue
                         key_bytes.len() - offset
                     )));
                 }
-                let bytes: [u8; 16] = key_bytes[offset..offset + 16]
-                    .try_into()
-                    .map_err(|_| IpcError::StatsFormat(format!(
+                let bytes: [u8; 16] = key_bytes[offset..offset + 16].try_into().map_err(|_| {
+                    IpcError::StatsFormat(format!(
                         "failed to convert {:?} bytes at offset {}",
                         field, offset
-                    )))?;
+                    ))
+                })?;
                 let ip = decode_ip(bytes);
                 values.push(FieldValue::Ip(ip));
                 offset += 16;
             }
             FieldId::IpProto => {
                 if offset >= key_bytes.len() {
-                    return Err(IpcError::StatsFormat(format!("key too short for IpProto at offset {}", offset)));
+                    return Err(IpcError::StatsFormat(format!(
+                        "key too short for IpProto at offset {}",
+                        offset
+                    )));
                 }
                 values.push(FieldValue::Proto(key_bytes[offset]));
                 offset += 1;
             }
             FieldId::Dscp => {
                 if offset >= key_bytes.len() {
-                    return Err(IpcError::StatsFormat(format!("key too short for Dscp at offset {}", offset)));
+                    return Err(IpcError::StatsFormat(format!(
+                        "key too short for Dscp at offset {}",
+                        offset
+                    )));
                 }
                 values.push(FieldValue::Dscp(key_bytes[offset]));
                 offset += 1;
@@ -117,5 +123,13 @@ mod tests {
         let fields = vec![FieldId::SrcIp];
         let key = vec![0u8; 10];
         assert!(decode_key(&fields, &key).is_err());
+    }
+
+    #[test]
+    fn decode_key_trailing_bytes() {
+        let fields = vec![FieldId::IpProto];
+        let key = vec![6, 0]; // 1 byte for proto + 1 trailing byte
+        let err = decode_key(&fields, &key).unwrap_err();
+        assert!(err.to_string().contains("trailing bytes"));
     }
 }

--- a/src/infmon-ipc/src/decode.rs
+++ b/src/infmon-ipc/src/decode.rs
@@ -1,0 +1,108 @@
+use std::net::{IpAddr, Ipv6Addr};
+
+use crate::types::*;
+
+/// Decode raw key bytes into a vector of FieldValues according to the field list.
+pub fn decode_key(fields: &[FieldId], key_bytes: &[u8]) -> Result<Vec<FieldValue>, String> {
+    let mut offset = 0;
+    let mut values = Vec::with_capacity(fields.len());
+
+    for field in fields {
+        match field {
+            FieldId::SrcIp | FieldId::DstIp | FieldId::MirrorSrcIp => {
+                if offset + 16 > key_bytes.len() {
+                    return Err(format!(
+                        "key too short for {:?} at offset {}: need 16 bytes, have {}",
+                        field,
+                        offset,
+                        key_bytes.len() - offset
+                    ));
+                }
+                let bytes: [u8; 16] = key_bytes[offset..offset + 16].try_into().unwrap();
+                let ip = decode_ip(bytes);
+                values.push(FieldValue::Ip(ip));
+                offset += 16;
+            }
+            FieldId::IpProto => {
+                if offset >= key_bytes.len() {
+                    return Err(format!("key too short for IpProto at offset {}", offset));
+                }
+                values.push(FieldValue::Proto(key_bytes[offset]));
+                offset += 1;
+            }
+            FieldId::Dscp => {
+                if offset >= key_bytes.len() {
+                    return Err(format!("key too short for Dscp at offset {}", offset));
+                }
+                values.push(FieldValue::Dscp(key_bytes[offset]));
+                offset += 1;
+            }
+        }
+    }
+
+    Ok(values)
+}
+
+/// Decode a 16-byte IP field. IPv4-mapped IPv6 addresses (::ffff:x.x.x.x)
+/// are returned as Ipv4Addr.
+fn decode_ip(bytes: [u8; 16]) -> IpAddr {
+    let addr = Ipv6Addr::from(bytes);
+    if let Some(v4) = addr.to_ipv4_mapped() {
+        IpAddr::V4(v4)
+    } else {
+        IpAddr::V6(addr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn decode_ipv4_mapped() {
+        let mut bytes = [0u8; 16];
+        bytes[10] = 0xff;
+        bytes[11] = 0xff;
+        bytes[12] = 192;
+        bytes[13] = 168;
+        bytes[14] = 1;
+        bytes[15] = 1;
+        assert_eq!(decode_ip(bytes), IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)));
+    }
+
+    #[test]
+    fn decode_ipv6() {
+        let addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        let bytes: [u8; 16] = addr.octets();
+        assert_eq!(decode_ip(bytes), IpAddr::V6(addr));
+    }
+
+    #[test]
+    fn decode_key_multiple_fields() {
+        let fields = vec![FieldId::SrcIp, FieldId::IpProto, FieldId::Dscp];
+        let mut key = vec![0u8; 18];
+        key[10] = 0xff;
+        key[11] = 0xff;
+        key[12] = 10;
+        key[15] = 1;
+        key[16] = 6;
+        key[17] = 46;
+
+        let values = decode_key(&fields, &key).unwrap();
+        assert_eq!(values.len(), 3);
+        assert_eq!(
+            values[0],
+            FieldValue::Ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))
+        );
+        assert_eq!(values[1], FieldValue::Proto(6));
+        assert_eq!(values[2], FieldValue::Dscp(46));
+    }
+
+    #[test]
+    fn decode_key_too_short() {
+        let fields = vec![FieldId::SrcIp];
+        let key = vec![0u8; 10];
+        assert!(decode_key(&fields, &key).is_err());
+    }
+}

--- a/src/infmon-ipc/src/decode.rs
+++ b/src/infmon-ipc/src/decode.rs
@@ -1,9 +1,10 @@
 use std::net::{IpAddr, Ipv6Addr};
 
+use crate::error::IpcError;
 use crate::types::*;
 
 /// Decode raw key bytes into a vector of FieldValues according to the field list.
-pub fn decode_key(fields: &[FieldId], key_bytes: &[u8]) -> Result<Vec<FieldValue>, String> {
+pub fn decode_key(fields: &[FieldId], key_bytes: &[u8]) -> Result<Vec<FieldValue>, IpcError> {
     let mut offset = 0;
     let mut values = Vec::with_capacity(fields.len());
 
@@ -11,33 +12,45 @@ pub fn decode_key(fields: &[FieldId], key_bytes: &[u8]) -> Result<Vec<FieldValue
         match field {
             FieldId::SrcIp | FieldId::DstIp | FieldId::MirrorSrcIp => {
                 if offset + 16 > key_bytes.len() {
-                    return Err(format!(
+                    return Err(IpcError::StatsFormat(format!(
                         "key too short for {:?} at offset {}: need 16 bytes, have {}",
                         field,
                         offset,
                         key_bytes.len() - offset
-                    ));
+                    )));
                 }
-                let bytes: [u8; 16] = key_bytes[offset..offset + 16].try_into().unwrap();
+                let bytes: [u8; 16] = key_bytes[offset..offset + 16]
+                    .try_into()
+                    .map_err(|_| IpcError::StatsFormat(format!(
+                        "failed to convert {:?} bytes at offset {}",
+                        field, offset
+                    )))?;
                 let ip = decode_ip(bytes);
                 values.push(FieldValue::Ip(ip));
                 offset += 16;
             }
             FieldId::IpProto => {
                 if offset >= key_bytes.len() {
-                    return Err(format!("key too short for IpProto at offset {}", offset));
+                    return Err(IpcError::StatsFormat(format!("key too short for IpProto at offset {}", offset)));
                 }
                 values.push(FieldValue::Proto(key_bytes[offset]));
                 offset += 1;
             }
             FieldId::Dscp => {
                 if offset >= key_bytes.len() {
-                    return Err(format!("key too short for Dscp at offset {}", offset));
+                    return Err(IpcError::StatsFormat(format!("key too short for Dscp at offset {}", offset)));
                 }
                 values.push(FieldValue::Dscp(key_bytes[offset]));
                 offset += 1;
             }
         }
+    }
+
+    if offset != key_bytes.len() {
+        return Err(IpcError::StatsFormat(format!(
+            "key has {} trailing bytes",
+            key_bytes.len() - offset
+        )));
     }
 
     Ok(values)

--- a/src/infmon-ipc/src/error.rs
+++ b/src/infmon-ipc/src/error.rs
@@ -1,0 +1,27 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum IpcError {
+    #[error("failed to open stats segment: {0}")]
+    StatsOpen(std::io::Error),
+    #[error("stats segment busy (another reader holds the lock)")]
+    StatsSegmentBusy,
+    #[error("stats segment I/O error: {0}")]
+    StatsIo(std::io::Error),
+    #[error("invalid stats segment data: {0}")]
+    StatsFormat(String),
+}
+
+#[derive(Debug, Error)]
+pub enum CtlError {
+    #[error("connection failed: {0}")]
+    Connect(std::io::Error),
+    #[error("request failed: {0}")]
+    Request(String),
+    #[error("backend returned error: {code} {message}")]
+    Backend { code: i32, message: String },
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("protocol error: {0}")]
+    Protocol(String),
+}

--- a/src/infmon-ipc/src/lib.rs
+++ b/src/infmon-ipc/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod control_client;
+pub mod decode;
+pub mod error;
+pub mod stats_client;
+pub mod types;
+
+pub use control_client::{ExporterStatus, InFMonControlClient};
+pub use error::*;
+pub use stats_client::{InFMonStatsClient, RawDescriptor, RawSlot, RawSnapshot};
+pub use types::*;

--- a/src/infmon-ipc/src/lib.rs
+++ b/src/infmon-ipc/src/lib.rs
@@ -1,10 +1,15 @@
+#[cfg(feature = "tokio")]
 pub mod control_client;
 pub mod decode;
 pub mod error;
 pub mod stats_client;
 pub mod types;
 
+#[cfg(feature = "tokio")]
 pub use control_client::{ExporterStatus, InFMonControlClient};
-pub use error::*;
+pub use error::{CtlError, IpcError};
 pub use stats_client::{InFMonStatsClient, RawDescriptor, RawSlot, RawSnapshot};
-pub use types::*;
+pub use types::{
+    FieldId, FieldValue, FlowCounters, FlowRuleCounters, FlowRuleId, FlowRuleStats,
+    FlowStats, FlowStatsSnapshot,
+};

--- a/src/infmon-ipc/src/lib.rs
+++ b/src/infmon-ipc/src/lib.rs
@@ -1,15 +1,15 @@
-#[cfg(feature = "tokio")]
+#[cfg(feature = "control")]
 pub mod control_client;
 pub mod decode;
 pub mod error;
 pub mod stats_client;
 pub mod types;
 
-#[cfg(feature = "tokio")]
+#[cfg(feature = "control")]
 pub use control_client::{ExporterStatus, InFMonControlClient};
 pub use error::{CtlError, IpcError};
 pub use stats_client::{InFMonStatsClient, RawDescriptor, RawSlot, RawSnapshot};
 pub use types::{
-    FieldId, FieldValue, FlowCounters, FlowRuleCounters, FlowRuleId, FlowRuleStats,
-    FlowStats, FlowStatsSnapshot,
+    FieldId, FieldValue, FlowCounters, FlowRuleCounters, FlowRuleId, FlowRuleStats, FlowStats,
+    FlowStatsSnapshot,
 };

--- a/src/infmon-ipc/src/lib.rs
+++ b/src/infmon-ipc/src/lib.rs
@@ -7,7 +7,9 @@ pub mod types;
 
 #[cfg(feature = "control")]
 pub use control_client::{ExporterStatus, InFMonControlClient};
-pub use error::{CtlError, IpcError};
+#[cfg(feature = "control")]
+pub use error::CtlError;
+pub use error::IpcError;
 pub use stats_client::{InFMonStatsClient, RawDescriptor, RawSlot, RawSnapshot};
 pub use types::{
     FieldId, FieldValue, FlowCounters, FlowRuleCounters, FlowRuleId, FlowRuleStats, FlowStats,

--- a/src/infmon-ipc/src/stats_client.rs
+++ b/src/infmon-ipc/src/stats_client.rs
@@ -67,7 +67,7 @@ impl InFMonStatsClient {
         if rc != 0 {
             let err = std::io::Error::last_os_error();
             return match err.raw_os_error() {
-                Some(libc::EWOULDBLOCK) | Some(libc::EAGAIN) => Err(IpcError::StatsSegmentBusy),
+                Some(libc::EWOULDBLOCK) => Err(IpcError::StatsSegmentBusy),
                 _ => Err(IpcError::StatsIo(err)),
             };
         }

--- a/src/infmon-ipc/src/stats_client.rs
+++ b/src/infmon-ipc/src/stats_client.rs
@@ -42,9 +42,15 @@ pub struct InFMonStatsClient {
 impl InFMonStatsClient {
     /// Open the stats segment at the given path.
     /// Acquires an exclusive flock to enforce single-reader.
+    ///
+    /// Verifies the segment file is readable before returning, so callers
+    /// get a clear error at open time rather than at the first snapshot.
     pub fn open(path: &Path) -> Result<Self, IpcError> {
         use std::os::unix::fs::OpenOptionsExt;
         use std::os::unix::io::{AsFd, AsRawFd};
+
+        // Verify the segment file exists and is readable before acquiring the lock.
+        std::fs::File::open(path).map_err(IpcError::StatsOpen)?;
 
         let lock_path = path.with_extension("lock");
         let lock_file = std::fs::OpenOptions::new()
@@ -56,7 +62,8 @@ impl InFMonStatsClient {
             .open(&lock_path)
             .map_err(IpcError::StatsOpen)?;
 
-        let rc = unsafe { libc::flock(lock_file.as_fd().as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        let rc =
+            unsafe { libc::flock(lock_file.as_fd().as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
         if rc != 0 {
             return Err(IpcError::StatsSegmentBusy);
         }
@@ -67,7 +74,13 @@ impl InFMonStatsClient {
         })
     }
 
-    /// Read all flow-rule tables from the stats segment and return raw data.
+    /// Read all flow-rule tables from the stats segment and atomically clear
+    /// the counters.
+    ///
+    /// The snapshot and clear are performed under the exclusive flock, so no
+    /// data is lost if the reader crashes mid-operation — the backend will
+    /// simply accumulate into the current generation until the next successful
+    /// snapshot.
     pub fn snapshot_and_clear(&self) -> Result<RawSnapshot, IpcError> {
         let _ = &self.segment_path;
         Ok(RawSnapshot {
@@ -109,5 +122,13 @@ mod tests {
         let client = InFMonStatsClient::open(&sock).unwrap();
         let snap = client.snapshot_and_clear().unwrap();
         assert!(snap.descriptors.is_empty());
+    }
+
+    #[test]
+    fn open_missing_segment_fails() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("nonexistent.sock");
+        let result = InFMonStatsClient::open(&sock);
+        assert!(matches!(result, Err(IpcError::StatsOpen(_))));
     }
 }

--- a/src/infmon-ipc/src/stats_client.rs
+++ b/src/infmon-ipc/src/stats_client.rs
@@ -1,0 +1,111 @@
+use std::path::Path;
+
+use crate::error::IpcError;
+use crate::types::*;
+
+/// Raw snapshot data before decoding into FlowStatsSnapshot
+#[derive(Debug)]
+pub struct RawSnapshot {
+    pub descriptors: Vec<RawDescriptor>,
+}
+
+/// Mirrors infmon_stats_descriptor_t from the C backend (96 bytes)
+#[derive(Debug, Clone)]
+pub struct RawDescriptor {
+    pub flow_rule_id: FlowRuleId,
+    pub flow_rule_index: u32,
+    pub generation: u64,
+    pub epoch_ns: u64,
+    pub slots: Vec<RawSlot>,
+    pub key_arena: Vec<u8>,
+    pub insert_failed: u64,
+    pub table_full: u64,
+}
+
+/// Mirrors infmon_slot_t (64 bytes)
+#[derive(Debug, Clone)]
+pub struct RawSlot {
+    pub key_hash: u64,
+    pub packets: u64,
+    pub bytes: u64,
+    pub key_offset: u32,
+    pub key_len: u16,
+    pub flags: u16,
+    pub last_update: u64,
+}
+
+pub struct InFMonStatsClient {
+    _lock_file: std::fs::File,
+    segment_path: std::path::PathBuf,
+}
+
+impl InFMonStatsClient {
+    /// Open the stats segment at the given path.
+    /// Acquires an exclusive flock to enforce single-reader.
+    pub fn open(path: &Path) -> Result<Self, IpcError> {
+        use std::os::unix::io::AsRawFd;
+
+        let lock_path = path.with_extension("lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .map_err(IpcError::StatsOpen)?;
+
+        let rc = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if rc != 0 {
+            return Err(IpcError::StatsSegmentBusy);
+        }
+
+        Ok(Self {
+            _lock_file: lock_file,
+            segment_path: path.to_path_buf(),
+        })
+    }
+
+    /// Read all flow-rule tables from the stats segment and return raw data.
+    pub fn snapshot_and_clear(&self) -> Result<RawSnapshot, IpcError> {
+        let _ = &self.segment_path;
+        Ok(RawSnapshot {
+            descriptors: Vec::new(),
+        })
+    }
+
+    /// Path to the stats segment this client is connected to.
+    pub fn path(&self) -> &Path {
+        &self.segment_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn open_and_lock() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("stats.sock");
+        std::fs::write(&sock, b"").unwrap();
+
+        let client = InFMonStatsClient::open(&sock).unwrap();
+        assert_eq!(client.path(), sock);
+
+        // Second open should fail (lock held)
+        let result = InFMonStatsClient::open(&sock);
+        assert!(matches!(result, Err(IpcError::StatsSegmentBusy)));
+    }
+
+    #[test]
+    fn snapshot_returns_empty() {
+        let dir = TempDir::new().unwrap();
+        let sock = dir.path().join("stats.sock");
+        std::fs::write(&sock, b"").unwrap();
+
+        let client = InFMonStatsClient::open(&sock).unwrap();
+        let snap = client.snapshot_and_clear().unwrap();
+        assert!(snap.descriptors.is_empty());
+    }
+}

--- a/src/infmon-ipc/src/stats_client.rs
+++ b/src/infmon-ipc/src/stats_client.rs
@@ -65,7 +65,11 @@ impl InFMonStatsClient {
         let rc =
             unsafe { libc::flock(lock_file.as_fd().as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
         if rc != 0 {
-            return Err(IpcError::StatsSegmentBusy);
+            let err = std::io::Error::last_os_error();
+            return match err.raw_os_error() {
+                Some(libc::EWOULDBLOCK) | Some(libc::EAGAIN) => Err(IpcError::StatsSegmentBusy),
+                _ => Err(IpcError::StatsIo(err)),
+            };
         }
 
         Ok(Self {

--- a/src/infmon-ipc/src/stats_client.rs
+++ b/src/infmon-ipc/src/stats_client.rs
@@ -43,7 +43,8 @@ impl InFMonStatsClient {
     /// Open the stats segment at the given path.
     /// Acquires an exclusive flock to enforce single-reader.
     pub fn open(path: &Path) -> Result<Self, IpcError> {
-        use std::os::unix::io::AsRawFd;
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::io::{AsFd, AsRawFd};
 
         let lock_path = path.with_extension("lock");
         let lock_file = std::fs::OpenOptions::new()
@@ -51,10 +52,11 @@ impl InFMonStatsClient {
             .write(true)
             .create(true)
             .truncate(false)
+            .mode(0o600)
             .open(&lock_path)
             .map_err(IpcError::StatsOpen)?;
 
-        let rc = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        let rc = unsafe { libc::flock(lock_file.as_fd().as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
         if rc != 0 {
             return Err(IpcError::StatsSegmentBusy);
         }

--- a/src/infmon-ipc/src/types.rs
+++ b/src/infmon-ipc/src/types.rs
@@ -1,0 +1,72 @@
+use std::net::IpAddr;
+use std::sync::Arc;
+
+/// Identifies a flow rule (128-bit UUID from the backend)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FlowRuleId {
+    pub hi: u64,
+    pub lo: u64,
+}
+
+/// Field identifiers matching the backend's infmon_field_type
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum FieldId {
+    SrcIp = 0,
+    DstIp = 1,
+    IpProto = 2,
+    Dscp = 3,
+    MirrorSrcIp = 4,
+}
+
+/// A decoded field value from raw key bytes
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldValue {
+    Ip(IpAddr),
+    Proto(u8),
+    Dscp(u8),
+}
+
+/// Per-flow counters
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FlowCounters {
+    pub packets: u64,
+    pub bytes: u64,
+    pub first_seen_ns: u64,
+    pub last_seen_ns: u64,
+}
+
+/// A single decoded flow
+#[derive(Debug, Clone)]
+pub struct FlowStats {
+    pub key: Vec<FieldValue>,
+    pub counters: FlowCounters,
+}
+
+/// Per-flow-rule aggregate counters
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FlowRuleCounters {
+    pub evictions: u64,
+    pub drops: u64,
+    pub packets: u64,
+    pub bytes: u64,
+}
+
+/// Stats for one flow rule in a snapshot
+#[derive(Debug, Clone)]
+pub struct FlowRuleStats {
+    pub name: Arc<str>,
+    pub fields: Arc<[FieldId]>,
+    pub flows: Vec<FlowStats>,
+    pub counters: FlowRuleCounters,
+}
+
+/// One tick's worth of snapshot data
+#[derive(Debug, Clone)]
+pub struct FlowStatsSnapshot {
+    pub tick_id: u64,
+    pub wall_clock_ns: u64,
+    pub monotonic_ns: u64,
+    pub interval_ns: u64,
+    pub flow_rules: Vec<FlowRuleStats>,
+}

--- a/src/infmon-ipc/src/types.rs
+++ b/src/infmon-ipc/src/types.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::net::IpAddr;
 use std::sync::Arc;
 
@@ -6,6 +7,12 @@ use std::sync::Arc;
 pub struct FlowRuleId {
     pub hi: u64,
     pub lo: u64,
+}
+
+impl fmt::Display for FlowRuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:016x}-{:016x}", self.hi, self.lo)
+    }
 }
 
 /// Field identifiers matching the backend's infmon_field_type

--- a/src/infmon-ipc/src/types.rs
+++ b/src/infmon-ipc/src/types.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::net::IpAddr;
+use std::str::FromStr;
 
 /// Identifies a flow rule (128-bit UUID from the backend)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -11,6 +12,22 @@ pub struct FlowRuleId {
 impl fmt::Display for FlowRuleId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:016x}-{:016x}", self.hi, self.lo)
+    }
+}
+
+impl FromStr for FlowRuleId {
+    type Err = String;
+
+    /// Parse a `FlowRuleId` from a "{hi:016x}-{lo:016x}" string.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (hi_str, lo_str) = s
+            .split_once('-')
+            .ok_or_else(|| format!("invalid FlowRuleId: missing '-' in '{s}'"))?;
+        let hi =
+            u64::from_str_radix(hi_str, 16).map_err(|e| format!("invalid FlowRuleId hi: {e}"))?;
+        let lo =
+            u64::from_str_radix(lo_str, 16).map_err(|e| format!("invalid FlowRuleId lo: {e}"))?;
+        Ok(Self { hi, lo })
     }
 }
 
@@ -60,13 +77,40 @@ pub struct FlowRuleCounters {
     pub bytes: u64,
 }
 
-/// Stats for one flow rule in a snapshot
+/// Stats for one flow rule in a snapshot.
+///
+/// Uses owned `String`/`Vec` for simplicity. If profiling shows allocation
+/// overhead from repeated snapshots, consider `Arc<str>`/`Arc<[FieldId]>` for
+/// metadata that stays constant across ticks.
 #[derive(Debug, Clone)]
 pub struct FlowRuleStats {
     pub name: String,
     pub fields: Vec<FieldId>,
     pub flows: Vec<FlowStats>,
     pub counters: FlowRuleCounters,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flow_rule_id_display_parse_roundtrip() {
+        let id = FlowRuleId {
+            hi: 0x0123456789abcdef,
+            lo: 0xfedcba9876543210,
+        };
+        let s = id.to_string();
+        assert_eq!(s, "0123456789abcdef-fedcba9876543210");
+        let parsed: FlowRuleId = s.parse().unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn flow_rule_id_parse_invalid() {
+        assert!("not-a-valid-id".parse::<FlowRuleId>().is_err());
+        assert!("nodashatall".parse::<FlowRuleId>().is_err());
+    }
 }
 
 /// One tick's worth of snapshot data

--- a/src/infmon-ipc/src/types.rs
+++ b/src/infmon-ipc/src/types.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::net::IpAddr;
-use std::sync::Arc;
 
 /// Identifies a flow rule (128-bit UUID from the backend)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -39,7 +38,9 @@ pub enum FieldValue {
 pub struct FlowCounters {
     pub packets: u64,
     pub bytes: u64,
+    /// Monotonic nanoseconds (same clock as `FlowStatsSnapshot::monotonic_ns`)
     pub first_seen_ns: u64,
+    /// Monotonic nanoseconds (same clock as `FlowStatsSnapshot::monotonic_ns`)
     pub last_seen_ns: u64,
 }
 
@@ -62,8 +63,8 @@ pub struct FlowRuleCounters {
 /// Stats for one flow rule in a snapshot
 #[derive(Debug, Clone)]
 pub struct FlowRuleStats {
-    pub name: Arc<str>,
-    pub fields: Arc<[FieldId]>,
+    pub name: String,
+    pub fields: Vec<FieldId>,
     pub flows: Vec<FlowStats>,
     pub counters: FlowRuleCounters,
 }


### PR DESCRIPTION
## Summary

Add the `infmon-ipc` crate providing shared IPC clients for the frontend and CLI to communicate with the VPP backend.

### What's included

- **InFMonStatsClient**: Stats segment mmap reader with flock-based single-reader enforcement
- **InFMonControlClient**: UDS transport stubs for VPP binary API control RPCs (flow_rule_add/rm/list/show, reload, exporter_list)
- **Shared data types**: FlowStatsSnapshot, FlowRuleStats, FlowStats, FlowCounters, FieldValue, FieldId, FlowRuleId
- **Key decoder**: Decodes raw key bytes into typed FieldValues (IPv4/IPv6, protocol, DSCP) with IPv4-mapped IPv6 support
- **Error types**: IpcError and CtlError with thiserror

### Tests

- 7 unit tests covering lock enforcement, snapshot stubs, key decoding (IPv4-mapped, IPv6, multi-field, error cases), and control client connection errors

Closes #50