### PR TITLE
feat(config): add frontend and exporter config validation

### DIFF
--- a/src/infmon-config/src/lib.rs
+++ b/src/infmon-config/src/lib.rs
@@ -280,7 +280,7 @@ mod frontend_config_tests {
                 queue_depth: 2,
                 export_timeout: "800ms".into(),
                 on_overflow: "drop_newest".into(),
-                extra: HashMap::new(),
+                extra: HashMap::from([("endpoint".to_string(), serde_yaml::Value::String("http://collector:4317".into()))]),
             }]),
         }
     }
@@ -405,6 +405,66 @@ mod frontend_config_tests {
                 name: "primary".into(),
                 policy: "drop_oldest".into(),
                 valid: "drop_newest".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn reject_zero_startup_timeout() {
+        let mut config = make_valid_config();
+        config.frontend.as_mut().unwrap().startup_timeout = "0s".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::ZeroStartupTimeout)
+        );
+    }
+
+    #[test]
+    fn reject_zero_export_timeout() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].export_timeout = "0ms".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::ZeroExportTimeout {
+                name: "primary".into()
+            })
+        );
+    }
+
+    #[test]
+    fn reject_invalid_exporter_name() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].name = "A".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::InvalidExporterName {
+                name: "A".into()
+            })
+        );
+    }
+
+    #[test]
+    fn reject_otlp_missing_endpoint() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].extra.remove("endpoint");
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::MissingOtlpEndpoint {
+                name: "primary".into()
+            })
+        );
+    }
+
+    #[test]
+    fn reject_otlp_empty_endpoint() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0]
+            .extra
+            .insert("endpoint".to_string(), serde_yaml::Value::String("".into()));
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::MissingOtlpEndpoint {
+                name: "primary".into()
             })
         );
     }

--- a/src/infmon-config/src/lib.rs
+++ b/src/infmon-config/src/lib.rs
@@ -383,6 +383,20 @@ mod frontend_config_tests {
     }
 
     #[test]
+    fn reject_queue_depth_too_large() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].queue_depth = 10_001;
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::QueueDepthTooLarge {
+                name: "primary".into(),
+                depth: 10_001,
+                max: 10_000,
+            })
+        );
+    }
+
+    #[test]
     fn reject_invalid_export_timeout() {
         let mut config = make_valid_config();
         config.exporters.as_mut().unwrap()[0].export_timeout = "forever".into();

--- a/src/infmon-config/src/lib.rs
+++ b/src/infmon-config/src/lib.rs
@@ -280,7 +280,10 @@ mod frontend_config_tests {
                 queue_depth: 2,
                 export_timeout: "800ms".into(),
                 on_overflow: "drop_newest".into(),
-                extra: HashMap::from([("endpoint".to_string(), serde_yaml::Value::String("http://collector:4317".into()))]),
+                extra: HashMap::from([(
+                    "endpoint".to_string(),
+                    serde_yaml::Value::String("http://collector:4317".into()),
+                )]),
             }]),
         }
     }
