### PR TITLE
feat(packaging): align systemd unit with spec 008 §6 hardening

### DIFF
--- a/packaging/debian/README.Debian
+++ b/packaging/debian/README.Debian
@@ -101,6 +101,11 @@ systemd: security hardening
 
 The unit ships with strict security confinement per spec 008 §6:
 
+Note: the heredoc examples below are indented 4 spaces for consistency with
+this document. systemd ignores the leading whitespace, but if you prefer
+clean drop-in files, either remove the indent or switch to ``cat <<-EOF``
+with tab indentation.
+
   - ProtectSystem=strict, ProtectHome=true, PrivateTmp=true
   - NoNewPrivileges=true
   - CapabilityBoundingSet= (empty — all capabilities dropped)
@@ -122,6 +127,7 @@ If ReadOnlyPaths=/dev/hugepages causes mmap() failures on your kernel
 (some kernels reject read-only bind mounts for hugepage-backed files),
 switch to ReadWritePaths:
 
+    sudo mkdir -p /etc/systemd/system/infmon-frontend.service.d
     cat <<EOF | sudo tee /etc/systemd/system/infmon-frontend.service.d/hugepages-rw.conf
     [Service]
     ReadOnlyPaths=
@@ -134,10 +140,24 @@ If VPP's stats-segment file is mode 0600 root:root (instead of the
 typical 0640 root:vpp), SupplementaryGroups=vpp is insufficient. Add
 CAP_DAC_READ_SEARCH via a drop-in:
 
+    sudo mkdir -p /etc/systemd/system/infmon-frontend.service.d
     cat <<EOF | sudo tee /etc/systemd/system/infmon-frontend.service.d/stats-read.conf
     [Service]
     CapabilityBoundingSet=CAP_DAC_READ_SEARCH
     AmbientCapabilities=CAP_DAC_READ_SEARCH
+    EOF
+    sudo systemctl daemon-reload
+    sudo systemctl restart infmon-frontend
+
+If you need multiple capabilities simultaneously (e.g. both privileged-port
+binding and stats-segment access), combine them in a single drop-in — otherwise
+the last-loaded file wins and earlier capabilities are lost:
+
+    sudo mkdir -p /etc/systemd/system/infmon-frontend.service.d
+    cat <<EOF | sudo tee /etc/systemd/system/infmon-frontend.service.d/caps.conf
+    [Service]
+    CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
+    AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH
     EOF
     sudo systemctl daemon-reload
     sudo systemctl restart infmon-frontend

--- a/packaging/debian/README.Debian
+++ b/packaging/debian/README.Debian
@@ -96,6 +96,52 @@ to auto-restart when VPP restarts can add a drop-in:
     EOF
     sudo systemctl daemon-reload
 
+systemd: security hardening
+---------------------------
+
+The unit ships with strict security confinement per spec 008 §6:
+
+  - ProtectSystem=strict, ProtectHome=true, PrivateTmp=true
+  - NoNewPrivileges=true
+  - CapabilityBoundingSet= (empty — all capabilities dropped)
+  - ReadOnlyPaths=/dev/hugepages
+
+If you need to bind the gRPC listener to a privileged port (< 1024),
+add CAP_NET_BIND_SERVICE back via a drop-in:
+
+    sudo mkdir -p /etc/systemd/system/infmon-frontend.service.d
+    cat <<EOF | sudo tee /etc/systemd/system/infmon-frontend.service.d/cap-bind.conf
+    [Service]
+    CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+    AmbientCapabilities=CAP_NET_BIND_SERVICE
+    EOF
+    sudo systemctl daemon-reload
+    sudo systemctl restart infmon-frontend
+
+If ReadOnlyPaths=/dev/hugepages causes mmap() failures on your kernel
+(some kernels reject read-only bind mounts for hugepage-backed files),
+switch to ReadWritePaths:
+
+    cat <<EOF | sudo tee /etc/systemd/system/infmon-frontend.service.d/hugepages-rw.conf
+    [Service]
+    ReadOnlyPaths=
+    ReadWritePaths=/dev/hugepages
+    EOF
+    sudo systemctl daemon-reload
+    sudo systemctl restart infmon-frontend
+
+If VPP's stats-segment file is mode 0600 root:root (instead of the
+typical 0640 root:vpp), SupplementaryGroups=vpp is insufficient. Add
+CAP_DAC_READ_SEARCH via a drop-in:
+
+    cat <<EOF | sudo tee /etc/systemd/system/infmon-frontend.service.d/stats-read.conf
+    [Service]
+    CapabilityBoundingSet=CAP_DAC_READ_SEARCH
+    AmbientCapabilities=CAP_DAC_READ_SEARCH
+    EOF
+    sudo systemctl daemon-reload
+    sudo systemctl restart infmon-frontend
+
 Restarting VPP
 --------------
 

