### PR TITLE
feat: add OTLP/gRPC metrics exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -68,10 +68,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
@@ -84,6 +194,12 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -121,7 +237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -131,10 +247,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -148,6 +344,37 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -171,10 +398,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "indexmap"
@@ -195,7 +549,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -203,15 +557,19 @@ name = "infmon-frontend"
 version = "0.1.0"
 dependencies = [
  "env_logger",
+ "hostname",
  "infmon-config",
  "infmon-ipc",
  "inventory",
  "libc",
  "log",
+ "opentelemetry-proto",
  "serde_yaml",
  "signal-hook",
  "tempfile",
  "tokio",
+ "tonic",
+ "uuid",
 ]
 
 [[package]]
@@ -221,7 +579,7 @@ dependencies = [
  "infmon-config",
  "libc",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -239,6 +597,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -271,6 +638,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,10 +672,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -308,7 +697,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -322,6 +711,78 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -345,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +834,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +870,36 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "regex"
@@ -417,7 +940,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -487,7 +1010,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -515,13 +1038,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -536,16 +1081,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -554,7 +1114,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -574,12 +1145,13 @@ version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -592,6 +1164,143 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -618,6 +1327,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +1371,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,7 +1432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -671,7 +1445,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -683,12 +1457,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -724,7 +1571,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -755,7 +1602,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -774,7 +1621,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -782,6 +1629,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -17,6 +17,8 @@ infmon-ipc = { path = "../infmon-ipc", default-features = false }
 inventory = "0.3"
 libc = "0.2"
 log = "0.4"
+# NOTE: opentelemetry-proto 0.27 with gen-tonic-messages requires tonic 0.12.
+# Upgrading either crate independently may cause compile errors — always upgrade together.
 opentelemetry-proto = { version = "0.27", features = ["gen-tonic-messages", "metrics"] }
 serde_yaml = "0.9"
 signal-hook = "0.3"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -11,14 +11,18 @@ path = "src/main.rs"
 
 [dependencies]
 env_logger = "0.11"
+hostname = "0.4"
 infmon-config = { path = "../infmon-config" }
 infmon-ipc = { path = "../infmon-ipc", default-features = false }
 inventory = "0.3"
 libc = "0.2"
 log = "0.4"
+opentelemetry-proto = { version = "0.27", features = ["gen-tonic-messages", "metrics"] }
 serde_yaml = "0.9"
 signal-hook = "0.3"
 tokio = { version = "1", features = ["rt", "time"] }
+tonic = "0.12"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod exporter;
 pub mod lifecycle;
+pub mod otlp;
 pub mod poller;

--- a/src/frontend/src/otlp.rs
+++ b/src/frontend/src/otlp.rs
@@ -419,10 +419,7 @@ impl Exporter for OtlpExporter {
         Box::pin(async move {
             let request = self.build_request(&snap);
 
-            let mut client = self
-                .get_client()
-                .await
-                .map_err(ExporterError::Transient)?;
+            let mut client = self.get_client().await.map_err(ExporterError::Transient)?;
 
             client.export(request).await.map_err(|e| {
                 // Classify gRPC status codes

--- a/src/frontend/src/otlp.rs
+++ b/src/frontend/src/otlp.rs
@@ -7,6 +7,7 @@
 
 use std::net::IpAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use opentelemetry_proto::tonic::collector::metrics::v1::{
     metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
@@ -17,7 +18,7 @@ use opentelemetry_proto::tonic::metrics::v1::{
 };
 use opentelemetry_proto::tonic::resource::v1::Resource;
 use tokio::sync::Mutex;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, Endpoint};
 
 use infmon_ipc::types::{FieldId, FieldValue, FlowRuleStats, FlowStatsSnapshot};
 
@@ -37,7 +38,6 @@ const ATTRIBUTE_LENGTH_CAP: usize = 256;
 const POINTS_PER_FLOW: u64 = 3;
 
 /// Number of per-flow-rule data points (flows, evictions, drops, packets, bytes).
-#[allow(dead_code)]
 const POINTS_PER_FLOW_RULE: u64 = 5;
 
 // ── OTLP Exporter ──────────────────────────────────────────────────
@@ -46,6 +46,8 @@ const POINTS_PER_FLOW_RULE: u64 = 5;
 pub struct OtlpExporter {
     name: String,
     endpoint: String,
+    #[allow(dead_code)] // stored for future reload support
+    instance_id_path: Option<String>,
     max_export_points_per_tick: u64,
     resource_attrs: Vec<KeyValue>,
     client: Mutex<Option<MetricsServiceClient<Channel>>>,
@@ -65,6 +67,9 @@ impl OtlpExporter {
             .get("max_export_points_per_tick")
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(DEFAULT_MAX_EXPORT_POINTS_PER_TICK);
+
+        // Optional configurable instance_id path (default: /var/lib/infmon/instance_id)
+        let instance_id_path = cfg.extra.get("instance_id_path").cloned();
 
         // Build resource attributes (spec §5).
         let mut resource_attrs = vec![
@@ -93,7 +98,10 @@ impl OtlpExporter {
         }
 
         // service.instance.id — read or create persistent instance ID
-        let instance_id = load_or_create_instance_id();
+        let id_path = instance_id_path
+            .as_deref()
+            .unwrap_or("/var/lib/infmon/instance_id");
+        let instance_id = load_or_create_instance_id(id_path);
         resource_attrs.push(kv_string("service.instance.id", &instance_id));
 
         // Operator-supplied resource attributes from extra config
@@ -109,6 +117,7 @@ impl OtlpExporter {
         Ok(Self {
             name: cfg.name.clone(),
             endpoint,
+            instance_id_path,
             max_export_points_per_tick,
             resource_attrs,
             client: Mutex::new(None),
@@ -125,17 +134,27 @@ impl OtlpExporter {
         }
 
         // Ensure endpoint has scheme
-        let endpoint =
+        let endpoint_uri =
             if self.endpoint.starts_with("http://") || self.endpoint.starts_with("https://") {
                 self.endpoint.clone()
             } else {
                 format!("http://{}", self.endpoint)
             };
 
-        let channel = Channel::from_shared(endpoint)?.connect().await?;
+        let channel = Endpoint::from_shared(endpoint_uri)?
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
+            .connect()
+            .await?;
         let client = MetricsServiceClient::new(channel);
         *guard = Some(client.clone());
         Ok(client)
+    }
+
+    /// Clear the cached client so the next call reconnects.
+    async fn clear_client(&self) {
+        let mut guard = self.client.lock().await;
+        *guard = None;
     }
 
     /// Build the full OTLP request from a snapshot.
@@ -145,7 +164,12 @@ impl OtlpExporter {
         // Calculate total flows and apply cardinality cap (spec §8.2).
         let total_flows: u64 = snap.flow_rules.iter().map(|fr| fr.flows.len() as u64).sum();
 
-        let effective_cap = self.max_export_points_per_tick / POINTS_PER_FLOW.max(1);
+        // Reserve budget for per-flow-rule points before computing per-flow allocations.
+        let flow_rule_budget = snap.flow_rules.len() as u64 * POINTS_PER_FLOW_RULE;
+        let remaining_budget = self
+            .max_export_points_per_tick
+            .saturating_sub(flow_rule_budget);
+        let effective_cap = remaining_budget / POINTS_PER_FLOW.max(1);
 
         // Determine per-flow-rule budget
         let flow_budgets: Vec<u64> = if total_flows == 0 || total_flows <= effective_cap {
@@ -177,6 +201,17 @@ impl OtlpExporter {
 
         let mut metrics: Vec<Metric> = Vec::new();
 
+        // Collect data points grouped by metric name to produce idiomatic OTLP
+        // (one Metric with N data points, rather than N Metrics with 1 each).
+        let mut flow_packets_points: Vec<NumberDataPoint> = Vec::new();
+        let mut flow_bytes_points: Vec<NumberDataPoint> = Vec::new();
+        let mut flow_last_seen_points: Vec<NumberDataPoint> = Vec::new();
+        let mut fr_flows_points: Vec<NumberDataPoint> = Vec::new();
+        let mut fr_evictions_points: Vec<NumberDataPoint> = Vec::new();
+        let mut fr_drops_points: Vec<NumberDataPoint> = Vec::new();
+        let mut fr_packets_points: Vec<NumberDataPoint> = Vec::new();
+        let mut fr_bytes_points: Vec<NumberDataPoint> = Vec::new();
+
         for (fr_idx, fr) in snap.flow_rules.iter().enumerate() {
             let budget = flow_budgets.get(fr_idx).copied().unwrap_or(0) as usize;
             let flows_to_emit = budget.min(fr.flows.len());
@@ -185,78 +220,42 @@ impl OtlpExporter {
             for flow in fr.flows.iter().take(flows_to_emit) {
                 let attrs = build_flow_attributes(fr, flow, &fr.fields);
 
-                // infmon.flow.packets (Sum, cumulative, monotonic)
-                metrics.push(Metric {
-                    name: "infmon.flow.packets".into(),
-                    description: "Total packets attributed to this flow".into(),
-                    unit: "{packets}".into(),
-                    data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
-                        Sum {
-                            data_points: vec![NumberDataPoint {
-                                attributes: attrs.clone(),
-                                start_time_unix_nano: flow.counters.first_seen_ns,
-                                time_unix_nano: wall_ns,
-                                value: Some(
-                                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
-                                        flow.counters.packets as i64,
-                                    ),
-                                ),
-                                ..Default::default()
-                            }],
-                            aggregation_temporality:
-                                AggregationTemporality::Cumulative as i32,
-                            is_monotonic: true,
-                        },
-                    )),
-                    metadata: Vec::new(),
-                });
-
-                // infmon.flow.bytes (Sum, cumulative, monotonic)
-                metrics.push(Metric {
-                    name: "infmon.flow.bytes".into(),
-                    description: "Total bytes attributed to this flow".into(),
-                    unit: "By".into(),
-                    data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
-                        Sum {
-                            data_points: vec![NumberDataPoint {
-                                attributes: attrs.clone(),
-                                start_time_unix_nano: flow.counters.first_seen_ns,
-                                time_unix_nano: wall_ns,
-                                value: Some(
-                                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
-                                        flow.counters.bytes as i64,
-                                    ),
-                                ),
-                                ..Default::default()
-                            }],
-                            aggregation_temporality:
-                                AggregationTemporality::Cumulative as i32,
-                            is_monotonic: true,
-                        },
-                    )),
-                    metadata: Vec::new(),
-                });
-
-                // infmon.flow.last_seen (Gauge, ns)
-                metrics.push(Metric {
-                    name: "infmon.flow.last_seen".into(),
-                    description: "Wall-clock ns of the most recent packet".into(),
-                    unit: "ns".into(),
-                    data: Some(
-                        opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(Gauge {
-                            data_points: vec![NumberDataPoint {
-                                attributes: attrs,
-                                time_unix_nano: wall_ns,
-                                value: Some(
-                                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
-                                        flow.counters.last_seen_ns as i64,
-                                    ),
-                                ),
-                                ..Default::default()
-                            }],
-                        }),
+                // infmon.flow.packets
+                flow_packets_points.push(NumberDataPoint {
+                    attributes: attrs.clone(),
+                    start_time_unix_nano: flow.counters.first_seen_ns,
+                    time_unix_nano: wall_ns,
+                    value: Some(
+                        opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                            saturating_i64(flow.counters.packets),
+                        ),
                     ),
-                    metadata: Vec::new(),
+                    ..Default::default()
+                });
+
+                // infmon.flow.bytes
+                flow_bytes_points.push(NumberDataPoint {
+                    attributes: attrs.clone(),
+                    start_time_unix_nano: flow.counters.first_seen_ns,
+                    time_unix_nano: wall_ns,
+                    value: Some(
+                        opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                            saturating_i64(flow.counters.bytes),
+                        ),
+                    ),
+                    ..Default::default()
+                });
+
+                // infmon.flow.last_seen
+                flow_last_seen_points.push(NumberDataPoint {
+                    attributes: attrs,
+                    time_unix_nano: wall_ns,
+                    value: Some(
+                        opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                            saturating_i64(flow.counters.last_seen_ns),
+                        ),
+                    ),
+                    ..Default::default()
                 });
             }
 
@@ -264,118 +263,187 @@ impl OtlpExporter {
             let fr_attrs = vec![kv_string("flow-rule", &fr.name)];
 
             // infmon.flow-rule.flows (Gauge)
+            fr_flows_points.push(NumberDataPoint {
+                attributes: fr_attrs.clone(),
+                time_unix_nano: wall_ns,
+                value: Some(
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                        saturating_i64(fr.flows.len() as u64),
+                    ),
+                ),
+                ..Default::default()
+            });
+
+            // infmon.flow-rule.evictions (Sum, cumulative)
+            fr_evictions_points.push(NumberDataPoint {
+                attributes: fr_attrs.clone(),
+                time_unix_nano: wall_ns,
+                value: Some(
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                        saturating_i64(fr.counters.evictions),
+                    ),
+                ),
+                ..Default::default()
+            });
+
+            // infmon.flow-rule.drops (Sum, cumulative) with reason attr
+            // TODO(extensibility): derive `reason` from data when additional
+            // drop reasons are added (currently only eviction_failed exists).
+            let mut drops_attrs = fr_attrs.clone();
+            drops_attrs.push(kv_string("reason", "eviction_failed"));
+            fr_drops_points.push(NumberDataPoint {
+                attributes: drops_attrs,
+                time_unix_nano: wall_ns,
+                value: Some(
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                        saturating_i64(fr.counters.drops),
+                    ),
+                ),
+                ..Default::default()
+            });
+
+            // infmon.flow-rule.packets (Sum, cumulative)
+            fr_packets_points.push(NumberDataPoint {
+                attributes: fr_attrs.clone(),
+                time_unix_nano: wall_ns,
+                value: Some(
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                        saturating_i64(fr.counters.packets),
+                    ),
+                ),
+                ..Default::default()
+            });
+
+            // infmon.flow-rule.bytes (Sum, cumulative)
+            fr_bytes_points.push(NumberDataPoint {
+                attributes: fr_attrs,
+                time_unix_nano: wall_ns,
+                value: Some(
+                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                        saturating_i64(fr.counters.bytes),
+                    ),
+                ),
+                ..Default::default()
+            });
+        }
+
+        // Build grouped Metric objects (one per metric name, N data points each)
+        if !flow_packets_points.is_empty() {
+            metrics.push(Metric {
+                name: "infmon.flow.packets".into(),
+                description: "Total packets attributed to this flow".into(),
+                unit: "{packets}".into(),
+                data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                    Sum {
+                        data_points: flow_packets_points,
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                    },
+                )),
+                metadata: Vec::new(),
+            });
+        }
+
+        if !flow_bytes_points.is_empty() {
+            metrics.push(Metric {
+                name: "infmon.flow.bytes".into(),
+                description: "Total bytes attributed to this flow".into(),
+                unit: "By".into(),
+                data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                    Sum {
+                        data_points: flow_bytes_points,
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                    },
+                )),
+                metadata: Vec::new(),
+            });
+        }
+
+        if !flow_last_seen_points.is_empty() {
+            metrics.push(Metric {
+                name: "infmon.flow.last_seen".into(),
+                description: "Wall-clock ns of the most recent packet".into(),
+                unit: "ns".into(),
+                data: Some(
+                    opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(Gauge {
+                        data_points: flow_last_seen_points,
+                    }),
+                ),
+                metadata: Vec::new(),
+            });
+        }
+
+        if !fr_flows_points.is_empty() {
             metrics.push(Metric {
                 name: "infmon.flow-rule.flows".into(),
                 description: "Number of live flows in this flow-rule".into(),
                 unit: "{flows}".into(),
                 data: Some(
                     opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(Gauge {
-                        data_points: vec![NumberDataPoint {
-                            attributes: fr_attrs.clone(),
-                            time_unix_nano: wall_ns,
-                            value: Some(
-                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
-                                    fr.flows.len() as i64,
-                                ),
-                            ),
-                            ..Default::default()
-                        }],
+                        data_points: fr_flows_points,
                     }),
                 ),
                 metadata: Vec::new(),
             });
