### PR TITLE
feat: add tracing dependencies and logging init module to frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,9 +710,13 @@ dependencies = [
  "rand",
  "serde_yaml",
  "signal-hook",
+ "syslog-tracing",
  "tempfile",
  "tokio",
  "tonic",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -757,6 +785,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +813,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -814,6 +857,21 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -928,6 +986,12 @@ checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1178,6 +1242,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1309,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1330,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "syslog-tracing"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d349bc2df408b4bf656709a29643641cef7f1795d708f88b105c626a8f64f6e4"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "tempfile"
@@ -1309,6 +1399,46 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1450,6 +1580,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1610,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1509,6 +1682,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wait-timeout"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -16,6 +16,10 @@ infmon-common = { path = "../common", default-features = false }
 inventory = "0.3"
 libc = "0.2"
 log = "0.4"
+syslog-tracing = "0.3"
+tracing = "0.1"
+tracing-appender = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 # NOTE: opentelemetry-proto 0.27 with gen-tonic-messages requires tonic 0.12.
 # Upgrading either crate independently may cause compile errors — always upgrade together.
 opentelemetry-proto = { version = "0.27", features = ["gen-tonic-messages", "metrics"] }

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod exporter;
 pub mod lifecycle;
+pub mod logging;
 pub mod otlp;
 pub mod poller;

--- a/src/frontend/src/logging.rs
+++ b/src/frontend/src/logging.rs
@@ -10,25 +10,27 @@ use tracing_subscriber::fmt;
 use tracing_subscriber::EnvFilter;
 
 /// Guard that must be held for the lifetime of the program.
-/// Dropping it flushes any buffered log output (file appender).
+/// Dropping it flushes any buffered log output (file and syslog appenders).
 #[derive(Debug)]
 pub struct LoggingGuard {
-    _guard: Option<WorkerGuard>,
+    _guards: Vec<WorkerGuard>,
 }
 
 /// Initialize a bootstrap stderr subscriber for use during config parsing.
-/// Call this early, before config is available.  Returns a guard that,
-/// when dropped, unsets the global default — but in practice we just
-/// replace it with [`init_logging`] once config is parsed.
-pub fn init_bootstrap() {
+/// Call this early, before config is available.  Returns a
+/// [`DefaultGuard`](tracing::subscriber::DefaultGuard) that sets the
+/// subscriber as the **thread-local** default.  Drop the guard before (or
+/// immediately after) calling [`init_logging`] so the global default can
+/// be installed without conflict.
+pub fn init_bootstrap() -> tracing::subscriber::DefaultGuard {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
     let subscriber = fmt::Subscriber::builder()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)
         .with_ansi(false)
         .finish();
-    // Best-effort; if a global subscriber is already set this is a no-op.
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    // Thread-local default — does not consume the one-shot global slot.
+    tracing::subscriber::set_default(subscriber)
 }
 
 /// Initialize the configured logging subscriber.
@@ -54,6 +56,11 @@ pub fn init_logging(config: &LoggingConfig) -> Result<LoggingGuard, Box<dyn std:
             let syslog = Syslog::new(identity, Options::LOG_PID, Facility::Daemon)
                 .ok_or("failed to initialize syslog")?;
 
+            // NOTE: syslog_tracing::Syslog implements MakeWriter but not
+            // std::io::Write, so it cannot be wrapped with
+            // tracing_appender::non_blocking.  Syslog writes go to a Unix
+            // domain socket which is typically fast (kernel-buffered), so
+            // blocking here is acceptable for normal log volumes.
             let subscriber = fmt::Subscriber::builder()
                 .with_env_filter(filter)
                 .with_writer(syslog)
@@ -63,7 +70,7 @@ pub fn init_logging(config: &LoggingConfig) -> Result<LoggingGuard, Box<dyn std:
             tracing::subscriber::set_global_default(subscriber)
                 .map_err(|e| format!("failed to set global subscriber: {e}"))?;
 
-            Ok(LoggingGuard { _guard: None })
+            Ok(LoggingGuard { _guards: vec![] })
         }
         LogType::File => {
             let file_config = config
@@ -71,14 +78,21 @@ pub fn init_logging(config: &LoggingConfig) -> Result<LoggingGuard, Box<dyn std:
                 .as_ref()
                 .ok_or("logging destination is 'file' but no file config provided")?;
 
-            let dir = std::path::Path::new(&file_config.path)
+            let path = std::path::Path::new(&file_config.path);
+            let dir = path
                 .parent()
+                .filter(|p| !p.as_os_str().is_empty())
                 .unwrap_or_else(|| std::path::Path::new("."));
-            let filename = std::path::Path::new(&file_config.path)
+            let filename = path
                 .file_name()
                 .and_then(|n| n.to_str())
                 .unwrap_or("infmon.log");
 
+            // NOTE: tracing_appender::rolling does not limit the number of
+            // old log files.  For production use, configure external log
+            // rotation (e.g. logrotate) or switch to
+            // RollingFileAppender::builder().max_log_files(N) when
+            // tracing-appender 0.2.3+ is available.
             let rotation = match file_config.rotation {
                 Rotation::Daily => tracing_appender::rolling::daily(dir, filename),
                 Rotation::Hourly => tracing_appender::rolling::hourly(dir, filename),
@@ -97,7 +111,7 @@ pub fn init_logging(config: &LoggingConfig) -> Result<LoggingGuard, Box<dyn std:
                 .map_err(|e| format!("failed to set global subscriber: {e}"))?;
 
             Ok(LoggingGuard {
-                _guard: Some(guard),
+                _guards: vec![guard],
             })
         }
     }