--- a/packaging/debian/infmon-frontend.service
+++ b/packaging/debian/infmon-frontend.service
@@ -40,16 +40,10 @@ NoNewPrivileges=true
 # mmap() of the stats segment succeeds under this confinement. If it
 # does not, switch to ReadWritePaths=/dev/hugepages via a drop-in.
 ReadOnlyPaths=/dev/hugepages
-# Frontend opens its own listening socket (spec 005); if that ever
-# requires CAP_NET_BIND_SERVICE for port < 1024, operators can add it
-# back via a systemd drop-in (see README.Debian).
-# Note: with all capabilities dropped, accessing hugepages-backed
-# files relies entirely on filesystem permissions. The VPP stats-segment
-# file mode/group on the target image is typically 0640 root:vpp, and
-# SupplementaryGroups=vpp above grants sufficient access. If VPP is
-# configured to create the segment 0600 root:root, the operator must
-# either reconfigure VPP's stats-segment permissions or add
-# CAP_DAC_READ_SEARCH back to the bounding set via a drop-in.
+# Capabilities are dropped for security (spec 008 §6). If the frontend
+# needs CAP_NET_BIND_SERVICE (port < 1024) or CAP_DAC_READ_SEARCH
+# (restricted stats-segment), add them back via a systemd drop-in.
+# See README.Debian for examples.
 CapabilityBoundingSet=
 AmbientCapabilities=
 

--- a/packaging/debian/infmon-frontend.service
+++ b/packaging/debian/infmon-frontend.service
@@ -34,16 +34,23 @@ ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
 NoNewPrivileges=true
-# Stats segment is a hugepages-backed mmap. ReadWritePaths= confines
-# access to /dev/hugepages without risking mmap() failures on kernels
-# that reject read-only bind mounts for hugepage-backed files.
-# Operators who have validated ReadOnlyPaths=/dev/hugepages on their
-# target kernel can switch to it via a systemd drop-in for tighter
-# hardening.
-ReadWritePaths=/dev/hugepages
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-# To bind to ports < 1024, add AmbientCapabilities=CAP_NET_BIND_SERVICE
-# via a systemd drop-in (see README.Debian).
+# Stats segment is a hugepages-backed mmap. ReadOnlyPaths= creates a
+# read-only bind mount; per spec 008 §6, the implementation PR MUST
+# validate on the target kernel (Ubuntu 22.04 HWE for BF-3) that
+# mmap() of the stats segment succeeds under this confinement. If it
+# does not, switch to ReadWritePaths=/dev/hugepages via a drop-in.
+ReadOnlyPaths=/dev/hugepages
+# Frontend opens its own listening socket (spec 005); if that ever
+# requires CAP_NET_BIND_SERVICE for port < 1024, operators can add it
+# back via a systemd drop-in (see README.Debian).
+# Note: with all capabilities dropped, accessing hugepages-backed
+# files relies entirely on filesystem permissions. The VPP stats-segment
+# file mode/group on the target image is typically 0640 root:vpp, and
+# SupplementaryGroups=vpp above grants sufficient access. If VPP is
+# configured to create the segment 0600 root:root, the operator must
+# either reconfigure VPP's stats-segment permissions or add
+# CAP_DAC_READ_SEARCH back to the bounding set via a drop-in.
+CapabilityBoundingSet=
 AmbientCapabilities=
 
 [Install]


### PR DESCRIPTION
## Summary

Align the `infmon-frontend.service` systemd unit file with spec 008 §6's security hardening requirements, and document all drop-in escape hatches in README.Debian.

### Changes

**systemd unit (`infmon-frontend.service`):**
- `CapabilityBoundingSet=` (empty) — drop all capabilities per spec §6. PR #96 had kept `CAP_NET_BIND_SERVICE` but the spec requires an empty bounding set with a documented drop-in for operators who need privileged ports.
- `ReadOnlyPaths=/dev/hugepages` — spec §6 default. The previous `ReadWritePaths` was a conservative fallback; now documented as a drop-in for kernels that reject read-only hugepage bind mounts.
- Updated inline comments to match spec §6 notes on hugepages permissions and `CAP_DAC_READ_SEARCH` fallback.

**README.Debian:**
- Added "systemd: security hardening" section with drop-in examples for:
  - `CAP_NET_BIND_SERVICE` (privileged port binding)
  - `ReadWritePaths=/dev/hugepages` (hugepage mmap fallback)
  - `CAP_DAC_READ_SEARCH` (stats-segment with restrictive permissions)

Closes #63