+        }
 
-            // infmon.flow-rule.evictions (Sum, cumulative)
+        if !fr_evictions_points.is_empty() {
             metrics.push(Metric {
                 name: "infmon.flow-rule.evictions".into(),
                 description: "Total evictions for this flow-rule".into(),
                 unit: "{evictions}".into(),
                 data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
                     Sum {
-                        data_points: vec![NumberDataPoint {
-                            attributes: fr_attrs.clone(),
-                            time_unix_nano: wall_ns,
-                            value: Some(
-                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
-                                    fr.counters.evictions as i64,
-                                ),
-                            ),
-                            ..Default::default()
-                        }],
+                        data_points: fr_evictions_points,
                         aggregation_temporality: AggregationTemporality::Cumulative as i32,
                         is_monotonic: true,
                     },
                 )),
                 metadata: Vec::new(),
             });
+        }
 
-            // infmon.flow-rule.drops (Sum, cumulative) with reason attr
-            let mut drops_attrs = fr_attrs.clone();
-            drops_attrs.push(kv_string("reason", "eviction_failed"));
+        if !fr_drops_points.is_empty() {
             metrics.push(Metric {
                 name: "infmon.flow-rule.drops".into(),
                 description: "Total drops for this flow-rule".into(),
                 unit: "{drops}".into(),
                 data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
                     Sum {
-                        data_points: vec![NumberDataPoint {
-                            attributes: drops_attrs,
-                            time_unix_nano: wall_ns,
-                            value: Some(
-                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
-                                    fr.counters.drops as i64,
-                                ),
-                            ),
-                            ..Default::default()
-                        }],
+                        data_points: fr_drops_points,
                         aggregation_temporality: AggregationTemporality::Cumulative as i32,
                         is_monotonic: true,
                     },
                 )),
                 metadata: Vec::new(),
             });
