### PR TITLE
feat(cli): add shell completions and man page generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +263,16 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "clap_mangen"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30ffc187e2e3aeafcd1c6e2aa416e29739454c0ccaa419226d5ecd181f2d78"
+dependencies = [
+ "clap",
+ "roff",
+]
 
 [[package]]
 name = "colorchoice"
@@ -629,6 +648,8 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "clap_complete",
+ "clap_mangen",
  "infmon-config",
  "infmon-ipc",
  "libc",
@@ -1073,6 +1094,12 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "roff"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rustix"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+clap_mangen = "0.2"
 infmon-config = { path = "../infmon-config" }
 infmon-ipc = { path = "../infmon-ipc" }
 serde = { version = "1", features = ["derive"] }

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -272,9 +272,8 @@ pub fn generate_completions(shell: &str) {
 pub fn generate_manpage() {
     let cmd = Cli::command();
     let man = clap_mangen::Man::new(cmd);
-    man.render(&mut std::io::stdout())
-        .unwrap_or_else(|e| {
-            eprintln!("infmonctl: failed to generate man page: {e}");
-            std::process::exit(exit_codes::EXIT_FAILURE);
-        });
+    man.render(&mut std::io::stdout()).unwrap_or_else(|e| {
+        eprintln!("infmonctl: failed to generate man page: {e}");
+        std::process::exit(exit_codes::EXIT_FAILURE);
+    });
 }

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -271,10 +271,16 @@ pub fn generate_completions(shell: &str) {
 
 /// Generate a man page and write to stdout.
 pub fn generate_manpage() {
+    use std::io::Write;
     let cmd = Cli::command();
     let man = clap_mangen::Man::new(cmd);
-    man.render(&mut std::io::stdout()).unwrap_or_else(|e| {
+    let mut out = std::io::stdout().lock();
+    man.render(&mut out).unwrap_or_else(|e| {
         eprintln!("infmonctl: failed to generate man page: {e}");
+        std::process::exit(exit_codes::EXIT_FAILURE);
+    });
+    out.flush().unwrap_or_else(|e| {
+        eprintln!("infmonctl: failed to flush man page output: {e}");
         std::process::exit(exit_codes::EXIT_FAILURE);
     });
 }

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 
 pub mod exit_codes;
 pub mod output;
@@ -246,4 +246,35 @@ pub enum LogCommands {
         #[arg(short, default_value_t = 100)]
         n: u64,
     },
+}
+
+// -----------------------------------------------------------------------
+// Shell completion and man page generation helpers
+// -----------------------------------------------------------------------
+
+/// Generate shell completions for the given shell and write to stdout.
+pub fn generate_completions(shell: &str) {
+    use clap_complete::{generate, Shell};
+    let shell = match shell {
+        "bash" => Shell::Bash,
+        "zsh" => Shell::Zsh,
+        "fish" => Shell::Fish,
+        _ => {
+            eprintln!("infmonctl: unsupported shell: {shell} (expected bash, zsh, or fish)");
+            std::process::exit(exit_codes::EXIT_USAGE);
+        }
+    };
+    let mut cmd = Cli::command();
+    generate(shell, &mut cmd, "infmonctl", &mut std::io::stdout());
+}
+
+/// Generate a man page and write to stdout.
+pub fn generate_manpage() {
+    let cmd = Cli::command();
+    let man = clap_mangen::Man::new(cmd);
+    man.render(&mut std::io::stdout())
+        .unwrap_or_else(|e| {
+            eprintln!("infmonctl: failed to generate man page: {e}");
+            std::process::exit(exit_codes::EXIT_FAILURE);
+        });
 }

--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -255,17 +255,18 @@ pub enum LogCommands {
 /// Generate shell completions for the given shell and write to stdout.
 pub fn generate_completions(shell: &str) {
     use clap_complete::{generate, Shell};
-    let shell = match shell {
-        "bash" => Shell::Bash,
-        "zsh" => Shell::Zsh,
-        "fish" => Shell::Fish,
-        _ => {
-            eprintln!("infmonctl: unsupported shell: {shell} (expected bash, zsh, or fish)");
-            std::process::exit(exit_codes::EXIT_USAGE);
-        }
-    };
+    use std::io::Write;
+    let shell: Shell = shell.parse().unwrap_or_else(|_| {
+        eprintln!("infmonctl: unsupported shell: {shell}");
+        std::process::exit(exit_codes::EXIT_USAGE);
+    });
     let mut cmd = Cli::command();
-    generate(shell, &mut cmd, "infmonctl", &mut std::io::stdout());
+    let mut out = std::io::stdout().lock();
+    generate(shell, &mut cmd, "infmonctl", &mut out);
+    out.flush().unwrap_or_else(|e| {
+        eprintln!("infmonctl: failed to write completions: {e}");
+        std::process::exit(exit_codes::EXIT_FAILURE);
+    });
 }
 
 /// Generate a man page and write to stdout.

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -10,6 +10,11 @@ use infmon_cli::{
 fn main() {
     // Handle --generate-completions and --generate-manpage before clap
     // parsing, since these flags are used without a subcommand.
+    // NOTE: We scan all args (not just args[1]) so that the flags work
+    // regardless of position.  This is intentional — these are hidden
+    // build-time helpers, not user-facing subcommands, so a positional
+    // collision (e.g. `infmonctl install --generate-completions bash`)
+    // is acceptable and extremely unlikely in practice.
     let args: Vec<String> = std::env::args().collect();
     for (i, arg) in args.iter().enumerate() {
         if arg == "--generate-completions" {

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -8,6 +8,28 @@ use infmon_cli::{
 };
 
 fn main() {
+    // Handle --generate-completions and --generate-manpage before clap
+    // parsing, since these flags are used without a subcommand.
+    let args: Vec<String> = std::env::args().collect();
+    for (i, arg) in args.iter().enumerate() {
+        if arg == "--generate-completions" {
+            let shell = args.get(i + 1).map(|s| s.as_str()).unwrap_or_else(|| {
+                eprintln!("infmonctl: --generate-completions requires a shell argument");
+                process::exit(EXIT_USAGE);
+            });
+            infmon_cli::generate_completions(shell);
+            process::exit(EXIT_SUCCESS);
+        }
+        if arg.starts_with("--generate-completions=") {
+            let shell = arg.trim_start_matches("--generate-completions=");
+            infmon_cli::generate_completions(shell);
+            process::exit(EXIT_SUCCESS);
+        }
+        if arg == "--generate-manpage" {
+            infmon_cli::generate_manpage();
+            process::exit(EXIT_SUCCESS);
+        }
+    }
     // Install SIGPIPE handler: exit 0 silently (spec 007 requirement).
     // We use SIG_IGN so writes to a closed pipe return EPIPE instead of
     // killing the process.  The write-error paths already cause the CLI

--- a/src/cli/tests/completions_manpage.rs
+++ b/src/cli/tests/completions_manpage.rs
@@ -1,0 +1,68 @@
+//! Tests for shell completion and man page generation (spec 007 §Open Q3).
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn bash_completions_contain_subcommands() {
+    Command::cargo_bin("infmonctl")
+        .unwrap()
+        .args(["--generate-completions", "bash"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("_infmonctl"))
+        .stdout(predicate::str::contains("install"))
+        .stdout(predicate::str::contains("flow-rule"));
+}
+
+#[test]
+fn zsh_completions_contain_compdef() {
+    Command::cargo_bin("infmonctl")
+        .unwrap()
+        .args(["--generate-completions", "zsh"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("#compdef infmonctl"))
+        .stdout(predicate::str::contains("install"));
+}
+
+#[test]
+fn fish_completions_generated() {
+    Command::cargo_bin("infmonctl")
+        .unwrap()
+        .args(["--generate-completions", "fish"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("complete -c infmonctl"));
+}
+
+#[test]
+fn unsupported_shell_exits_2() {
+    Command::cargo_bin("infmonctl")
+        .unwrap()
+        .args(["--generate-completions", "powershell"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("unsupported shell"));
+}
+
+#[test]
+fn manpage_contains_name_section() {
+    Command::cargo_bin("infmonctl")
+        .unwrap()
+        .arg("--generate-manpage")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(".TH infmonctl"))
+        .stdout(predicate::str::contains(".SH NAME"));
+}
+
+#[test]
+fn generate_completions_equals_syntax() {
+    Command::cargo_bin("infmonctl")
+        .unwrap()
+        .arg("--generate-completions=bash")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("_infmonctl"));
+}

--- a/src/cli/tests/completions_manpage.rs
+++ b/src/cli/tests/completions_manpage.rs
@@ -40,10 +40,19 @@ fn fish_completions_generated() {
 fn unsupported_shell_exits_2() {
     Command::cargo_bin("infmonctl")
         .unwrap()
-        .args(["--generate-completions", "powershell"])
+        .args(["--generate-completions", "nosuchshell"])
         .assert()
         .code(2)
         .stderr(predicate::str::contains("unsupported shell"));
+}
+
+#[test]
+fn powershell_completions_generated() {
+    Command::cargo_bin("infmonctl")
+        .unwrap()
+        .args(["--generate-completions", "powershell"])
+        .assert()
+        .success();
 }
 
 #[test]
@@ -65,4 +74,14 @@ fn generate_completions_equals_syntax() {
         .assert()
         .success()
         .stdout(predicate::str::contains("_infmonctl"));
+}
+
+#[test]
+fn generate_completions_missing_arg_exits_2() {
+    Command::cargo_bin("infmonctl")
+        .unwrap()
+        .arg("--generate-completions")
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("requires a shell argument"));
 }


### PR DESCRIPTION
## Summary

Add `--generate-completions <bash|zsh|fish>` and `--generate-manpage` hidden flags to `infmonctl`, using `clap_complete` and `clap_mangen`. These flags are invoked by the `.deb` build (`packaging/debian/rules`) to produce shell completions and man pages at package time.

### Changes
- Add `clap_complete` and `clap_mangen` dependencies
- Add `generate_completions()` and `generate_manpage()` helpers in `lib.rs`
- Pre-parse `--generate-completions` and `--generate-manpage` in `main.rs` before clap subcommand dispatch (so they work without a subcommand)
- Bash completions → `/usr/share/bash-completion/completions/infmonctl`
- Zsh completions → `/usr/share/zsh/vendor-completions/_infmonctl`
- Fish completions also supported
- 6 integration tests covering all shells, error cases, and `=` syntax

### Spec reference
[007-cli §Open Q3](https://github.com/r12f/InFMon/blob/main/specs/007-cli.md) — ship completions in v1 via `clap_complete`.

Closes #61