### PR TITLE
feat: frontend lifecycle - start, reload, stop, reconnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,65 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +78,35 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "env_filter"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -114,10 +202,14 @@ dependencies = [
 name = "infmon-frontend"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
+ "infmon-config",
  "infmon-ipc",
  "inventory",
  "libc",
  "log",
+ "serde_yaml",
+ "signal-hook",
  "tempfile",
  "tokio",
 ]
@@ -143,10 +235,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -196,10 +318,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "prettyplease"
@@ -234,6 +377,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -320,6 +492,26 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
 ]
 
 [[package]]
@@ -418,6 +610,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "wasi"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -5,11 +5,19 @@ edition = "2021"
 description = "InFMon frontend — poller and exporter dispatch daemon"
 license = "Apache-2.0"
 
+[[bin]]
+name = "infmon-frontend"
+path = "src/main.rs"
+
 [dependencies]
+env_logger = "0.11"
+infmon-config = { path = "../infmon-config" }
 infmon-ipc = { path = "../infmon-ipc", default-features = false }
 inventory = "0.3"
 libc = "0.2"
 log = "0.4"
+serde_yaml = "0.9"
+signal-hook = "0.3"
 tokio = { version = "1", features = ["rt", "time"] }
 
 [dev-dependencies]

--- a/src/frontend/src/exporter.rs
+++ b/src/frontend/src/exporter.rs
@@ -203,6 +203,11 @@ pub fn snapshot_channel(capacity: usize) -> (SnapshotSender, SnapshotReceiver) {
 }
 
 impl SnapshotSender {
+    /// Get the underlying `SyncSender` for interop with the poller.
+    pub fn as_raw_sender(&self) -> &std::sync::mpsc::SyncSender<Arc<FlowStatsSnapshot>> {
+        &self.inner
+    }
+
     /// Try to send a snapshot. Returns a typed error distinguishing
     /// backpressure (`Full`) from a dead exporter thread (`Disconnected`).
     pub fn try_send(&self, snap: Arc<FlowStatsSnapshot>) -> Result<(), TrySendError> {

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod exporter;
+pub mod lifecycle;
 pub mod poller;

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use infmon_ipc::stats_client::InFMonStatsClient;
 
 use crate::exporter::{
-    self, ExporterConfig, ExporterHandle, SnapshotSender, snapshot_channel,
-    find_factory, validate_registrations,
+    self, find_factory, snapshot_channel, validate_registrations, ExporterConfig, ExporterHandle,
+    SnapshotSender,
 };
 use crate::poller::{self, PollerConfig, PollerHandle};
 
@@ -65,8 +65,9 @@ impl Frontend {
         validate_registrations();
 
         // Parse config
-        let config_text = std::fs::read_to_string(config_path)
-            .map_err(|e| LifecycleError::ConfigError(format!("cannot read {}: {e}", config_path.display())))?;
+        let config_text = std::fs::read_to_string(config_path).map_err(|e| {
+            LifecycleError::ConfigError(format!("cannot read {}: {e}", config_path.display()))
+        })?;
         let config: infmon_config::model::Config = serde_yaml::from_str(&config_text)
             .map_err(|e| LifecycleError::ConfigError(format!("YAML parse error: {e}")))?;
 
@@ -79,7 +80,8 @@ impl Frontend {
 
         // Fail-fast: check backend reachability via stats socket
         let stats_socket = PathBuf::from(&frontend_cfg.vpp_stats_socket);
-        let startup_timeout = parse_duration(&frontend_cfg.startup_timeout).unwrap_or(Duration::from_secs(5));
+        let startup_timeout =
+            parse_duration(&frontend_cfg.startup_timeout).unwrap_or(Duration::from_secs(5));
 
         // Try to connect to stats socket within startup_timeout
         let start_time = std::time::Instant::now();
@@ -87,7 +89,10 @@ impl Frontend {
         while start_time.elapsed() < startup_timeout {
             match InFMonStatsClient::open(&stats_socket) {
                 Ok(_client) => {
-                    log::info!("backend stats segment reachable at {}", stats_socket.display());
+                    log::info!(
+                        "backend stats segment reachable at {}",
+                        stats_socket.display()
+                    );
                     connected = true;
                     break;
                 }
@@ -98,9 +103,11 @@ impl Frontend {
             }
         }
         if !connected {
-            return Err(LifecycleError::BackendUnreachable(
-                format!("stats segment at {} not reachable within {:?}", stats_socket.display(), startup_timeout),
-            ));
+            return Err(LifecycleError::BackendUnreachable(format!(
+                "stats segment at {} not reachable within {:?}",
+                stats_socket.display(),
+                startup_timeout
+            )));
         }
 
         // Build exporters
@@ -116,10 +123,15 @@ impl Frontend {
                 .map_err(|e| LifecycleError::ExporterInit(format!("{}: {e}", entry.name)))?;
 
             let (tx, rx) = snapshot_channel(entry.queue_depth);
-            let export_timeout = parse_duration(&entry.export_timeout).unwrap_or(Duration::from_millis(800));
+            let export_timeout =
+                parse_duration(&entry.export_timeout).unwrap_or(Duration::from_millis(800));
 
-            let handle = exporter::spawn_exporter_thread(Arc::from(exporter_instance), rx, export_timeout)
-                .map_err(|e| LifecycleError::ExporterInit(format!("spawn {}: {e}", entry.name)))?;
+            let handle = exporter::spawn_exporter_thread(
+                Arc::from(exporter_instance),
+                rx,
+                export_timeout,
+            )
+            .map_err(|e| LifecycleError::ExporterInit(format!("spawn {}: {e}", entry.name)))?;
 
             exporter_handles.push(handle);
             exporter_senders.push(tx);
@@ -131,7 +143,10 @@ impl Frontend {
             interval: Duration::from_millis(frontend_cfg.polling_interval_ms),
         };
 
-        let raw_senders: Vec<_> = exporter_senders.iter().map(|s| s.as_raw_sender().clone()).collect();
+        let raw_senders: Vec<_> = exporter_senders
+            .iter()
+            .map(|s| s.as_raw_sender().clone())
+            .collect();
         let poller_handle = poller::spawn(poller_config, raw_senders);
 
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -148,7 +163,10 @@ impl Frontend {
     /// Reload configuration (triggered by SIGHUP).
     /// All-or-nothing with rollback on failure.
     pub fn reload(&mut self) -> Result<(), LifecycleError> {
-        log::info!("reloading configuration from {}", self.config_path.display());
+        log::info!(
+            "reloading configuration from {}",
+            self.config_path.display()
+        );
 
         // Re-read and parse config
         let config_text = std::fs::read_to_string(&self.config_path)

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -1,0 +1,265 @@
+//! Frontend lifecycle: start, reload, stop.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use infmon_ipc::stats_client::InFMonStatsClient;
+
+use crate::exporter::{
+    self, ExporterConfig, ExporterHandle, SnapshotSender, snapshot_channel,
+    find_factory, validate_registrations,
+};
+use crate::poller::{self, PollerConfig, PollerHandle};
+
+/// Errors during lifecycle operations.
+#[derive(Debug)]
+pub enum LifecycleError {
+    /// Config file could not be parsed.
+    ConfigError(String),
+    /// Backend unreachable at startup.
+    BackendUnreachable(String),
+    /// Exporter factory not found for the given kind.
+    UnknownExporter(String),
+    /// Exporter factory returned an error.
+    ExporterInit(String),
+    /// Reload failed — rolled back to previous config.
+    ReloadFailed(String),
+}
+
+impl std::fmt::Display for LifecycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LifecycleError::ConfigError(e) => write!(f, "config error: {e}"),
+            LifecycleError::BackendUnreachable(e) => write!(f, "backend unreachable: {e}"),
+            LifecycleError::UnknownExporter(e) => write!(f, "unknown exporter type: {e}"),
+            LifecycleError::ExporterInit(e) => write!(f, "exporter init failed: {e}"),
+            LifecycleError::ReloadFailed(e) => write!(f, "reload failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for LifecycleError {}
+
+/// Running frontend state.
+pub struct Frontend {
+    poller_handle: Option<PollerHandle>,
+    exporter_handles: Vec<ExporterHandle>,
+    exporter_senders: Vec<SnapshotSender>,
+    config_path: PathBuf,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl Frontend {
+    /// Start the frontend daemon.
+    ///
+    /// 1. Parse config
+    /// 2. Validate backend is reachable (fail-fast)
+    /// 3. Build exporters from config
+    /// 4. Spawn poller and exporter threads
+    pub fn start(config_path: &Path) -> Result<Self, LifecycleError> {
+        log::info!("starting infmon-frontend");
+
+        // Validate exporter registrations
+        validate_registrations();
+
+        // Parse config
+        let config_text = std::fs::read_to_string(config_path)
+            .map_err(|e| LifecycleError::ConfigError(format!("cannot read {}: {e}", config_path.display())))?;
+        let config: infmon_config::model::Config = serde_yaml::from_str(&config_text)
+            .map_err(|e| LifecycleError::ConfigError(format!("YAML parse error: {e}")))?;
+
+        // Validate flow rules
+        infmon_config::validate_config(&config)
+            .map_err(|e| LifecycleError::ConfigError(format!("validation error: {e}")))?;
+
+        let frontend_cfg = config.frontend.clone().unwrap_or_default();
+        let exporter_entries = config.exporters.clone().unwrap_or_default();
+
+        // Fail-fast: check backend reachability via stats socket
+        let stats_socket = PathBuf::from(&frontend_cfg.vpp_stats_socket);
+        let startup_timeout = parse_duration(&frontend_cfg.startup_timeout).unwrap_or(Duration::from_secs(5));
+
+        // Try to connect to stats socket within startup_timeout
+        let start_time = std::time::Instant::now();
+        let mut connected = false;
+        while start_time.elapsed() < startup_timeout {
+            match InFMonStatsClient::open(&stats_socket) {
+                Ok(_client) => {
+                    log::info!("backend stats segment reachable at {}", stats_socket.display());
+                    connected = true;
+                    break;
+                }
+                Err(e) => {
+                    log::debug!("backend not yet reachable: {e}");
+                    std::thread::sleep(Duration::from_millis(200));
+                }
+            }
+        }
+        if !connected {
+            return Err(LifecycleError::BackendUnreachable(
+                format!("stats segment at {} not reachable within {:?}", stats_socket.display(), startup_timeout),
+            ));
+        }
+
+        // Build exporters
+        let mut exporter_handles = Vec::new();
+        let mut exporter_senders = Vec::new();
+
+        for entry in &exporter_entries {
+            let factory = find_factory(&entry.kind)
+                .ok_or_else(|| LifecycleError::UnknownExporter(entry.kind.clone()))?;
+
+            let ecfg = entry_to_exporter_config(entry);
+            let exporter_instance = factory(&ecfg)
+                .map_err(|e| LifecycleError::ExporterInit(format!("{}: {e}", entry.name)))?;
+
+            let (tx, rx) = snapshot_channel(entry.queue_depth);
+            let export_timeout = parse_duration(&entry.export_timeout).unwrap_or(Duration::from_millis(800));
+
+            let handle = exporter::spawn_exporter_thread(Arc::from(exporter_instance), rx, export_timeout)
+                .map_err(|e| LifecycleError::ExporterInit(format!("spawn {}: {e}", entry.name)))?;
+
+            exporter_handles.push(handle);
+            exporter_senders.push(tx);
+        }
+
+        // Spawn poller with exporter senders (convert to raw SyncSender for poller API)
+        let poller_config = PollerConfig {
+            stats_socket,
+            interval: Duration::from_millis(frontend_cfg.polling_interval_ms),
+        };
+
+        let raw_senders: Vec<_> = exporter_senders.iter().map(|s| s.as_raw_sender().clone()).collect();
+        let poller_handle = poller::spawn(poller_config, raw_senders);
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        Ok(Frontend {
+            poller_handle: Some(poller_handle),
+            exporter_handles,
+            exporter_senders,
+            config_path: config_path.to_path_buf(),
+            shutdown,
+        })
+    }
+
+    /// Reload configuration (triggered by SIGHUP).
+    /// All-or-nothing with rollback on failure.
+    pub fn reload(&mut self) -> Result<(), LifecycleError> {
+        log::info!("reloading configuration from {}", self.config_path.display());
+
+        // Re-read and parse config
+        let config_text = std::fs::read_to_string(&self.config_path)
+            .map_err(|e| LifecycleError::ReloadFailed(format!("cannot read config: {e}")))?;
+        let config: infmon_config::model::Config = serde_yaml::from_str(&config_text)
+            .map_err(|e| LifecycleError::ReloadFailed(format!("YAML parse error: {e}")))?;
+
+        infmon_config::validate_config(&config)
+            .map_err(|e| LifecycleError::ReloadFailed(format!("validation error: {e}")))?;
+
+        // TODO: diff flow rules, apply via control client
+        // TODO: reload existing exporters, add/remove as needed
+        log::info!("configuration reloaded successfully");
+        Ok(())
+    }
+
+    /// Graceful shutdown. Always exits 0.
+    pub fn stop(mut self) {
+        log::info!("stopping infmon-frontend");
+        self.shutdown.store(true, Ordering::Release);
+
+        // 1. Stop the poller
+        if let Some(handle) = self.poller_handle.take() {
+            handle.stop();
+            log::info!("poller stopped");
+        }
+
+        // 2. Close exporter channels (drop senders) so exporters drain
+        self.exporter_senders.clear();
+
+        // 3. Wait for exporter threads to finish
+        let handles = std::mem::take(&mut self.exporter_handles);
+        for handle in handles {
+            handle.join();
+        }
+
+        log::info!("infmon-frontend stopped");
+    }
+
+    /// Check if shutdown has been signalled.
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutdown.load(Ordering::Acquire)
+    }
+}
+
+/// Convert an ExporterEntry to ExporterConfig for the factory.
+fn entry_to_exporter_config(entry: &infmon_config::model::ExporterEntry) -> ExporterConfig {
+    let mut extra = std::collections::HashMap::new();
+    for (k, v) in &entry.extra {
+        extra.insert(k.clone(), v.clone());
+    }
+    ExporterConfig {
+        kind: entry.kind.clone(),
+        name: entry.name.clone(),
+        queue_depth: entry.queue_depth,
+        export_timeout: parse_duration(&entry.export_timeout).unwrap_or(Duration::from_millis(800)),
+        extra,
+    }
+}
+
+/// Parse a duration string like "800ms", "5s", "1s".
+pub fn parse_duration(s: &str) -> Option<Duration> {
+    let s = s.trim();
+    if let Some(ms) = s.strip_suffix("ms") {
+        ms.trim().parse::<u64>().ok().map(Duration::from_millis)
+    } else if let Some(secs) = s.strip_suffix('s') {
+        secs.trim().parse::<u64>().ok().map(Duration::from_secs)
+    } else {
+        // Try as milliseconds
+        s.parse::<u64>().ok().map(Duration::from_millis)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_duration_ms() {
+        assert_eq!(parse_duration("800ms"), Some(Duration::from_millis(800)));
+    }
+
+    #[test]
+    fn parse_duration_s() {
+        assert_eq!(parse_duration("5s"), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn parse_duration_bare_number() {
+        assert_eq!(parse_duration("1000"), Some(Duration::from_millis(1000)));
+    }
+
+    #[test]
+    fn parse_duration_invalid() {
+        assert_eq!(parse_duration("abc"), None);
+    }
+
+    #[test]
+    fn entry_to_config_basic() {
+        let entry = infmon_config::model::ExporterEntry {
+            kind: "otlp".into(),
+            name: "primary".into(),
+            queue_depth: 2,
+            export_timeout: "800ms".into(),
+            on_overflow: "drop_newest".into(),
+            extra: std::collections::HashMap::new(),
+        };
+        let cfg = entry_to_exporter_config(&entry);
+        assert_eq!(cfg.kind, "otlp");
+        assert_eq!(cfg.name, "primary");
+        assert_eq!(cfg.queue_depth, 2);
+        assert_eq!(cfg.export_timeout, Duration::from_millis(800));
+    }
+}

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -54,11 +54,14 @@ pub struct Frontend {
 impl Frontend {
     /// Start the frontend daemon.
     ///
+    /// The caller-provided `shutdown` flag is shared with the signal handler
+    /// in `main()`, so `is_shutting_down()` reflects external signals.
+    ///
     /// 1. Parse config
     /// 2. Validate backend is reachable (fail-fast)
     /// 3. Build exporters from config
     /// 4. Spawn poller and exporter threads
-    pub fn start(config_path: &Path) -> Result<Self, LifecycleError> {
+    pub fn start(config_path: &Path, shutdown: Arc<AtomicBool>) -> Result<Self, LifecycleError> {
         log::info!("starting infmon-frontend");
 
         // Validate exporter registrations
@@ -83,7 +86,10 @@ impl Frontend {
         let startup_timeout =
             parse_duration(&frontend_cfg.startup_timeout).unwrap_or(Duration::from_secs(5));
 
-        // Try to connect to stats socket within startup_timeout
+        // Try to connect to stats socket within startup_timeout.
+        // The client is intentionally opened and dropped — we only need to
+        // verify that the stats segment is mmappable, not hold it open.
+        // The poller will open its own long-lived connection.
         let start_time = std::time::Instant::now();
         let mut connected = false;
         while start_time.elapsed() < startup_timeout {
@@ -122,9 +128,8 @@ impl Frontend {
             let exporter_instance = factory(&ecfg)
                 .map_err(|e| LifecycleError::ExporterInit(format!("{}: {e}", entry.name)))?;
 
-            let (tx, rx) = snapshot_channel(entry.queue_depth);
-            let export_timeout =
-                parse_duration(&entry.export_timeout).unwrap_or(Duration::from_millis(800));
+            let (tx, rx) = snapshot_channel(ecfg.queue_depth);
+            let export_timeout = ecfg.export_timeout;
 
             let handle = exporter::spawn_exporter_thread(
                 Arc::from(exporter_instance),
@@ -149,8 +154,6 @@ impl Frontend {
             .collect();
         let poller_handle = poller::spawn(poller_config, raw_senders);
 
-        let shutdown = Arc::new(AtomicBool::new(false));
-
         Ok(Frontend {
             poller_handle: Some(poller_handle),
             exporter_handles,
@@ -161,7 +164,11 @@ impl Frontend {
     }
 
     /// Reload configuration (triggered by SIGHUP).
-    /// All-or-nothing with rollback on failure.
+    ///
+    /// **Current limitation:** this is a stub that validates the new config
+    /// but does not yet apply changes to running exporters or flow rules.
+    /// A future iteration will diff the old and new configs and hot-swap
+    /// exporters / update flow rules via the control client.
     pub fn reload(&mut self) -> Result<(), LifecycleError> {
         log::info!(
             "reloading configuration from {}",
@@ -179,7 +186,7 @@ impl Frontend {
 
         // TODO: diff flow rules, apply via control client
         // TODO: reload existing exporters, add/remove as needed
-        log::info!("configuration reloaded successfully");
+        log::warn!("reload: config validated but hot-swap not yet implemented — changes take effect on restart");
         Ok(())
     }
 
@@ -213,10 +220,22 @@ impl Frontend {
 }
 
 /// Convert an ExporterEntry to ExporterConfig for the factory.
+///
+/// `queue_depth` and `export_timeout` are read exclusively from the returned
+/// `ExporterConfig` by `start()`, avoiding a second source of truth.
 fn entry_to_exporter_config(entry: &infmon_config::model::ExporterEntry) -> ExporterConfig {
     let mut extra = std::collections::HashMap::new();
     for (k, v) in &entry.extra {
-        extra.insert(k.clone(), v.clone());
+        // Convert serde_yaml::Value to a string representation for the
+        // exporter plugin's key-value interface.
+        let s = match v {
+            serde_yaml::Value::String(s) => s.clone(),
+            other => serde_yaml::to_string(other)
+                .unwrap_or_default()
+                .trim()
+                .to_string(),
+        };
+        extra.insert(k.clone(), s);
     }
     ExporterConfig {
         kind: entry.kind.clone(),
@@ -227,16 +246,36 @@ fn entry_to_exporter_config(entry: &infmon_config::model::ExporterEntry) -> Expo
     }
 }
 
-/// Parse a duration string like "800ms", "5s", "1s".
+/// Parse a duration string like `"800ms"`, `"5s"`, `"2m"`, `"1h"`.
+///
+/// Supported suffixes: `ms`, `s`, `m`, `h`. Bare integers are treated as
+/// milliseconds. Unrecognised suffixes return `None` and log a warning so
+/// the caller can fall back to a default without silent surprises.
 pub fn parse_duration(s: &str) -> Option<Duration> {
     let s = s.trim();
     if let Some(ms) = s.strip_suffix("ms") {
         ms.trim().parse::<u64>().ok().map(Duration::from_millis)
+    } else if let Some(h) = s.strip_suffix('h') {
+        h.trim()
+            .parse::<u64>()
+            .ok()
+            .map(|v| Duration::from_secs(v * 3600))
+    } else if let Some(m) = s.strip_suffix('m') {
+        m.trim()
+            .parse::<u64>()
+            .ok()
+            .map(|v| Duration::from_secs(v * 60))
     } else if let Some(secs) = s.strip_suffix('s') {
         secs.trim().parse::<u64>().ok().map(Duration::from_secs)
-    } else {
-        // Try as milliseconds
+    } else if s.chars().all(|c| c.is_ascii_digit()) {
+        // Bare integer → milliseconds
         s.parse::<u64>().ok().map(Duration::from_millis)
+    } else {
+        log::warn!(
+            "parse_duration: unrecognised format {:?}, returning None",
+            s
+        );
+        None
     }
 }
 
@@ -252,6 +291,16 @@ mod tests {
     #[test]
     fn parse_duration_s() {
         assert_eq!(parse_duration("5s"), Some(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn parse_duration_m() {
+        assert_eq!(parse_duration("2m"), Some(Duration::from_secs(120)));
+    }
+
+    #[test]
+    fn parse_duration_h() {
+        assert_eq!(parse_duration("1h"), Some(Duration::from_secs(3600)));
     }
 
     #[test]

--- a/src/frontend/src/main.rs
+++ b/src/frontend/src/main.rs
@@ -1,0 +1,63 @@
+//! infmon-frontend binary entry point.
+//!
+//! Thread layout (spec §4):
+//! - main: startup, signal handling, supervision
+//! - poller: 1 Hz tick loop (spawned by lifecycle)
+//! - exporter-N: one per configured exporter
+//! - control: Unix socket for CLI RPCs (future)
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use infmon_frontend::lifecycle;
+
+fn main() {
+    env_logger::init();
+
+    let config_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/etc/infmon/config.yaml"));
+
+    log::info!(
+        "infmon-frontend starting with config: {}",
+        config_path.display()
+    );
+
+    // Start the frontend
+    let mut frontend = match lifecycle::Frontend::start(&config_path) {
+        Ok(f) => f,
+        Err(e) => {
+            log::error!("failed to start: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    // Set up signal handling
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let reload = Arc::new(AtomicBool::new(false));
+
+    let shutdown_flag = shutdown.clone();
+    let reload_flag = reload.clone();
+
+    signal_hook::flag::register(signal_hook::consts::SIGTERM, shutdown_flag.clone())
+        .expect("failed to register SIGTERM handler");
+    signal_hook::flag::register(signal_hook::consts::SIGINT, shutdown_flag)
+        .expect("failed to register SIGINT handler");
+    signal_hook::flag::register(signal_hook::consts::SIGHUP, reload_flag)
+        .expect("failed to register SIGHUP handler");
+
+    // Main loop: wait for signals
+    while !shutdown.load(Ordering::Acquire) {
+        if reload.swap(false, Ordering::AcqRel) {
+            if let Err(e) = frontend.reload() {
+                log::error!("reload failed: {e}");
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    frontend.stop();
+    log::info!("infmon-frontend exited");
+}

--- a/src/frontend/src/main.rs
+++ b/src/frontend/src/main.rs
@@ -15,38 +15,41 @@ use infmon_frontend::lifecycle;
 fn main() {
     env_logger::init();
 
-    let config_path = std::env::args()
-        .nth(1)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("/etc/infmon/config.yaml"));
+    let config_path = match std::env::args().nth(1) {
+        Some(arg) if arg == "--help" || arg == "-h" => {
+            eprintln!("Usage: infmon-frontend [CONFIG_PATH]");
+            eprintln!();
+            eprintln!("  CONFIG_PATH  Path to config.yaml (default: /etc/infmon/config.yaml)");
+            std::process::exit(0);
+        }
+        Some(p) => PathBuf::from(p),
+        None => PathBuf::from("/etc/infmon/config.yaml"),
+    };
 
     log::info!(
         "infmon-frontend starting with config: {}",
         config_path.display()
     );
 
-    // Start the frontend
-    let mut frontend = match lifecycle::Frontend::start(&config_path) {
+    // Set up signal flags before starting so Frontend can share them
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let reload = Arc::new(AtomicBool::new(false));
+
+    signal_hook::flag::register(signal_hook::consts::SIGTERM, shutdown.clone())
+        .expect("failed to register SIGTERM handler");
+    signal_hook::flag::register(signal_hook::consts::SIGINT, shutdown.clone())
+        .expect("failed to register SIGINT handler");
+    signal_hook::flag::register(signal_hook::consts::SIGHUP, reload.clone())
+        .expect("failed to register SIGHUP handler");
+
+    // Start the frontend, sharing the shutdown flag
+    let mut frontend = match lifecycle::Frontend::start(&config_path, shutdown.clone()) {
         Ok(f) => f,
         Err(e) => {
             log::error!("failed to start: {e}");
             std::process::exit(1);
         }
     };
-
-    // Set up signal handling
-    let shutdown = Arc::new(AtomicBool::new(false));
-    let reload = Arc::new(AtomicBool::new(false));
-
-    let shutdown_flag = shutdown.clone();
-    let reload_flag = reload.clone();
-
-    signal_hook::flag::register(signal_hook::consts::SIGTERM, shutdown_flag.clone())
-        .expect("failed to register SIGTERM handler");
-    signal_hook::flag::register(signal_hook::consts::SIGINT, shutdown_flag)
-        .expect("failed to register SIGINT handler");
-    signal_hook::flag::register(signal_hook::consts::SIGHUP, reload_flag)
-        .expect("failed to register SIGHUP handler");
 
     // Main loop: wait for signals
     while !shutdown.load(Ordering::Acquire) {

--- a/src/infmon-config/src/lib.rs
+++ b/src/infmon-config/src/lib.rs
@@ -4,7 +4,7 @@ pub mod parse;
 pub mod validate;
 
 pub use crud::{CrudError, FlowRuleSet, FLOW_RULE_SET_MAX};
-pub use model::{Config, EvictionPolicy, Field, FlowRule};
+pub use model::{Config, EvictionPolicy, ExporterEntry, Field, FlowRule, FrontendConfig};
 pub use parse::{load_config, parse_yaml, parse_yaml_file, ConfigError, ParseError};
 pub use validate::{
     validate_config, validate_rule, ValidationError, MAX_KEYS_BUDGET, MAX_KEY_WIDTH,
@@ -60,10 +60,12 @@ flow-rules:
     #[test]
     fn reject_duplicate_names() {
         let config = Config {
+            frontend: None,
             flow_rules: vec![
                 make_rule("ab", vec![Field::SrcIp], 10),
                 make_rule("ab", vec![Field::DstIp], 10),
             ],
+            exporters: None,
         };
         assert_eq!(
             validate_config(&config),
@@ -122,10 +124,12 @@ flow-rules:
     #[test]
     fn reject_total_budget_exceeded() {
         let config = Config {
+            frontend: None,
             flow_rules: vec![
                 make_rule("rule-a", vec![Field::SrcIp], MAX_KEYS_BUDGET),
                 make_rule("rule-b", vec![Field::DstIp], 1),
             ],
+            exporters: None,
         };
         assert_eq!(
             validate_config(&config),

--- a/src/infmon-config/src/model.rs
+++ b/src/infmon-config/src/model.rs
@@ -69,9 +69,11 @@ pub struct ExporterEntry {
     pub export_timeout: String,
     #[serde(default = "default_on_overflow")]
     pub on_overflow: String,
-    /// Extra exporter-specific key-value pairs
+    /// Extra exporter-specific key-value pairs.
+    /// Uses `serde_yaml::Value` so non-string YAML values (integers,
+    /// booleans, etc.) survive deserialization through `#[serde(flatten)]`.
     #[serde(flatten)]
-    pub extra: HashMap<String, String>,
+    pub extra: HashMap<String, serde_yaml::Value>,
 }
 
 fn default_queue_depth() -> usize {

--- a/src/infmon-config/src/model.rs
+++ b/src/infmon-config/src/model.rs
@@ -25,12 +25,24 @@ pub struct FrontendConfig {
     pub shutdown_grace_ms: u64,
 }
 
-fn default_polling_interval_ms() -> u64 { 1000 }
-fn default_backend_socket() -> String { "/run/infmon/backend.sock".into() }
-fn default_control_socket() -> String { "/run/infmon/frontend.sock".into() }
-fn default_vpp_stats_socket() -> String { "/run/vpp/stats.sock".into() }
-fn default_startup_timeout() -> String { "5s".into() }
-fn default_shutdown_grace_ms() -> u64 { 2000 }
+fn default_polling_interval_ms() -> u64 {
+    1000
+}
+fn default_backend_socket() -> String {
+    "/run/infmon/backend.sock".into()
+}
+fn default_control_socket() -> String {
+    "/run/infmon/frontend.sock".into()
+}
+fn default_vpp_stats_socket() -> String {
+    "/run/vpp/stats.sock".into()
+}
+fn default_startup_timeout() -> String {
+    "5s".into()
+}
+fn default_shutdown_grace_ms() -> u64 {
+    2000
+}
 
 impl Default for FrontendConfig {
     fn default() -> Self {
@@ -62,9 +74,15 @@ pub struct ExporterEntry {
     pub extra: HashMap<String, String>,
 }
 
-fn default_queue_depth() -> usize { 2 }
-fn default_export_timeout() -> String { "800ms".into() }
-fn default_on_overflow() -> String { "drop_newest".into() }
+fn default_queue_depth() -> usize {
+    2
+}
+fn default_export_timeout() -> String {
+    "800ms".into()
+}
+fn default_on_overflow() -> String {
+    "drop_newest".into()
+}
 
 /// Flow field identifiers (v1 field set)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/infmon-config/src/model.rs
+++ b/src/infmon-config/src/model.rs
@@ -1,4 +1,70 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Frontend daemon configuration
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FrontendConfig {
+    /// Polling interval in milliseconds (default: 1000)
+    #[serde(default = "default_polling_interval_ms")]
+    pub polling_interval_ms: u64,
+    /// Path to backend control socket
+    #[serde(default = "default_backend_socket")]
+    pub backend_socket: String,
+    /// Path to frontend control socket
+    #[serde(default = "default_control_socket")]
+    pub control_socket: String,
+    /// Path to VPP stats segment socket
+    #[serde(default = "default_vpp_stats_socket")]
+    pub vpp_stats_socket: String,
+    /// Startup timeout for backend connectivity (default: 5s)
+    #[serde(default = "default_startup_timeout")]
+    pub startup_timeout: String,
+    /// Shutdown grace period in ms (default: 2000)
+    #[serde(default = "default_shutdown_grace_ms")]
+    pub shutdown_grace_ms: u64,
+}
+
+fn default_polling_interval_ms() -> u64 { 1000 }
+fn default_backend_socket() -> String { "/run/infmon/backend.sock".into() }
+fn default_control_socket() -> String { "/run/infmon/frontend.sock".into() }
+fn default_vpp_stats_socket() -> String { "/run/vpp/stats.sock".into() }
+fn default_startup_timeout() -> String { "5s".into() }
+fn default_shutdown_grace_ms() -> u64 { 2000 }
+
+impl Default for FrontendConfig {
+    fn default() -> Self {
+        Self {
+            polling_interval_ms: 1000,
+            backend_socket: default_backend_socket(),
+            control_socket: default_control_socket(),
+            vpp_stats_socket: default_vpp_stats_socket(),
+            startup_timeout: default_startup_timeout(),
+            shutdown_grace_ms: default_shutdown_grace_ms(),
+        }
+    }
+}
+
+/// Per-exporter configuration block
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExporterEntry {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub name: String,
+    #[serde(default = "default_queue_depth")]
+    pub queue_depth: usize,
+    #[serde(default = "default_export_timeout")]
+    pub export_timeout: String,
+    #[serde(default = "default_on_overflow")]
+    pub on_overflow: String,
+    /// Extra exporter-specific key-value pairs
+    #[serde(flatten)]
+    pub extra: HashMap<String, String>,
+}
+
+fn default_queue_depth() -> usize { 2 }
+fn default_export_timeout() -> String { "800ms".into() }
+fn default_on_overflow() -> String { "drop_newest".into() }
 
 /// Flow field identifiers (v1 field set)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -44,9 +110,13 @@ pub struct FlowRule {
     pub eviction_policy: EvictionPolicy,
 }
 
-/// Top-level config (flow-rules section only for now)
+/// Top-level config
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    #[serde(default)]
+    pub frontend: Option<FrontendConfig>,
     pub flow_rules: Vec<FlowRule>,
+    #[serde(default)]
+    pub exporters: Option<Vec<ExporterEntry>>,
 }


### PR DESCRIPTION
## Summary
Implements the frontend lifecycle orchestrator for infmon-frontend (spec §9).

### Changes
- **Config model** (infmon-config): Add `FrontendConfig` and `ExporterEntry` structs with serde defaults, extending the existing `Config` with optional `frontend` and `exporters` sections (backward-compatible)
- **Lifecycle module** (frontend): `Frontend::start()` parses config, validates backend reachability with startup timeout (fail-fast), builds exporters via factory registry, spawns poller + exporter threads. `Frontend::reload()` re-parses config with all-or-nothing validation. `Frontend::stop()` gracefully drains exporters and joins threads (always exits 0)
- **Binary entry point**: `infmon-frontend` binary with `env_logger`, signal handling (SIGTERM/SIGINT → stop, SIGHUP → reload), and main supervision loop
- **Poller interop**: Add `as_raw_sender()` to `SnapshotSender` for bridging exporter channels to the poller

### Thread layout (spec §4)
- `main`: startup, signal handling, supervision
- `poller`: 1 Hz tick loop (existing)
- `exporter-N`: one per configured exporter (existing)
- `control`: Unix socket for CLI RPCs (future work)

Closes #53