+        }
 
-            // infmon.flow-rule.packets (Sum, cumulative)
+        if !fr_packets_points.is_empty() {
             metrics.push(Metric {
                 name: "infmon.flow-rule.packets".into(),
                 description: "Total packets for this flow-rule".into(),
                 unit: "{packets}".into(),
                 data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
                     Sum {
-                        data_points: vec![NumberDataPoint {
-                            attributes: fr_attrs.clone(),
-                            time_unix_nano: wall_ns,
-                            value: Some(
-                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
-                                    fr.counters.packets as i64,
-                                ),
-                            ),
-                            ..Default::default()
-                        }],
+                        data_points: fr_packets_points,
                         aggregation_temporality: AggregationTemporality::Cumulative as i32,
                         is_monotonic: true,
                     },
                 )),
                 metadata: Vec::new(),
             });
+        }
 
-            // infmon.flow-rule.bytes (Sum, cumulative)
+        if !fr_bytes_points.is_empty() {
             metrics.push(Metric {
                 name: "infmon.flow-rule.bytes".into(),
                 description: "Total bytes for this flow-rule".into(),
                 unit: "By".into(),
                 data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
                     Sum {
-                        data_points: vec![NumberDataPoint {
-                            attributes: fr_attrs,
-                            time_unix_nano: wall_ns,
-                            value: Some(
-                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
-                                    fr.counters.bytes as i64,
-                                ),
-                            ),
-                            ..Default::default()
-                        }],
+                        data_points: fr_bytes_points,
                         aggregation_temporality: AggregationTemporality::Cumulative as i32,
                         is_monotonic: true,
                     },
@@ -421,28 +489,41 @@ impl Exporter for OtlpExporter {
 
             let mut client = self.get_client().await.map_err(ExporterError::Transient)?;
 
-            client.export(request).await.map_err(|e| {
-                // Classify gRPC status codes
-                match e.code() {
-                    tonic::Code::Unavailable
-                    | tonic::Code::DeadlineExceeded
-                    | tonic::Code::ResourceExhausted
-                    | tonic::Code::Aborted => ExporterError::Transient(Box::new(e)),
-                    tonic::Code::Unauthenticated
-                    | tonic::Code::PermissionDenied
-                    | tonic::Code::InvalidArgument
-                    | tonic::Code::Unimplemented => ExporterError::Permanent(Box::new(e)),
-                    _ => ExporterError::Transient(Box::new(e)),
+            match client.export(request).await {
+                Ok(_) => Ok(()),
+                Err(e) => {
+                    // Classify gRPC status codes
+                    let err = match e.code() {
+                        tonic::Code::Unavailable
+                        | tonic::Code::DeadlineExceeded
+                        | tonic::Code::ResourceExhausted
+                        | tonic::Code::Aborted => {
+                            // Clear cached client on transient errors so next tick reconnects
+                            self.clear_client().await;
+                            ExporterError::Transient(Box::new(e))
+                        }
+                        tonic::Code::Unauthenticated
+                        | tonic::Code::PermissionDenied
+                        | tonic::Code::InvalidArgument
+                        | tonic::Code::Unimplemented => ExporterError::Permanent(Box::new(e)),
+                        _ => {
+                            self.clear_client().await;
+                            ExporterError::Transient(Box::new(e))
+                        }
+                    };
+                    Err(err)
                 }
-            })?;
-
-            Ok(())
+            }
         })
     }
 
     fn reload(&self, _cfg: &ExporterConfig) -> Result<(), ConfigError> {
-        // Reload is not yet supported for OTLP; a restart is required.
-        Ok(())
+        // OTLP exporter doesn't support live reload — endpoint, resource attrs,
+        // and caps are immutable after construction. Return an error so callers
+        // know a restart is required.
+        Err(ConfigError(
+            "OTLP exporter requires restart to apply config changes".into(),
+        ))
     }
 
     fn shutdown(&self) -> BoxFuture<'_, ()> {
@@ -463,6 +544,11 @@ inventory::submit!(ExporterRegistration {
 });
 
 // ── Helpers ────────────────────────────────────────────────────────
+
+/// Saturating u64 → i64 conversion: clamps at i64::MAX instead of wrapping.
+fn saturating_i64(v: u64) -> i64 {
+    i64::try_from(v).unwrap_or(i64::MAX)
+}
 
 /// Build a `KeyValue` with a string value.
 fn kv_string(key: &str, value: &str) -> KeyValue {
@@ -563,8 +649,9 @@ fn build_flow_attributes(
 }
 
 /// Load or create a persistent instance ID (spec §5: service.instance.id).
-fn load_or_create_instance_id() -> String {
-    let path = "/var/lib/infmon/instance_id";
+/// The path is configurable via the `instance_id_path` extra config key;
+/// defaults to `/var/lib/infmon/instance_id`.
+fn load_or_create_instance_id(path: &str) -> String {
     if let Ok(id) = std::fs::read_to_string(path) {
         let id = id.trim().to_string();
         if !id.is_empty() {
@@ -574,7 +661,9 @@ fn load_or_create_instance_id() -> String {
     // Generate a new UUID v4
     let id = uuid::Uuid::new_v4().to_string();
     // Try to persist it (best-effort; may fail if dir doesn't exist or no perms)
-    let _ = std::fs::create_dir_all("/var/lib/infmon");
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
     let _ = std::fs::write(path, &id);
     id
 }
@@ -731,8 +820,8 @@ mod tests {
     fn build_request_cardinality_cap() {
         let mut extra = std::collections::HashMap::new();
         extra.insert("endpoint".to_string(), "localhost:4317".to_string());
-        // Cap at 6 points = 2 flows (3 points each)
-        extra.insert("max_export_points_per_tick".to_string(), "6".to_string());
+        // Cap at 21 points: 5 per-flow-rule + 16 remaining = 5 flows (3 pts each = 15, cap 5)
+        extra.insert("max_export_points_per_tick".to_string(), "21".to_string());
         let cfg = ExporterConfig {
             kind: "otlp".into(),
             name: "test-cap".into(),
@@ -770,13 +859,29 @@ mod tests {
         let req = exporter.build_request(&snap);
         let metrics = &req.resource_metrics[0].scope_metrics[0].metrics;
 
-        // Count per-flow metrics (should be capped)
+        // Count per-flow metrics (should be capped to 2 flows)
         let flow_metric_count = metrics
             .iter()
             .filter(|m| m.name.starts_with("infmon.flow."))
             .count();
-        // 2 flows * 3 metrics = 6 per-flow metrics
-        assert_eq!(flow_metric_count, 6);
+        // 3 grouped Metric objects (packets, bytes, last_seen) each with 5 data points
+        assert_eq!(flow_metric_count, 3);
+
+        // Verify capped data point count: 5 flows × 3 metrics = 15 data points total
+        let flow_data_points: usize = metrics
+            .iter()
+            .filter(|m| m.name.starts_with("infmon.flow."))
+            .map(|m| match &m.data {
+                Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(s)) => {
+                    s.data_points.len()
+                }
+                Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(g)) => {
+                    g.data_points.len()
+                }
+                _ => 0,
+            })
+            .sum();
+        assert_eq!(flow_data_points, 15);
 
         // Plus 5 per-flow-rule metrics
         let fr_metric_count = metrics

--- a/src/frontend/src/otlp.rs
+++ b/src/frontend/src/otlp.rs
@@ -1,0 +1,883 @@
+//! OTLP/gRPC metrics exporter.
+//!
+//! Implements the [`Exporter`] trait and translates [`FlowStatsSnapshot`]
+//! data into OTLP metrics, shipping them over gRPC (or HTTP/protobuf).
+//!
+//! Spec reference: `specs/006-exporter-otlp.md`
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    metrics_service_client::MetricsServiceClient, ExportMetricsServiceRequest,
+};
+use opentelemetry_proto::tonic::common::v1::{AnyValue, InstrumentationScope, KeyValue};
+use opentelemetry_proto::tonic::metrics::v1::{
+    AggregationTemporality, Gauge, Metric, NumberDataPoint, ResourceMetrics, ScopeMetrics, Sum,
+};
+use opentelemetry_proto::tonic::resource::v1::Resource;
+use tokio::sync::Mutex;
+use tonic::transport::Channel;
+
+use infmon_ipc::types::{FieldId, FieldValue, FlowRuleStats, FlowStatsSnapshot};
+
+use crate::exporter::{
+    BoxFuture, ConfigError, Exporter, ExporterConfig, ExporterError, ExporterRegistration,
+};
+
+// ── Constants ──────────────────────────────────────────────────────
+
+/// Default per-tick point cap (spec §8.2).
+const DEFAULT_MAX_EXPORT_POINTS_PER_TICK: u64 = 2_000_000;
+
+/// Max length for string attribute values (spec §8.2).
+const ATTRIBUTE_LENGTH_CAP: usize = 256;
+
+/// Number of per-flow data points (packets, bytes, last_seen).
+const POINTS_PER_FLOW: u64 = 3;
+
+/// Number of per-flow-rule data points (flows, evictions, drops, packets, bytes).
+#[allow(dead_code)]
+const POINTS_PER_FLOW_RULE: u64 = 5;
+
+// ── OTLP Exporter ──────────────────────────────────────────────────
+
+/// OTLP/gRPC metrics exporter.
+pub struct OtlpExporter {
+    name: String,
+    endpoint: String,
+    max_export_points_per_tick: u64,
+    resource_attrs: Vec<KeyValue>,
+    client: Mutex<Option<MetricsServiceClient<Channel>>>,
+}
+
+impl OtlpExporter {
+    /// Build a new exporter from its config block.
+    pub fn new(cfg: &ExporterConfig) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let endpoint = cfg.extra.get("endpoint").cloned().unwrap_or_default();
+
+        if endpoint.is_empty() {
+            return Err("OTLP exporter requires a non-empty 'endpoint'".into());
+        }
+
+        let max_export_points_per_tick = cfg
+            .extra
+            .get("max_export_points_per_tick")
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_MAX_EXPORT_POINTS_PER_TICK);
+
+        // Build resource attributes (spec §5).
+        let mut resource_attrs = vec![
+            kv_string("service.name", "infmon-frontend"),
+            kv_string("service.namespace", "infmon"),
+            kv_string(
+                "service.version",
+                option_env!("CARGO_PKG_VERSION").unwrap_or("0.0.0"),
+            ),
+        ];
+
+        // host.name
+        if let Ok(hostname) = hostname::get() {
+            resource_attrs.push(kv_string("host.name", &hostname.to_string_lossy()));
+        }
+
+        // host.arch (runtime, never hard-coded)
+        resource_attrs.push(kv_string("host.arch", std::env::consts::ARCH));
+
+        // host.id from /etc/machine-id (silent omit if unavailable)
+        if let Ok(machine_id) = std::fs::read_to_string("/etc/machine-id") {
+            let id = machine_id.trim();
+            if !id.is_empty() {
+                resource_attrs.push(kv_string("host.id", id));
+            }
+        }
+
+        // service.instance.id — read or create persistent instance ID
+        let instance_id = load_or_create_instance_id();
+        resource_attrs.push(kv_string("service.instance.id", &instance_id));
+
+        // Operator-supplied resource attributes from extra config
+        // (keys prefixed with "resource." are treated as resource attrs)
+        for (k, v) in &cfg.extra {
+            if let Some(attr_key) = k.strip_prefix("resource.") {
+                if !attr_key.is_empty() {
+                    resource_attrs.push(kv_string(attr_key, v));
+                }
+            }
+        }
+
+        Ok(Self {
+            name: cfg.name.clone(),
+            endpoint,
+            max_export_points_per_tick,
+            resource_attrs,
+            client: Mutex::new(None),
+        })
+    }
+
+    /// Lazily connect to the gRPC endpoint.
+    async fn get_client(
+        &self,
+    ) -> Result<MetricsServiceClient<Channel>, Box<dyn std::error::Error + Send + Sync>> {
+        let mut guard = self.client.lock().await;
+        if let Some(ref client) = *guard {
+            return Ok(client.clone());
+        }
+
+        // Ensure endpoint has scheme
+        let endpoint =
+            if self.endpoint.starts_with("http://") || self.endpoint.starts_with("https://") {
+                self.endpoint.clone()
+            } else {
+                format!("http://{}", self.endpoint)
+            };
+
+        let channel = Channel::from_shared(endpoint)?.connect().await?;
+        let client = MetricsServiceClient::new(channel);
+        *guard = Some(client.clone());
+        Ok(client)
+    }
+
+    /// Build the full OTLP request from a snapshot.
+    fn build_request(&self, snap: &FlowStatsSnapshot) -> ExportMetricsServiceRequest {
+        let wall_ns = snap.wall_clock_ns;
+
+        // Calculate total flows and apply cardinality cap (spec §8.2).
+        let total_flows: u64 = snap.flow_rules.iter().map(|fr| fr.flows.len() as u64).sum();
+
+        let effective_cap = self.max_export_points_per_tick / POINTS_PER_FLOW.max(1);
+
+        // Determine per-flow-rule budget
+        let flow_budgets: Vec<u64> = if total_flows == 0 || total_flows <= effective_cap {
+            snap.flow_rules
+                .iter()
+                .map(|fr| fr.flows.len() as u64)
+                .collect()
+        } else {
+            // Proportional allocation
+            let mut budgets: Vec<u64> = snap
+                .flow_rules
+                .iter()
+                .map(|fr| {
+                    (effective_cap as u128 * fr.flows.len() as u128 / total_flows as u128) as u64
+                })
+                .collect();
+            // Distribute remainder
+            let allocated: u64 = budgets.iter().sum();
+            let mut remainder = effective_cap.saturating_sub(allocated);
+            for b in budgets.iter_mut() {
+                if remainder == 0 {
+                    break;
+                }
+                *b += 1;
+                remainder -= 1;
+            }
+            budgets
+        };
+
+        let mut metrics: Vec<Metric> = Vec::new();
+
+        for (fr_idx, fr) in snap.flow_rules.iter().enumerate() {
+            let budget = flow_budgets.get(fr_idx).copied().unwrap_or(0) as usize;
+            let flows_to_emit = budget.min(fr.flows.len());
+
+            // Per-flow data points
+            for flow in fr.flows.iter().take(flows_to_emit) {
+                let attrs = build_flow_attributes(fr, flow, &fr.fields);
+
+                // infmon.flow.packets (Sum, cumulative, monotonic)
+                metrics.push(Metric {
+                    name: "infmon.flow.packets".into(),
+                    description: "Total packets attributed to this flow".into(),
+                    unit: "{packets}".into(),
+                    data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                        Sum {
+                            data_points: vec![NumberDataPoint {
+                                attributes: attrs.clone(),
+                                start_time_unix_nano: flow.counters.first_seen_ns,
+                                time_unix_nano: wall_ns,
+                                value: Some(
+                                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                                        flow.counters.packets as i64,
+                                    ),
+                                ),
+                                ..Default::default()
+                            }],
+                            aggregation_temporality:
+                                AggregationTemporality::Cumulative as i32,
+                            is_monotonic: true,
+                        },
+                    )),
+                    metadata: Vec::new(),
+                });
+
+                // infmon.flow.bytes (Sum, cumulative, monotonic)
+                metrics.push(Metric {
+                    name: "infmon.flow.bytes".into(),
+                    description: "Total bytes attributed to this flow".into(),
+                    unit: "By".into(),
+                    data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                        Sum {
+                            data_points: vec![NumberDataPoint {
+                                attributes: attrs.clone(),
+                                start_time_unix_nano: flow.counters.first_seen_ns,
+                                time_unix_nano: wall_ns,
+                                value: Some(
+                                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                                        flow.counters.bytes as i64,
+                                    ),
+                                ),
+                                ..Default::default()
+                            }],
+                            aggregation_temporality:
+                                AggregationTemporality::Cumulative as i32,
+                            is_monotonic: true,
+                        },
+                    )),
+                    metadata: Vec::new(),
+                });
+
+                // infmon.flow.last_seen (Gauge, ns)
+                metrics.push(Metric {
+                    name: "infmon.flow.last_seen".into(),
+                    description: "Wall-clock ns of the most recent packet".into(),
+                    unit: "ns".into(),
+                    data: Some(
+                        opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(Gauge {
+                            data_points: vec![NumberDataPoint {
+                                attributes: attrs,
+                                time_unix_nano: wall_ns,
+                                value: Some(
+                                    opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                                        flow.counters.last_seen_ns as i64,
+                                    ),
+                                ),
+                                ..Default::default()
+                            }],
+                        }),
+                    ),
+                    metadata: Vec::new(),
+                });
+            }
+
+            // Per-flow-rule observability points (spec §3.4)
+            let fr_attrs = vec![kv_string("flow-rule", &fr.name)];
+
+            // infmon.flow-rule.flows (Gauge)
+            metrics.push(Metric {
+                name: "infmon.flow-rule.flows".into(),
+                description: "Number of live flows in this flow-rule".into(),
+                unit: "{flows}".into(),
+                data: Some(
+                    opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(Gauge {
+                        data_points: vec![NumberDataPoint {
+                            attributes: fr_attrs.clone(),
+                            time_unix_nano: wall_ns,
+                            value: Some(
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                                    fr.flows.len() as i64,
+                                ),
+                            ),
+                            ..Default::default()
+                        }],
+                    }),
+                ),
+                metadata: Vec::new(),
+            });
+
+            // infmon.flow-rule.evictions (Sum, cumulative)
+            metrics.push(Metric {
+                name: "infmon.flow-rule.evictions".into(),
+                description: "Total evictions for this flow-rule".into(),
+                unit: "{evictions}".into(),
+                data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                    Sum {
+                        data_points: vec![NumberDataPoint {
+                            attributes: fr_attrs.clone(),
+                            time_unix_nano: wall_ns,
+                            value: Some(
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                                    fr.counters.evictions as i64,
+                                ),
+                            ),
+                            ..Default::default()
+                        }],
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                    },
+                )),
+                metadata: Vec::new(),
+            });
+
+            // infmon.flow-rule.drops (Sum, cumulative) with reason attr
+            let mut drops_attrs = fr_attrs.clone();
+            drops_attrs.push(kv_string("reason", "eviction_failed"));
+            metrics.push(Metric {
+                name: "infmon.flow-rule.drops".into(),
+                description: "Total drops for this flow-rule".into(),
+                unit: "{drops}".into(),
+                data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                    Sum {
+                        data_points: vec![NumberDataPoint {
+                            attributes: drops_attrs,
+                            time_unix_nano: wall_ns,
+                            value: Some(
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                                    fr.counters.drops as i64,
+                                ),
+                            ),
+                            ..Default::default()
+                        }],
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                    },
+                )),
+                metadata: Vec::new(),
+            });
+
+            // infmon.flow-rule.packets (Sum, cumulative)
+            metrics.push(Metric {
+                name: "infmon.flow-rule.packets".into(),
+                description: "Total packets for this flow-rule".into(),
+                unit: "{packets}".into(),
+                data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                    Sum {
+                        data_points: vec![NumberDataPoint {
+                            attributes: fr_attrs.clone(),
+                            time_unix_nano: wall_ns,
+                            value: Some(
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                                    fr.counters.packets as i64,
+                                ),
+                            ),
+                            ..Default::default()
+                        }],
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                    },
+                )),
+                metadata: Vec::new(),
+            });
+
+            // infmon.flow-rule.bytes (Sum, cumulative)
+            metrics.push(Metric {
+                name: "infmon.flow-rule.bytes".into(),
+                description: "Total bytes for this flow-rule".into(),
+                unit: "By".into(),
+                data: Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(
+                    Sum {
+                        data_points: vec![NumberDataPoint {
+                            attributes: fr_attrs,
+                            time_unix_nano: wall_ns,
+                            value: Some(
+                                opentelemetry_proto::tonic::metrics::v1::number_data_point::Value::AsInt(
+                                    fr.counters.bytes as i64,
+                                ),
+                            ),
+                            ..Default::default()
+                        }],
+                        aggregation_temporality: AggregationTemporality::Cumulative as i32,
+                        is_monotonic: true,
+                    },
+                )),
+                metadata: Vec::new(),
+            });
+        }
+
+        ExportMetricsServiceRequest {
+            resource_metrics: vec![ResourceMetrics {
+                resource: Some(Resource {
+                    attributes: self.resource_attrs.clone(),
+                    dropped_attributes_count: 0,
+                }),
+                scope_metrics: vec![ScopeMetrics {
+                    scope: Some(InstrumentationScope {
+                        name: "infmon".into(),
+                        version: option_env!("CARGO_PKG_VERSION").unwrap_or("0.0.0").into(),
+                        attributes: Vec::new(),
+                        dropped_attributes_count: 0,
+                    }),
+                    metrics,
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        }
+    }
+}
+
+impl Exporter for OtlpExporter {
+    fn kind(&self) -> &'static str {
+        "otlp"
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn export(&self, snap: Arc<FlowStatsSnapshot>) -> BoxFuture<'_, Result<(), ExporterError>> {
+        Box::pin(async move {
+            let request = self.build_request(&snap);
+
+            let mut client = self
+                .get_client()
+                .await
+                .map_err(ExporterError::Transient)?;
+
+            client.export(request).await.map_err(|e| {
+                // Classify gRPC status codes
+                match e.code() {
+                    tonic::Code::Unavailable
+                    | tonic::Code::DeadlineExceeded
+                    | tonic::Code::ResourceExhausted
+                    | tonic::Code::Aborted => ExporterError::Transient(Box::new(e)),
+                    tonic::Code::Unauthenticated
+                    | tonic::Code::PermissionDenied
+                    | tonic::Code::InvalidArgument
+                    | tonic::Code::Unimplemented => ExporterError::Permanent(Box::new(e)),
+                    _ => ExporterError::Transient(Box::new(e)),
+                }
+            })?;
+
+            Ok(())
+        })
+    }
+
+    fn reload(&self, _cfg: &ExporterConfig) -> Result<(), ConfigError> {
+        // Reload is not yet supported for OTLP; a restart is required.
+        Ok(())
+    }
+
+    fn shutdown(&self) -> BoxFuture<'_, ()> {
+        Box::pin(async {
+            // Drop the client to close the gRPC channel.
+            let mut guard = self.client.lock().await;
+            *guard = None;
+            log::info!("OTLP exporter '{}' shut down", self.name);
+        })
+    }
+}
+
+// ── Registration ───────────────────────────────────────────────────
+
+inventory::submit!(ExporterRegistration {
+    kind: "otlp",
+    factory: |cfg| Ok(Box::new(OtlpExporter::new(cfg)?)),
+});
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/// Build a `KeyValue` with a string value.
+fn kv_string(key: &str, value: &str) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(AnyValue {
+            value: Some(
+                opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(
+                    truncate_utf8(value, ATTRIBUTE_LENGTH_CAP).to_string(),
+                ),
+            ),
+        }),
+    }
+}
+
+/// Build a `KeyValue` with an integer value.
+fn kv_int(key: &str, value: i64) -> KeyValue {
+    KeyValue {
+        key: key.to_string(),
+        value: Some(AnyValue {
+            value: Some(opentelemetry_proto::tonic::common::v1::any_value::Value::IntValue(value)),
+        }),
+    }
+}
+
+/// Truncate a string to at most `max_bytes` bytes, respecting UTF-8 char
+/// boundaries, appending `…` if truncated (spec §8.2).
+fn truncate_utf8(s: &str, max_bytes: usize) -> std::borrow::Cow<'_, str> {
+    if s.len() <= max_bytes {
+        return std::borrow::Cow::Borrowed(s);
+    }
+    // Leave room for the ellipsis (3 bytes for '…')
+    let limit = max_bytes.saturating_sub(3);
+    let mut end = limit;
+    // Back up to a char boundary
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut truncated = s[..end].to_string();
+    truncated.push('…');
+    std::borrow::Cow::Owned(truncated)
+}
+
+/// Render an IP address in canonical text form.
+/// IPv4-mapped IPv6 addresses (::ffff:a.b.c.d) are rendered as IPv4.
+fn render_ip(addr: &IpAddr) -> String {
+    match addr {
+        IpAddr::V4(v4) => v4.to_string(),
+        IpAddr::V6(v6) => {
+            // Check for IPv4-mapped: ::ffff:x.x.x.x
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                v4.to_string()
+            } else {
+                v6.to_string()
+            }
+        }
+    }
+}
+
+/// Build per-flow attributes from the flow-rule's field list and the flow's key.
+fn build_flow_attributes(
+    fr: &FlowRuleStats,
+    flow: &infmon_ipc::types::FlowStats,
+    fields: &[FieldId],
+) -> Vec<KeyValue> {
+    let mut attrs = Vec::with_capacity(fields.len() + 1);
+
+    // Always include flow-rule name
+    attrs.push(kv_string("flow-rule", &fr.name));
+
+    // Map each field to its attribute, matching field position to key position
+    for (i, field_id) in fields.iter().enumerate() {
+        if let Some(value) = flow.key.get(i) {
+            match (field_id, value) {
+                (FieldId::SrcIp, FieldValue::Ip(addr)) => {
+                    attrs.push(kv_string("flow.src_ip", &render_ip(addr)));
+                }
+                (FieldId::DstIp, FieldValue::Ip(addr)) => {
+                    attrs.push(kv_string("flow.dst_ip", &render_ip(addr)));
+                }
+                (FieldId::MirrorSrcIp, FieldValue::Ip(addr)) => {
+                    attrs.push(kv_string("flow.mirror_src_ip", &render_ip(addr)));
+                }
+                (FieldId::IpProto, FieldValue::Proto(p)) => {
+                    attrs.push(kv_int("flow.ip_proto", *p as i64));
+                }
+                (FieldId::Dscp, FieldValue::Dscp(d)) => {
+                    attrs.push(kv_int("flow.dscp", *d as i64));
+                }
+                _ => {} // field/value type mismatch — skip
+            }
+        }
+    }
+
+    // Sort by key for stable wire representation (spec §4.2)
+    attrs.sort_by(|a, b| a.key.cmp(&b.key));
+    attrs
+}
+
+/// Load or create a persistent instance ID (spec §5: service.instance.id).
+fn load_or_create_instance_id() -> String {
+    let path = "/var/lib/infmon/instance_id";
+    if let Ok(id) = std::fs::read_to_string(path) {
+        let id = id.trim().to_string();
+        if !id.is_empty() {
+            return id;
+        }
+    }
+    // Generate a new UUID v4
+    let id = uuid::Uuid::new_v4().to_string();
+    // Try to persist it (best-effort; may fail if dir doesn't exist or no perms)
+    let _ = std::fs::create_dir_all("/var/lib/infmon");
+    let _ = std::fs::write(path, &id);
+    id
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use infmon_ipc::types::{FlowCounters, FlowRuleCounters, FlowStats};
+
+    fn make_config() -> ExporterConfig {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("endpoint".to_string(), "localhost:4317".to_string());
+        ExporterConfig {
+            kind: "otlp".into(),
+            name: "test-otlp".into(),
+            extra,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn new_requires_endpoint() {
+        let cfg = ExporterConfig {
+            kind: "otlp".into(),
+            name: "test".into(),
+            ..Default::default()
+        };
+        assert!(OtlpExporter::new(&cfg).is_err());
+    }
+
+    #[test]
+    fn new_succeeds_with_endpoint() {
+        let cfg = make_config();
+        let exporter = OtlpExporter::new(&cfg).unwrap();
+        assert_eq!(exporter.kind(), "otlp");
+        assert_eq!(exporter.name(), "test-otlp");
+    }
+
+    #[test]
+    fn truncate_utf8_no_truncation() {
+        let s = "hello";
+        assert_eq!(truncate_utf8(s, 256).as_ref(), "hello");
+    }
+
+    #[test]
+    fn truncate_utf8_truncates() {
+        let s = "a".repeat(300);
+        let result = truncate_utf8(&s, 256);
+        assert!(result.len() <= 256);
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn truncate_utf8_respects_char_boundaries() {
+        // '€' is 3 bytes in UTF-8
+        let s = "€".repeat(100); // 300 bytes
+        let result = truncate_utf8(&s, 10);
+        // Should truncate to a valid UTF-8 string
+        assert!(result.len() <= 10);
+        assert!(result.ends_with('…'));
+    }
+
+    #[test]
+    fn render_ip_v4() {
+        let addr: IpAddr = "192.168.1.1".parse().unwrap();
+        assert_eq!(render_ip(&addr), "192.168.1.1");
+    }
+
+    #[test]
+    fn render_ip_v6() {
+        let addr: IpAddr = "2001:db8::1".parse().unwrap();
+        assert_eq!(render_ip(&addr), "2001:db8::1");
+    }
+
+    #[test]
+    fn render_ip_v4_mapped_v6() {
+        let v6: std::net::Ipv6Addr = "::ffff:192.168.1.1".parse().unwrap();
+        let addr = IpAddr::V6(v6);
+        assert_eq!(render_ip(&addr), "192.168.1.1");
+    }
+
+    #[test]
+    fn build_request_empty_snapshot() {
+        let cfg = make_config();
+        let exporter = OtlpExporter::new(&cfg).unwrap();
+        let snap = FlowStatsSnapshot {
+            tick_id: 1,
+            wall_clock_ns: 1_000_000_000,
+            monotonic_ns: 1_000_000_000,
+            interval_ns: 1_000_000_000,
+            flow_rules: vec![],
+        };
+        let req = exporter.build_request(&snap);
+        assert_eq!(req.resource_metrics.len(), 1);
+        let rm = &req.resource_metrics[0];
+        assert!(rm.resource.is_some());
+        assert_eq!(rm.scope_metrics.len(), 1);
+        assert_eq!(rm.scope_metrics[0].metrics.len(), 0);
+    }
+
+    #[test]
+    fn build_request_with_flows() {
+        let cfg = make_config();
+        let exporter = OtlpExporter::new(&cfg).unwrap();
+        let snap = FlowStatsSnapshot {
+            tick_id: 1,
+            wall_clock_ns: 1_000_000_000,
+            monotonic_ns: 1_000_000_000,
+            interval_ns: 1_000_000_000,
+            flow_rules: vec![FlowRuleStats {
+                name: "test-rule".into(),
+                fields: vec![FieldId::SrcIp, FieldId::DstIp],
+                flows: vec![FlowStats {
+                    key: vec![
+                        FieldValue::Ip("10.0.0.1".parse().unwrap()),
+                        FieldValue::Ip("10.0.0.2".parse().unwrap()),
+                    ],
+                    counters: FlowCounters {
+                        packets: 100,
+                        bytes: 5000,
+                        first_seen_ns: 500_000_000,
+                        last_seen_ns: 900_000_000,
+                    },
+                }],
+                counters: FlowRuleCounters {
+                    evictions: 0,
+                    drops: 0,
+                    packets: 100,
+                    bytes: 5000,
+                },
+            }],
+        };
+        let req = exporter.build_request(&snap);
+        let metrics = &req.resource_metrics[0].scope_metrics[0].metrics;
+
+        // 3 per-flow + 5 per-flow-rule = 8
+        assert_eq!(metrics.len(), 8);
+
+        // Check metric names
+        let names: Vec<&str> = metrics.iter().map(|m| m.name.as_str()).collect();
+        assert!(names.contains(&"infmon.flow.packets"));
+        assert!(names.contains(&"infmon.flow.bytes"));
+        assert!(names.contains(&"infmon.flow.last_seen"));
+        assert!(names.contains(&"infmon.flow-rule.flows"));
+        assert!(names.contains(&"infmon.flow-rule.evictions"));
+        assert!(names.contains(&"infmon.flow-rule.drops"));
+        assert!(names.contains(&"infmon.flow-rule.packets"));
+        assert!(names.contains(&"infmon.flow-rule.bytes"));
+    }
+
+    #[test]
+    fn build_request_cardinality_cap() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("endpoint".to_string(), "localhost:4317".to_string());
+        // Cap at 6 points = 2 flows (3 points each)
+        extra.insert("max_export_points_per_tick".to_string(), "6".to_string());
+        let cfg = ExporterConfig {
+            kind: "otlp".into(),
+            name: "test-cap".into(),
+            extra,
+            ..Default::default()
+        };
+        let exporter = OtlpExporter::new(&cfg).unwrap();
+
+        let mut flows = Vec::new();
+        for i in 0..10 {
+            flows.push(FlowStats {
+                key: vec![FieldValue::Ip(format!("10.0.0.{}", i).parse().unwrap())],
+                counters: FlowCounters {
+                    packets: 10,
+                    bytes: 100,
+                    first_seen_ns: 0,
+                    last_seen_ns: 0,
+                },
+            });
+        }
+
+        let snap = FlowStatsSnapshot {
+            tick_id: 1,
+            wall_clock_ns: 1_000_000_000,
+            monotonic_ns: 1_000_000_000,
+            interval_ns: 1_000_000_000,
+            flow_rules: vec![FlowRuleStats {
+                name: "big-rule".into(),
+                fields: vec![FieldId::SrcIp],
+                flows,
+                counters: FlowRuleCounters::default(),
+            }],
+        };
+
+        let req = exporter.build_request(&snap);
+        let metrics = &req.resource_metrics[0].scope_metrics[0].metrics;
+
+        // Count per-flow metrics (should be capped)
+        let flow_metric_count = metrics
+            .iter()
+            .filter(|m| m.name.starts_with("infmon.flow."))
+            .count();
+        // 2 flows * 3 metrics = 6 per-flow metrics
+        assert_eq!(flow_metric_count, 6);
+
+        // Plus 5 per-flow-rule metrics
+        let fr_metric_count = metrics
+            .iter()
+            .filter(|m| m.name.starts_with("infmon.flow-rule."))
+            .count();
+        assert_eq!(fr_metric_count, 5);
+    }
+
+    #[test]
+    fn resource_attributes_include_required() {
+        let cfg = make_config();
+        let exporter = OtlpExporter::new(&cfg).unwrap();
+        let attr_keys: Vec<&str> = exporter
+            .resource_attrs
+            .iter()
+            .map(|kv| kv.key.as_str())
+            .collect();
+
+        assert!(attr_keys.contains(&"service.name"));
+        assert!(attr_keys.contains(&"service.namespace"));
+        assert!(attr_keys.contains(&"service.version"));
+        assert!(attr_keys.contains(&"host.arch"));
+        assert!(attr_keys.contains(&"service.instance.id"));
+    }
+
+    #[test]
+    fn resource_attrs_from_extra_config() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("endpoint".to_string(), "localhost:4317".to_string());
+        extra.insert(
+            "resource.infmon.dpu.id".to_string(),
+            "bf3-rack17".to_string(),
+        );
+        let cfg = ExporterConfig {
+            kind: "otlp".into(),
+            name: "test-res".into(),
+            extra,
+            ..Default::default()
+        };
+        let exporter = OtlpExporter::new(&cfg).unwrap();
+        let has_dpu_id = exporter
+            .resource_attrs
+            .iter()
+            .any(|kv| kv.key == "infmon.dpu.id");
+        assert!(has_dpu_id);
+    }
+
+    #[test]
+    fn flow_attributes_only_for_declared_fields() {
+        // A flow-rule with only Dscp should produce only flow-rule + flow.dscp attrs
+        let fr = FlowRuleStats {
+            name: "dscp-only".into(),
+            fields: vec![FieldId::Dscp],
+            flows: vec![],
+            counters: FlowRuleCounters::default(),
+        };
+        let flow = FlowStats {
+            key: vec![FieldValue::Dscp(46)],
+            counters: FlowCounters::default(),
+        };
+        let attrs = build_flow_attributes(&fr, &flow, &fr.fields);
+
+        let keys: Vec<&str> = attrs.iter().map(|kv| kv.key.as_str()).collect();
+        assert!(keys.contains(&"flow-rule"));
+        assert!(keys.contains(&"flow.dscp"));
+        assert!(!keys.contains(&"flow.src_ip"));
+        assert!(!keys.contains(&"flow.dst_ip"));
+    }
+
+    #[test]
+    fn flow_attributes_sorted_by_key() {
+        let fr = FlowRuleStats {
+            name: "multi".into(),
+            fields: vec![
+                FieldId::SrcIp,
+                FieldId::DstIp,
+                FieldId::IpProto,
+                FieldId::Dscp,
+            ],
+            flows: vec![],
+            counters: FlowRuleCounters::default(),
+        };
+        let flow = FlowStats {
+            key: vec![
+                FieldValue::Ip("10.0.0.1".parse().unwrap()),
+                FieldValue::Ip("10.0.0.2".parse().unwrap()),
+                FieldValue::Proto(6),
+                FieldValue::Dscp(0),
+            ],
+            counters: FlowCounters::default(),
+        };
+        let attrs = build_flow_attributes(&fr, &flow, &fr.fields);
+        let keys: Vec<&str> = attrs.iter().map(|kv| kv.key.as_str()).collect();
+
+        // Should be sorted
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted);
+    }
+}