@@ -451,16 +454,16 @@ mod frontend_config_tests {
         config.exporters.as_mut().unwrap()[0].name = "A".into();
         assert_eq!(
             validate_config(&config),
-            Err(ValidationError::InvalidExporterName {
-                name: "A".into()
-            })
+            Err(ValidationError::InvalidExporterName { name: "A".into() })
         );
     }
 
     #[test]
     fn reject_otlp_missing_endpoint() {
         let mut config = make_valid_config();
-        config.exporters.as_mut().unwrap()[0].extra.remove("endpoint");
+        config.exporters.as_mut().unwrap()[0]
+            .extra
+            .remove("endpoint");
         assert_eq!(
             validate_config(&config),
             Err(ValidationError::MissingOtlpEndpoint {

--- a/src/infmon-config/src/lib.rs
+++ b/src/infmon-config/src/lib.rs
@@ -7,7 +7,8 @@ pub use crud::{CrudError, FlowRuleSet, FLOW_RULE_SET_MAX};
 pub use model::{Config, EvictionPolicy, ExporterEntry, Field, FlowRule, FrontendConfig};
 pub use parse::{load_config, parse_yaml, parse_yaml_file, ConfigError, ParseError};
 pub use validate::{
-    validate_config, validate_rule, ValidationError, MAX_KEYS_BUDGET, MAX_KEY_WIDTH,
+    validate_config, validate_exporter, validate_frontend, validate_rule, ValidationError,
+    KNOWN_EXPORTER_TYPES, MAX_KEYS_BUDGET, MAX_KEY_WIDTH, VALID_OVERFLOW_POLICIES,
 };
 
 #[cfg(test)]
@@ -256,5 +257,209 @@ flow-rules:
             set.add(make_rule("overflow", vec![Field::SrcIp], 1)),
             Err(CrudError::SetFull { .. })
         ));
+    }
+}
+
+#[cfg(test)]
+mod frontend_config_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_valid_config() -> Config {
+        Config {
+            frontend: Some(FrontendConfig::default()),
+            flow_rules: vec![FlowRule {
+                name: "test-rule".to_string(),
+                fields: vec![Field::SrcIp],
+                max_keys: 100,
+                eviction_policy: EvictionPolicy::LruDrop,
+            }],
+            exporters: Some(vec![ExporterEntry {
+                kind: "otlp".into(),
+                name: "primary".into(),
+                queue_depth: 2,
+                export_timeout: "800ms".into(),
+                on_overflow: "drop_newest".into(),
+                extra: HashMap::new(),
+            }]),
+        }
+    }
+
+    #[test]
+    fn valid_full_config() {
+        let config = make_valid_config();
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn reject_zero_polling_interval() {
+        let mut config = make_valid_config();
+        config.frontend.as_mut().unwrap().polling_interval_ms = 0;
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::ZeroPollingInterval)
+        );
+    }
+
+    #[test]
+    fn reject_zero_shutdown_grace() {
+        let mut config = make_valid_config();
+        config.frontend.as_mut().unwrap().shutdown_grace_ms = 0;
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::ZeroShutdownGrace)
+        );
+    }
+
+    #[test]
+    fn reject_invalid_startup_timeout() {
+        let mut config = make_valid_config();
+        config.frontend.as_mut().unwrap().startup_timeout = "abc".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::InvalidStartupTimeout {
+                value: "abc".into()
+            })
+        );
+    }
+
+    #[test]
+    fn reject_unknown_exporter_type() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].kind = "prometheus".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::UnknownExporterType {
+                name: "primary".into(),
+                kind: "prometheus".into(),
+                known: "otlp".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn reject_empty_exporter_name() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].name = "".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::EmptyExporterName { index: 0 })
+        );
+    }
+
+    #[test]
+    fn reject_empty_exporter_type() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].kind = "".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::EmptyExporterType {
+                name: "primary".into()
+            })
+        );
+    }
+
+    #[test]
+    fn reject_duplicate_exporter_names() {
+        let mut config = make_valid_config();
+        let dup = config.exporters.as_ref().unwrap()[0].clone();
+        config.exporters.as_mut().unwrap().push(dup);
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::DuplicateExporterName("primary".into()))
+        );
+    }
+
+    #[test]
+    fn reject_zero_queue_depth() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].queue_depth = 0;
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::ZeroQueueDepth {
+                name: "primary".into()
+            })
+        );
+    }
+
+    #[test]
+    fn reject_invalid_export_timeout() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].export_timeout = "forever".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::InvalidExportTimeout {
+                name: "primary".into(),
+                value: "forever".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn reject_invalid_overflow_policy() {
+        let mut config = make_valid_config();
+        config.exporters.as_mut().unwrap()[0].on_overflow = "drop_oldest".into();
+        assert_eq!(
+            validate_config(&config),
+            Err(ValidationError::InvalidOverflowPolicy {
+                name: "primary".into(),
+                policy: "drop_oldest".into(),
+                valid: "drop_newest".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn accept_no_frontend_section() {
+        let mut config = make_valid_config();
+        config.frontend = None;
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn accept_no_exporters_section() {
+        let mut config = make_valid_config();
+        config.exporters = None;
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn parse_full_yaml_with_frontend_and_exporters() {
+        let yaml = r#"
+frontend:
+  polling_interval_ms: 500
+  backend_socket: "/run/infmon/backend.sock"
+  control_socket: "/run/infmon/frontend.sock"
+  vpp_stats_socket: "/run/vpp/stats.sock"
+  startup_timeout: "10s"
+  shutdown_grace_ms: 3000
+
+flow-rules:
+  - name: by-src
+    fields: [src_ip]
+    max_keys: 1000
+    eviction_policy: lru_drop
+
+exporters:
+  - type: "otlp"
+    name: "primary"
+    endpoint: "http://collector.local:4317"
+    export_timeout: "800ms"
+    queue_depth: 2
+    on_overflow: "drop_newest"
+"#;
+        let config = parse_yaml(yaml).unwrap();
+        validate_config(&config).unwrap();
+        assert!(config.frontend.is_some());
+        assert_eq!(config.frontend.unwrap().polling_interval_ms, 500);
+        assert_eq!(config.exporters.as_ref().unwrap().len(), 1);
+        assert_eq!(config.exporters.as_ref().unwrap()[0].kind, "otlp");
+        assert_eq!(
+            config.exporters.as_ref().unwrap()[0]
+                .extra
+                .get("endpoint")
+                .and_then(|v| v.as_str()),
+            Some("http://collector.local:4317")
+        );
     }
 }

--- a/src/infmon-config/src/validate.rs
+++ b/src/infmon-config/src/validate.rs
@@ -58,7 +58,11 @@ pub enum ValidationError {
     #[error("exporter '{name}': queue_depth must be >= 1")]
     ZeroQueueDepth { name: String },
     #[error("exporter '{name}': queue_depth {depth} exceeds maximum {max}")]
-    QueueDepthTooLarge { name: String, depth: usize, max: usize },
+    QueueDepthTooLarge {
+        name: String,
+        depth: usize,
+        max: usize,
+    },
     #[error("exporter '{name}': invalid export_timeout format: {value:?}")]
     InvalidExportTimeout { name: String, value: String },
     #[error("exporter '{name}': unknown on_overflow policy '{policy}' (valid: {valid})")]
@@ -241,7 +245,7 @@ pub fn validate_exporter(entry: &ExporterEntry, index: usize) -> Result<(), Vali
             .extra
             .get("endpoint")
             .and_then(|v| v.as_str())
-            .map_or(false, |s| !s.is_empty());
+            .is_some_and(|s| !s.is_empty());
         if !has_endpoint {
             return Err(ValidationError::MissingOtlpEndpoint {
                 name: entry.name.clone(),

--- a/src/infmon-config/src/validate.rs
+++ b/src/infmon-config/src/validate.rs
@@ -14,6 +14,9 @@ pub const KNOWN_EXPORTER_TYPES: &[&str] = &["otlp"];
 /// Valid overflow policies. v1 only supports `drop_newest`.
 pub const VALID_OVERFLOW_POLICIES: &[&str] = &["drop_newest"];
 
+/// Maximum allowed queue_depth per exporter.
+pub const MAX_QUEUE_DEPTH: usize = 10_000;
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ValidationError {
     #[error("duplicate flow-rule name: {0}")]
@@ -54,6 +57,8 @@ pub enum ValidationError {
     DuplicateExporterName(String),
     #[error("exporter '{name}': queue_depth must be >= 1")]
     ZeroQueueDepth { name: String },
+    #[error("exporter '{name}': queue_depth {depth} exceeds maximum {max}")]
+    QueueDepthTooLarge { name: String, depth: usize, max: usize },
     #[error("exporter '{name}': invalid export_timeout format: {value:?}")]
     InvalidExportTimeout { name: String, value: String },
     #[error("exporter '{name}': unknown on_overflow policy '{policy}' (valid: {valid})")]
@@ -207,6 +212,13 @@ pub fn validate_exporter(entry: &ExporterEntry, index: usize) -> Result<(), Vali
     if entry.queue_depth == 0 {
         return Err(ValidationError::ZeroQueueDepth {
             name: entry.name.clone(),
+        });
+    }
+    if entry.queue_depth > MAX_QUEUE_DEPTH {
+        return Err(ValidationError::QueueDepthTooLarge {
+            name: entry.name.clone(),
+            depth: entry.queue_depth,
+            max: MAX_QUEUE_DEPTH,
         });
     }
     match parse_duration_str(&entry.export_timeout) {

--- a/src/infmon-config/src/validate.rs
+++ b/src/infmon-config/src/validate.rs
@@ -62,6 +62,14 @@ pub enum ValidationError {
         policy: String,
         valid: String,
     },
+    #[error("frontend: startup_timeout must be > 0")]
+    ZeroStartupTimeout,
+    #[error("exporter '{name}': export_timeout must be > 0")]
+    ZeroExportTimeout { name: String },
+    #[error("exporter '{name}': name is invalid: must match ^[a-z0-9][a-z0-9_-]{{1,30}}$")]
+    InvalidExporterName { name: String },
+    #[error("exporter '{name}': OTLP exporter must have a non-empty 'endpoint'")]
+    MissingOtlpEndpoint { name: String },
 }
 
 /// Validate a flow-rule name.
@@ -158,10 +166,16 @@ pub fn validate_frontend(cfg: &FrontendConfig) -> Result<(), ValidationError> {
     if cfg.shutdown_grace_ms == 0 {
         return Err(ValidationError::ZeroShutdownGrace);
     }
-    if parse_duration_str(&cfg.startup_timeout).is_none() {
-        return Err(ValidationError::InvalidStartupTimeout {
-            value: cfg.startup_timeout.clone(),
-        });
+    match parse_duration_str(&cfg.startup_timeout) {
+        None => {
+            return Err(ValidationError::InvalidStartupTimeout {
+                value: cfg.startup_timeout.clone(),
+            });
+        }
+        Some(0) => {
+            return Err(ValidationError::ZeroStartupTimeout);
+        }
+        Some(_) => {}
     }
     Ok(())
 }
@@ -172,6 +186,11 @@ pub fn validate_frontend(cfg: &FrontendConfig) -> Result<(), ValidationError> {
 pub fn validate_exporter(entry: &ExporterEntry, index: usize) -> Result<(), ValidationError> {
     if entry.name.is_empty() {
         return Err(ValidationError::EmptyExporterName { index });
+    }
+    if !is_valid_name(&entry.name) {
+        return Err(ValidationError::InvalidExporterName {
+            name: entry.name.clone(),
+        });
     }
     if entry.kind.is_empty() {
         return Err(ValidationError::EmptyExporterType {
@@ -190,11 +209,32 @@ pub fn validate_exporter(entry: &ExporterEntry, index: usize) -> Result<(), Vali
             name: entry.name.clone(),
         });
     }
-    if parse_duration_str(&entry.export_timeout).is_none() {
-        return Err(ValidationError::InvalidExportTimeout {
-            name: entry.name.clone(),
-            value: entry.export_timeout.clone(),
-        });
+    match parse_duration_str(&entry.export_timeout) {
+        None => {
+            return Err(ValidationError::InvalidExportTimeout {
+                name: entry.name.clone(),
+                value: entry.export_timeout.clone(),
+            });
+        }
+        Some(0) => {
+            return Err(ValidationError::ZeroExportTimeout {
+                name: entry.name.clone(),
+            });
+        }
+        Some(_) => {}
+    }
+    // OTLP exporters must have a non-empty endpoint
+    if entry.kind == "otlp" {
+        let has_endpoint = entry
+            .extra
+            .get("endpoint")
+            .and_then(|v| v.as_str())
+            .map_or(false, |s| !s.is_empty());
+        if !has_endpoint {
+            return Err(ValidationError::MissingOtlpEndpoint {
+                name: entry.name.clone(),
+            });
+        }
     }
     if !VALID_OVERFLOW_POLICIES.contains(&entry.on_overflow.as_str()) {
         return Err(ValidationError::InvalidOverflowPolicy {

--- a/src/infmon-config/src/validate.rs
+++ b/src/infmon-config/src/validate.rs
@@ -1,12 +1,18 @@
 use std::collections::HashSet;
 
-use crate::model::{Config, Field, FlowRule};
+use crate::model::{Config, ExporterEntry, Field, FlowRule, FrontendConfig};
 use thiserror::Error;
 
 pub const MAX_KEY_WIDTH: u32 = 64;
 pub const MAX_KEYS_BUDGET: u32 = 16 * 1024 * 1024;
 pub const NAME_MAX_LEN: usize = 31;
 pub const NAME_MIN_LEN: usize = 2;
+
+/// Known exporter type keys. Unknown types are a config error per spec §5.
+pub const KNOWN_EXPORTER_TYPES: &[&str] = &["otlp"];
+
+/// Valid overflow policies. v1 only supports `drop_newest`.
+pub const VALID_OVERFLOW_POLICIES: &[&str] = &["drop_newest"];
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ValidationError {
@@ -28,6 +34,34 @@ pub enum ValidationError {
     TooManyRules { count: usize, max: usize },
     #[error("flow-rule name '{name}' is invalid: must match ^[a-z0-9][a-z0-9_-]{{1,30}}$")]
     InvalidName { name: String },
+    #[error("frontend: polling_interval_ms must be > 0")]
+    ZeroPollingInterval,
+    #[error("frontend: shutdown_grace_ms must be > 0")]
+    ZeroShutdownGrace,
+    #[error("frontend: invalid startup_timeout format: {value:?}")]
+    InvalidStartupTimeout { value: String },
+    #[error("exporter '{name}': type is empty")]
+    EmptyExporterType { name: String },
+    #[error("exporter '{name}': unknown type '{kind}' (known: {known})")]
+    UnknownExporterType {
+        name: String,
+        kind: String,
+        known: String,
+    },
+    #[error("exporter at index {index}: name is empty")]
+    EmptyExporterName { index: usize },
+    #[error("duplicate exporter name: {0}")]
+    DuplicateExporterName(String),
+    #[error("exporter '{name}': queue_depth must be >= 1")]
+    ZeroQueueDepth { name: String },
+    #[error("exporter '{name}': invalid export_timeout format: {value:?}")]
+    InvalidExportTimeout { name: String, value: String },
+    #[error("exporter '{name}': unknown on_overflow policy '{policy}' (valid: {valid})")]
+    InvalidOverflowPolicy {
+        name: String,
+        policy: String,
+        valid: String,
+    },
 }
 
 /// Validate a flow-rule name.
@@ -51,6 +85,27 @@ fn is_valid_name(name: &str) -> bool {
     bytes[1..]
         .iter()
         .all(|&b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'_' || b == b'-')
+}
+
+/// Parse a duration string like `"800ms"`, `"5s"`, `"2m"`, `"1h"`.
+///
+/// Supported suffixes: `ms`, `s`, `m`, `h`. Bare integers are treated as
+/// milliseconds. Returns `None` for unrecognised formats.
+fn parse_duration_str(s: &str) -> Option<u64> {
+    let s = s.trim();
+    if let Some(ms) = s.strip_suffix("ms") {
+        ms.trim().parse::<u64>().ok()
+    } else if let Some(h) = s.strip_suffix('h') {
+        h.trim().parse::<u64>().ok().map(|v| v * 3_600_000)
+    } else if let Some(m) = s.strip_suffix('m') {
+        m.trim().parse::<u64>().ok().map(|v| v * 60_000)
+    } else if let Some(secs) = s.strip_suffix('s') {
+        secs.trim().parse::<u64>().ok().map(|v| v * 1000)
+    } else if s.chars().all(|c| c.is_ascii_digit()) && !s.is_empty() {
+        s.parse::<u64>().ok()
+    } else {
+        None
+    }
 }
 
 /// Validate a single flow-rule in isolation
@@ -95,8 +150,71 @@ pub fn validate_rule(rule: &FlowRule) -> Result<(), ValidationError> {
     Ok(())
 }
 
-/// Validate the entire config (all rules, cross-rule constraints)
+/// Validate the frontend configuration block.
+pub fn validate_frontend(cfg: &FrontendConfig) -> Result<(), ValidationError> {
+    if cfg.polling_interval_ms == 0 {
+        return Err(ValidationError::ZeroPollingInterval);
+    }
+    if cfg.shutdown_grace_ms == 0 {
+        return Err(ValidationError::ZeroShutdownGrace);
+    }
+    if parse_duration_str(&cfg.startup_timeout).is_none() {
+        return Err(ValidationError::InvalidStartupTimeout {
+            value: cfg.startup_timeout.clone(),
+        });
+    }
+    Ok(())
+}
+
+/// Validate a single exporter entry.
+///
+/// `index` is used for error messages when the name is empty.
+pub fn validate_exporter(entry: &ExporterEntry, index: usize) -> Result<(), ValidationError> {
+    if entry.name.is_empty() {
+        return Err(ValidationError::EmptyExporterName { index });
+    }
+    if entry.kind.is_empty() {
+        return Err(ValidationError::EmptyExporterType {
+            name: entry.name.clone(),
+        });
+    }
+    if !KNOWN_EXPORTER_TYPES.contains(&entry.kind.as_str()) {
+        return Err(ValidationError::UnknownExporterType {
+            name: entry.name.clone(),
+            kind: entry.kind.clone(),
+            known: KNOWN_EXPORTER_TYPES.join(", "),
+        });
+    }
+    if entry.queue_depth == 0 {
+        return Err(ValidationError::ZeroQueueDepth {
+            name: entry.name.clone(),
+        });
+    }
+    if parse_duration_str(&entry.export_timeout).is_none() {
+        return Err(ValidationError::InvalidExportTimeout {
+            name: entry.name.clone(),
+            value: entry.export_timeout.clone(),
+        });
+    }
+    if !VALID_OVERFLOW_POLICIES.contains(&entry.on_overflow.as_str()) {
+        return Err(ValidationError::InvalidOverflowPolicy {
+            name: entry.name.clone(),
+            policy: entry.on_overflow.clone(),
+            valid: VALID_OVERFLOW_POLICIES.join(", "),
+        });
+    }
+    Ok(())
+}
+
+/// Validate the entire config (all rules, cross-rule constraints,
+/// frontend config, and exporter entries).
 pub fn validate_config(config: &Config) -> Result<(), ValidationError> {
+    // Validate frontend section if present
+    if let Some(ref frontend) = config.frontend {
+        validate_frontend(frontend)?;
+    }
+
+    // Validate flow rules
     let mut names = HashSet::new();
     for rule in &config.flow_rules {
         if !names.insert(&rule.name) {
@@ -114,5 +232,17 @@ pub fn validate_config(config: &Config) -> Result<(), ValidationError> {
     if total > MAX_KEYS_BUDGET as u64 {
         return Err(ValidationError::BudgetExceeded { total });
     }
+
+    // Validate exporters section if present
+    if let Some(ref exporters) = config.exporters {
+        let mut exporter_names = HashSet::new();
+        for (i, entry) in exporters.iter().enumerate() {
+            validate_exporter(entry, i)?;
+            if !exporter_names.insert(&entry.name) {
+                return Err(ValidationError::DuplicateExporterName(entry.name.clone()));
+            }
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Add validation for frontend and exporter configuration sections in the `infmon-config` crate.

### Frontend validation
- `polling_interval_ms` must be > 0
- `shutdown_grace_ms` must be > 0
- `startup_timeout` must be parseable as a duration

### Exporter validation
- Name must be non-empty (2-31 chars)
- Type must be non-empty and known (`otlp` only in v1)
- `queue_depth` must be > 0
- `export_timeout` must be parseable as a duration
- `on_overflow` must be a valid policy (`drop_newest` only in v1)
- No duplicate exporter names
- OTLP exporters must have a non-empty endpoint

### Tests
14 new unit tests covering all validation paths, plus a full YAML round-trip test.

Closes #54