### PR TITLE
ci(packaging): fix source paths and add Rust toolchain to deb build

### DIFF
--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -82,7 +82,8 @@ jobs:
             fakeroot \
             lintian \
             cmake \
-            pkg-config
+            pkg-config \
+            libgtest-dev
 
       - name: Validate debian/control parses
         run: dpkg-checkbuilddeps || true   # informational

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -5,11 +5,9 @@ name: package-deb
 # binary packages + the meta package and uploads them as workflow
 # artefacts.
 #
-# This workflow is intentionally permissive while the source trees
-# are still empty: debian/rules skips the cmake/cargo steps when
-# the corresponding inputs are missing, so this gate verifies the
-# packaging tree itself (control / changelog / scripts / unit file)
-# before the implementations land.
+# The backend VPP plugin build is skipped until vpp-dev is available
+# in CI (a stub .so is used). The frontend and CLI are built from
+# the Rust workspace with cargo.
 
 on:
   push:
@@ -19,6 +17,8 @@ on:
       - 'packaging/tools/sync-debian-changelog.py'
       - 'CHANGELOG.md'
       - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
       - '.github/workflows/package-deb.yml'
   pull_request:
     paths:
@@ -26,6 +26,8 @@ on:
       - 'packaging/tools/sync-debian-changelog.py'
       - 'CHANGELOG.md'
       - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
       - '.github/workflows/package-deb.yml'
   workflow_dispatch:
 
@@ -56,6 +58,19 @@ jobs:
       - name: Run sync script unit tests
         run: python3 -m unittest discover -s packaging/tools/tests -v
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: deb-arm64-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: deb-arm64-cargo-
+
       - name: Install build tooling
         run: |
           sudo apt-get update
@@ -65,7 +80,9 @@ jobs:
             debhelper \
             dpkg-dev \
             fakeroot \
-            lintian
+            lintian \
+            cmake \
+            pkg-config
 
       - name: Validate debian/control parses
         run: dpkg-checkbuilddeps || true   # informational
@@ -100,13 +117,9 @@ jobs:
         env:
           DEB_BUILD_OPTIONS: "nocheck parallel=2"
         run: |
-          # -B = binary-only, -d = ignore build-dep check (we don't
-          # have vpp-dev installed and the rules file no-ops the
-          # build steps when the source trees are missing). When the
-          # backend/frontend impls land we will drop -d and install
-          # the real build-deps via mk-build-deps.
-          # TODO(DPU-XX): remove -d and add mk-build-deps step once
-          # VPP build-deps are available in CI.
+          # -B = binary-only, -d = ignore build-dep check (vpp-dev is
+          # not available in CI so the backend plugin build is stubbed).
+          # Frontend and CLI are built from the Rust workspace.
           dpkg-buildpackage -B -us -uc -d
           mkdir -p artifacts
           mv ../*.deb ../*.changes ../*.buildinfo artifacts/ 2>/dev/null || true

--- a/.github/workflows/package-deb.yml
+++ b/.github/workflows/package-deb.yml
@@ -111,6 +111,7 @@ jobs:
         env:
           DEB_BUILD_OPTIONS: "nocheck parallel=2"
         run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
           dpkg-buildpackage -S -us -uc -d
           ls -la ../
 
@@ -118,6 +119,7 @@ jobs:
         env:
           DEB_BUILD_OPTIONS: "nocheck parallel=2"
         run: |
+          export PATH="$HOME/.cargo/bin:$PATH"
           # -B = binary-only, -d = ignore build-dep check (vpp-dev is
           # not available in CI so the backend plugin build is stubbed).
           # Frontend and CLI are built from the Rust workspace.

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -59,9 +59,9 @@ override_dh_auto_configure:
 # ----------------------------------------------------------------------
 override_dh_auto_build:
 	# ---- backend (VPP plugin) ----
-	if [ -f src/infmon-backend/CMakeLists.txt ]; then \
+	if [ -f src/backend/CMakeLists.txt ]; then \
 	  echo ">>> building infmon-backend (cmake)"; \
-	  cmake -S src/infmon-backend -B $(BACKEND_BUILD_DIR) \
+	  cmake -S src/backend -B $(BACKEND_BUILD_DIR) \
 	        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	        -DCMAKE_INSTALL_PREFIX=/usr; \
 	  cmake --build $(BACKEND_BUILD_DIR) --parallel; \
@@ -73,8 +73,8 @@ override_dh_auto_build:
 	if [ -f Cargo.toml ]; then \
 	  echo ">>> building infmon-frontend + infmon-cli (cargo)"; \
 	  cargo build --release --locked \
-	      $$( [ -d src/infmon-frontend ] && echo -p infmon-frontend ) \
-	      $$( [ -d src/infmon-cli ]      && echo -p infmon-cli ); \
+	      $$( [ -d src/frontend ] && echo -p infmon-frontend ) \
+	      $$( [ -d src/cli ]      && echo -p infmon-cli ); \
 	else \
 	  echo ">>> skipping cargo build (no Cargo.toml yet)"; \
 	fi

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -24,7 +24,10 @@ export PATH := $(HOME)/.cargo/bin:$(PATH)
 
 # Cargo / cargo target dirs — keep build artefacts inside debian/ so
 # `dpkg-buildpackage -nc` and clean(1) behave predictably.
-export CARGO_HOME       ?= $(CURDIR)/debian/cargo-home
+# Force a build-local CARGO_HOME so that `dh_auto_clean → rm -rf
+# $(CARGO_HOME)` never accidentally deletes the system toolchain
+# installed by dtolnay/rust-toolchain (which lives in ~/.cargo).
+export CARGO_HOME       := $(CURDIR)/debian/cargo-home
 export CARGO_TARGET_DIR ?= $(CURDIR)/target
 
 # CMake build tree for the backend plugin.

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -17,6 +17,11 @@
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DH_VERBOSE = 1
 
+# Ensure cargo is on PATH even when dpkg-buildpackage sanitises the
+# environment (the dtolnay/rust-toolchain action sets GITHUB_PATH but
+# dpkg-buildpackage may not inherit it).
+export PATH := $(HOME)/.cargo/bin:$(PATH)
+
 # Cargo / cargo target dirs — keep build artefacts inside debian/ so
 # `dpkg-buildpackage -nc` and clean(1) behave predictably.
 export CARGO_HOME       ?= $(CURDIR)/debian/cargo-home


### PR DESCRIPTION
## Summary

- Fix `debian/rules`: source directory paths (`src/infmon-backend` → `src/backend`, `src/infmon-frontend` → `src/frontend`, `src/infmon-cli` → `src/cli`) to match the actual repository layout
- Add Rust toolchain (`dtolnay/rust-toolchain@stable`) and cargo cache to `package-deb.yml` so frontend and CLI binaries are built from real source
- Install `cmake` and `pkg-config` in CI for the backend build step
- Add `Cargo.toml` and `Cargo.lock` to workflow path triggers
- Update comments to reflect current state (source trees exist, only VPP backend remains stubbed)

## What changes

| File | Change |
|------|--------|
| `packaging/debian/rules` | Fix 4 source directory paths to match actual layout |
| `.github/workflows/package-deb.yml` | Add Rust toolchain, cargo cache, cmake/pkg-config deps, path triggers |

## Test Plan

- CI `package-deb` workflow runs on this PR and produces real `.deb` artifacts with built frontend + CLI binaries
- Backend plugin remains stubbed (expected — vpp-dev not available in CI)

Closes #64