### PR DESCRIPTION
## Summary

Implement the OTLP exporter ([spec 006](https://github.com/r12f/InFMon/blob/main/specs/006-exporter-otlp.md)) as a new `otlp` module in `infmon-frontend`, registered via the inventory-based plugin system.

### Per-flow metrics (3)
- `infmon.flow.packets` — Sum, cumulative, monotonic
- `infmon.flow.bytes` — Sum, cumulative, monotonic
- `infmon.flow.last_seen` — Gauge (ns)

### Per-flow-rule metrics (5)
- `infmon.flow-rule.flows` — Gauge
- `infmon.flow-rule.evictions` — Sum, cumulative
- `infmon.flow-rule.drops` — Sum, cumulative (with `reason` attribute)
- `infmon.flow-rule.packets` — Sum, cumulative
- `infmon.flow-rule.bytes` — Sum, cumulative

### Resource attributes
`service.name`, `service.namespace`, `service.version`, `service.instance.id`, `host.name`, `host.arch`, `host.id`, plus operator-supplied attrs via `resource.*` config keys (e.g. `infmon.dpu.id`, `infmon.dpu.platform`).

### Per-flow attribute mapping
Attributes derived from the flow-rule's declared field list only (spec §4). IPv4-mapped IPv6 addresses rendered as dotted-quad. Attributes sorted by key for stable wire bytes (spec §4.2).

### Cardinality safeguards (spec §8.2)
- Per-tick point cap (default 2M) with proportional per-flow-rule budget allocation
- 256-byte UTF-8-safe attribute value truncation with `…` suffix

### gRPC error classification
Status codes mapped to `Transient` (retryable) vs `Permanent` (disable exporter) errors per spec §7.3.

### Tests
12 unit tests covering: config validation, attribute mapping, IP rendering, cardinality cap, resource attributes, field-only attributes, and attribute sort order.

Closes #56