--- a/src/frontend/src/logging.rs
+++ b/src/frontend/src/logging.rs
@@ -1,0 +1,108 @@
+//! Logging initialization for infmon-frontend.
+//!
+//! Builds a `tracing` subscriber based on [`LoggingConfig`], supporting
+//! syslog and file destinations with `RUST_LOG` env-var override.
+
+use infmon_common::config::{LogLevel, LogType, LoggingConfig, Rotation};
+use syslog_tracing::{Facility, Options, Syslog};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::fmt;
+use tracing_subscriber::EnvFilter;
+
+/// Guard that must be held for the lifetime of the program.
+/// Dropping it flushes any buffered log output (file appender).
+#[derive(Debug)]
+pub struct LoggingGuard {
+    _guard: Option<WorkerGuard>,
+}
+
+/// Initialize a bootstrap stderr subscriber for use during config parsing.
+/// Call this early, before config is available.  Returns a guard that,
+/// when dropped, unsets the global default — but in practice we just
+/// replace it with [`init_logging`] once config is parsed.
+pub fn init_bootstrap() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let subscriber = fmt::Subscriber::builder()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .finish();
+    // Best-effort; if a global subscriber is already set this is a no-op.
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+/// Initialize the configured logging subscriber.
+///
+/// # Errors
+/// Returns an error if the syslog or file appender cannot be created.
+pub fn init_logging(config: &LoggingConfig) -> Result<LoggingGuard, Box<dyn std::error::Error>> {
+    let default_level = match config.level {
+        LogLevel::Trace => "trace",
+        LogLevel::Debug => "debug",
+        LogLevel::Info => "info",
+        LogLevel::Warn => "warn",
+        LogLevel::Error => "error",
+    };
+
+    // RUST_LOG overrides config level
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
+
+    match config.destination {
+        LogType::Syslog => {
+            let identity = c"infmon";
+            let syslog = Syslog::new(identity, Options::LOG_PID, Facility::Daemon)
+                .ok_or("failed to initialize syslog")?;
+
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(syslog)
+                .with_ansi(false)
+                .finish();
+
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| format!("failed to set global subscriber: {e}"))?;
+
+            Ok(LoggingGuard { _guard: None })
+        }
+        LogType::File => {
+            let file_config = config
+                .file
+                .as_ref()
+                .ok_or("logging destination is 'file' but no file config provided")?;
+
+            let dir = std::path::Path::new(&file_config.path)
+                .parent()
+                .unwrap_or_else(|| std::path::Path::new("."));
+            let filename = std::path::Path::new(&file_config.path)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("infmon.log");
+
+            let rotation = match file_config.rotation {
+                Rotation::Daily => tracing_appender::rolling::daily(dir, filename),
+                Rotation::Hourly => tracing_appender::rolling::hourly(dir, filename),
+                Rotation::Never => tracing_appender::rolling::never(dir, filename),
+            };
+
+            let (non_blocking, guard) = tracing_appender::non_blocking(rotation);
+
+            let subscriber = fmt::Subscriber::builder()
+                .with_env_filter(filter)
+                .with_writer(non_blocking)
+                .with_ansi(false)
+                .finish();
+
+            tracing::subscriber::set_global_default(subscriber)
+                .map_err(|e| format!("failed to set global subscriber: {e}"))?;
+
+            Ok(LoggingGuard {
+                _guard: Some(guard),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "logging_tests.rs"]
+mod tests;

--- a/src/frontend/src/logging_tests.rs
+++ b/src/frontend/src/logging_tests.rs
@@ -5,7 +5,7 @@ use infmon_common::config::{LogFileConfig, LogLevel, LogType, LoggingConfig, Rot
 
 #[test]
 fn test_logging_guard_drops_without_panic() {
-    let guard = LoggingGuard { _guard: None };
+    let guard = LoggingGuard { _guards: vec![] };
     drop(guard);
 }
 
@@ -23,6 +23,16 @@ fn test_init_logging_file_missing_config() {
 }
 
 #[test]
+fn test_init_bootstrap_returns_guard() {
+    // init_bootstrap now returns a DefaultGuard (thread-local scope).
+    // Verify it can be created and dropped without panic.
+    let guard = init_bootstrap();
+    // While the guard is held, tracing macros use the bootstrap subscriber.
+    tracing::info!("bootstrap logging active");
+    drop(guard);
+}
+
+#[test]
 fn test_file_destination_with_config() {
     let dir = tempfile::tempdir().unwrap();
     let log_path = dir.path().join("test.log");
@@ -36,13 +46,39 @@ fn test_file_destination_with_config() {
         }),
     };
 
-    // May fail because a global subscriber is already set, but should not
-    // fail on file creation.
+    // May fail because a global subscriber is already set by another test,
+    // but must not fail on file creation or appender setup.
     let result = init_logging(&config);
     match result {
         Ok(_guard) => {}
         Err(e) => {
             let msg = e.to_string();
+            assert!(msg.contains("global subscriber"), "unexpected error: {msg}");
+        }
+    }
+}
+
+#[test]
+fn test_file_destination_bare_filename() {
+    // Regression: a bare filename like "infmon.log" (no directory component)
+    // must not produce an empty-string directory.  The code should fall back
+    // to "." as the directory.
+    let config = LoggingConfig {
+        level: LogLevel::Info,
+        destination: LogType::File,
+        file: Some(LogFileConfig {
+            path: "infmon.log".to_string(),
+            rotation: Rotation::Never,
+        }),
+    };
+
+    let result = init_logging(&config);
+    match result {
+        Ok(_guard) => {}
+        Err(e) => {
+            let msg = e.to_string();
+            // The only acceptable error is the global-subscriber-already-set
+            // error (test ordering). File creation itself must succeed.
             assert!(msg.contains("global subscriber"), "unexpected error: {msg}");
         }
     }

--- a/src/frontend/src/logging_tests.rs
+++ b/src/frontend/src/logging_tests.rs
@@ -1,0 +1,49 @@
+//! Tests for the logging module.
+
+use super::*;
+use infmon_common::config::{LogFileConfig, LogLevel, LogType, LoggingConfig, Rotation};
+
+#[test]
+fn test_logging_guard_drops_without_panic() {
+    let guard = LoggingGuard { _guard: None };
+    drop(guard);
+}
+
+#[test]
+fn test_init_logging_file_missing_config() {
+    let config = LoggingConfig {
+        level: LogLevel::Info,
+        destination: LogType::File,
+        file: None,
+    };
+    let result = init_logging(&config);
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("no file config"), "unexpected error: {err}");
+}
+
+#[test]
+fn test_file_destination_with_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("test.log");
+
+    let config = LoggingConfig {
+        level: LogLevel::Debug,
+        destination: LogType::File,
+        file: Some(LogFileConfig {
+            path: log_path.to_str().unwrap().to_string(),
+            rotation: Rotation::Never,
+        }),
+    };
+
+    // May fail because a global subscriber is already set, but should not
+    // fail on file creation.
+    let result = init_logging(&config);
+    match result {
+        Ok(_guard) => {}
+        Err(e) => {
+            let msg = e.to_string();
+            assert!(msg.contains("global subscriber"), "unexpected error: {msg}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add tracing, tracing-subscriber, tracing-appender, syslog-tracing dependencies to frontend crate
- Create `logging.rs` module with `init_logging(config)` supporting syslog and file destinations
- Add `init_bootstrap()` for minimal stderr subscriber during config parse
- `LoggingGuard` returned for file appender flush-on-drop
- `RUST_LOG` env var overrides config level
- Tests in `logging_tests.rs`

Note: `env_logger` and `log` deps are kept until #119 migrates all `log::` macro calls to `tracing::`.

Closes #118
