### PR TITLE
feat: replace all log:: macros with tracing:: in frontend source files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,29 +317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,12 +677,10 @@ dependencies = [
 name = "infmon-frontend"
 version = "0.1.0"
 dependencies = [
- "env_logger",
  "hostname",
  "infmon-common",
  "inventory",
  "libc",
- "log",
  "opentelemetry-proto",
  "rand",
  "serde_yaml",
@@ -749,30 +724,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "js-sys"
@@ -971,21 +922,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -10,12 +10,10 @@ name = "infmon-frontend"
 path = "src/main.rs"
 
 [dependencies]
-env_logger = "0.11"
 hostname = "0.4"
 infmon-common = { path = "../common", default-features = false }
 inventory = "0.3"
 libc = "0.2"
-log = "0.4"
 syslog-tracing = "0.3"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/src/frontend/src/exporter.rs
+++ b/src/frontend/src/exporter.rs
@@ -214,7 +214,7 @@ pub fn validate_registrations() {
     let mut seen = std::collections::HashSet::new();
     for reg in inventory::iter::<ExporterRegistration> {
         if !seen.insert(reg.kind) {
-            log::warn!(
+            tracing::warn!(
                 "duplicate exporter registration for kind '{}' — only the first will be used",
                 reg.kind,
             );
@@ -251,7 +251,7 @@ pub struct SnapshotReceiver {
 /// the drop-newest overflow policy.
 pub fn snapshot_channel(capacity: usize) -> (SnapshotSender, SnapshotReceiver) {
     let cap = if capacity == 0 {
-        log::warn!("snapshot_channel: capacity 0 clamped to 1");
+        tracing::warn!("snapshot_channel: capacity 0 clamped to 1");
         1
     } else {
         capacity
@@ -311,7 +311,7 @@ impl ExporterHandle {
     pub fn join(mut self) {
         if let Some(h) = self.join.take() {
             if let Err(e) = h.join() {
-                log::error!("exporter thread panicked: {:?}", e);
+                tracing::error!("exporter thread panicked: {:?}", e);
             }
         }
     }
@@ -324,7 +324,7 @@ impl Drop for ExporterHandle {
         // without this the thread could outlive resources it references.
         if let Some(h) = self.join.take() {
             if let Err(e) = h.join() {
-                log::error!("exporter thread panicked: {:?}", e);
+                tracing::error!("exporter thread panicked: {:?}", e);
             }
         }
     }
@@ -353,7 +353,7 @@ pub fn spawn_exporter_thread(
         {
             Ok(rt) => rt,
             Err(e) => {
-                log::error!(
+                tracing::error!(
                     "exporter '{}': failed to build tokio runtime: {}",
                     exporter.name(),
                     e,
@@ -374,7 +374,7 @@ pub fn spawn_exporter_thread(
                         backoff = Duration::from_millis(100); // reset on success
                     }
                     Ok(Err(ExporterError::Timeout)) => {
-                        log::warn!("exporter '{}' self-reported timeout", exporter.name(),);
+                        tracing::warn!("exporter '{}' self-reported timeout", exporter.name(),);
                         if let Some(ref m) = metrics {
                             m.batches_failed_transient.fetch_add(1, Ordering::Relaxed);
                         }
@@ -383,7 +383,7 @@ pub fn spawn_exporter_thread(
                         backoff = (backoff * 2).min(MAX_BACKOFF);
                     }
                     Err(_) => {
-                        log::warn!(
+                        tracing::warn!(
                             "exporter '{}' export exceeded framework deadline ({:?})",
                             exporter.name(),
                             export_timeout,
@@ -396,7 +396,7 @@ pub fn spawn_exporter_thread(
                         backoff = (backoff * 2).min(MAX_BACKOFF);
                     }
                     Ok(Err(ExporterError::Transient(e))) => {
-                        log::warn!("exporter '{}' transient error: {}", exporter.name(), e);
+                        tracing::warn!("exporter '{}' transient error: {}", exporter.name(), e);
                         if let Some(ref m) = metrics {
                             m.batches_failed_transient.fetch_add(1, Ordering::Relaxed);
                         }
@@ -404,7 +404,7 @@ pub fn spawn_exporter_thread(
                         backoff = (backoff * 2).min(MAX_BACKOFF);
                     }
                     Ok(Err(ExporterError::Permanent(e))) => {
-                        log::error!(
+                        tracing::error!(
                             "exporter '{}' permanent error: {} — disabling",
                             exporter.name(),
                             e,
@@ -420,7 +420,7 @@ pub fn spawn_exporter_thread(
 
             // Flush exporter buffers on shutdown (spec §9.3).
             exporter.shutdown().await;
-            log::info!("exporter '{}' thread exiting", exporter.name());
+            tracing::info!("exporter '{}' thread exiting", exporter.name());
         });
     })?;
 

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -62,7 +62,7 @@ impl Frontend {
     /// 3. Build exporters from config
     /// 4. Spawn poller and exporter threads
     pub fn start(config_path: &Path, shutdown: Arc<AtomicBool>) -> Result<Self, LifecycleError> {
-        log::info!("starting infmon-frontend");
+        tracing::info!("starting infmon-frontend");
 
         // Validate exporter registrations
         validate_registrations();
@@ -95,7 +95,7 @@ impl Frontend {
         while start_time.elapsed() < startup_timeout {
             match InFMonStatsClient::open(&stats_socket) {
                 Ok(_client) => {
-                    log::info!(
+                    tracing::info!(
                         "backend stats segment reachable at {}",
                         stats_socket.display()
                     );
@@ -103,7 +103,7 @@ impl Frontend {
                     break;
                 }
                 Err(e) => {
-                    log::debug!("backend not yet reachable: {e}");
+                    tracing::debug!("backend not yet reachable: {e}");
                     std::thread::sleep(Duration::from_millis(200));
                 }
             }
@@ -170,7 +170,7 @@ impl Frontend {
     /// A future iteration will diff the old and new configs and hot-swap
     /// exporters / update flow rules via the control client.
     pub fn reload(&mut self) -> Result<(), LifecycleError> {
-        log::info!(
+        tracing::info!(
             "reloading configuration from {}",
             self.config_path.display()
         );
@@ -186,19 +186,19 @@ impl Frontend {
 
         // TODO: diff flow rules, apply via control client
         // TODO: reload existing exporters, add/remove as needed
-        log::warn!("reload: config validated but hot-swap not yet implemented — changes take effect on restart");
+        tracing::warn!("reload: config validated but hot-swap not yet implemented — changes take effect on restart");
         Ok(())
     }
 
     /// Graceful shutdown. Always exits 0.
     pub fn stop(mut self) {
-        log::info!("stopping infmon-frontend");
+        tracing::info!("stopping infmon-frontend");
         self.shutdown.store(true, Ordering::Release);
 
         // 1. Stop the poller
         if let Some(handle) = self.poller_handle.take() {
             handle.stop();
-            log::info!("poller stopped");
+            tracing::info!("poller stopped");
         }
 
         // 2. Close exporter channels (drop senders) so exporters drain
@@ -210,7 +210,7 @@ impl Frontend {
             handle.join();
         }
 
-        log::info!("infmon-frontend stopped");
+        tracing::info!("infmon-frontend stopped");
     }
 
     /// Check if shutdown has been signalled.
@@ -271,7 +271,7 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
         // Bare integer → milliseconds
         s.parse::<u64>().ok().map(Duration::from_millis)
     } else {
-        log::warn!(
+        tracing::warn!(
             "parse_duration: unrecognised format {:?}, returning None",
             s
         );

--- a/src/frontend/src/main.rs
+++ b/src/frontend/src/main.rs
@@ -11,9 +11,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use infmon_frontend::lifecycle;
+use infmon_frontend::logging;
 
 fn main() {
-    env_logger::init();
+    let _bootstrap_guard = logging::init_bootstrap();
 
     let config_path = match std::env::args().nth(1) {
         Some(arg) if arg == "--help" || arg == "-h" => {
@@ -26,7 +27,7 @@ fn main() {
         None => PathBuf::from("/etc/infmon/config.yaml"),
     };
 
-    log::info!(
+    tracing::info!(
         "infmon-frontend starting with config: {}",
         config_path.display()
     );
@@ -46,7 +47,7 @@ fn main() {
     let mut frontend = match lifecycle::Frontend::start(&config_path, shutdown.clone()) {
         Ok(f) => f,
         Err(e) => {
-            log::error!("failed to start: {e}");
+            tracing::error!("failed to start: {e}");
             std::process::exit(1);
         }
     };
@@ -55,12 +56,12 @@ fn main() {
     while !shutdown.load(Ordering::Acquire) {
         if reload.swap(false, Ordering::AcqRel) {
             if let Err(e) = frontend.reload() {
-                log::error!("reload failed: {e}");
+                tracing::error!("reload failed: {e}");
             }
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
     frontend.stop();
-    log::info!("infmon-frontend exited");
+    tracing::info!("infmon-frontend exited");
 }

--- a/src/frontend/src/otlp.rs
+++ b/src/frontend/src/otlp.rs
@@ -639,7 +639,7 @@ impl OtlpExporter {
         request: ExportMetricsServiceRequest,
     ) -> Vec<ExportMetricsServiceRequest> {
         if self.max_batch_points == 0 {
-            log::warn!(
+            tracing::warn!(
                 "max_batch_points is 0 (batching disabled) — this is likely a misconfiguration"
             );
             return vec![request];
@@ -809,7 +809,7 @@ impl OtlpExporter {
                 let backoff_max = RETRY_CAP.min(RETRY_BASE * 2u32.saturating_pow(attempt));
                 let jitter = rand::thread_rng().gen_range(0.0..1.0);
                 let delay = backoff_max.mul_f64(jitter);
-                log::warn!(
+                tracing::warn!(
                     "OTLP export retry {}/{} after {:.1}s backoff",
                     attempt,
                     MAX_RETRIES,
@@ -843,7 +843,7 @@ impl OtlpExporter {
                             | tonic::Code::Aborted
                     );
                     if is_retryable {
-                        log::warn!(
+                        tracing::warn!(
                             "OTLP export attempt {}/{} failed with retryable gRPC code {:?}: {}",
                             attempt,
                             MAX_RETRIES,
@@ -855,7 +855,7 @@ impl OtlpExporter {
                         continue;
                     } else {
                         // Non-retryable: drop immediately
-                        log::error!(
+                        tracing::error!(
                             "OTLP export failed with permanent gRPC code {:?}: {}",
                             e.code(),
                             e.message()
@@ -975,7 +975,7 @@ impl Exporter for OtlpExporter {
             // Drop the client to close the gRPC channel.
             let mut guard = self.client.lock().await;
             *guard = None;
-            log::info!("OTLP exporter '{}' shut down", self.name);
+            tracing::info!("OTLP exporter '{}' shut down", self.name);
         })
     }
 

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -99,7 +99,7 @@ fn monotonic_ns() -> u64 {
     // SAFETY: CLOCK_MONOTONIC is always valid.
     let ret = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut ts) };
     if ret != 0 {
-        log::error!("clock_gettime(CLOCK_MONOTONIC) failed: {}", ret);
+        tracing::error!("clock_gettime(CLOCK_MONOTONIC) failed: {}", ret);
         return 0;
     }
     debug_assert!(ts.tv_sec >= 0, "CLOCK_MONOTONIC returned negative tv_sec");
@@ -115,7 +115,7 @@ fn wall_clock_ns() -> u64 {
     };
     let ret = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut ts) };
     if ret != 0 {
-        log::error!("clock_gettime(CLOCK_REALTIME) failed: {}", ret);
+        tracing::error!("clock_gettime(CLOCK_REALTIME) failed: {}", ret);
         return 0;
     }
     debug_assert!(ts.tv_sec >= 0, "CLOCK_REALTIME returned negative tv_sec");
@@ -126,11 +126,11 @@ fn wall_clock_ns() -> u64 {
 fn try_connect(path: &Path) -> Option<InFMonStatsClient> {
     match InFMonStatsClient::open(path) {
         Ok(c) => {
-            log::info!("connected to stats segment at {}", path.display());
+            tracing::info!("connected to stats segment at {}", path.display());
             Some(c)
         }
         Err(e) => {
-            log::warn!(
+            tracing::warn!(
                 "failed to connect to stats segment at {}: {}",
                 path.display(),
                 e
@@ -175,14 +175,14 @@ fn decode_snapshot(
                     let start = slot.key_offset as usize;
                     let end = start + slot.key_len as usize;
                     if end > desc.key_arena.len() {
-                        log::warn!("slot key extends past arena, skipping");
+                        tracing::warn!("slot key extends past arena, skipping");
                         return None;
                     }
                     let key_bytes = &desc.key_arena[start..end];
                     let key = match decode_key(&fields, key_bytes) {
                         Ok(k) => k,
                         Err(e) => {
-                            log::warn!("failed to decode flow key: {}", e);
+                            tracing::warn!("failed to decode flow key: {}", e);
                             return None;
                         }
                     };
@@ -246,7 +246,7 @@ fn run_loop(
             client = try_connect(&config.stats_socket);
             if client.is_none() {
                 // Exponential backoff on reconnection.
-                log::debug!("reconnect backoff: {:?}", backoff);
+                tracing::debug!("reconnect backoff: {:?}", backoff);
                 sleep_interruptible(backoff, stop);
                 backoff = (backoff * 2).min(max_backoff);
                 continue;
@@ -272,7 +272,7 @@ fn run_loop(
                     // Fan out to exporters.
                     for (i, tx) in senders.iter().enumerate() {
                         if tx.try_send(snap.clone()).is_err() {
-                            log::warn!(
+                            tracing::warn!(
                                 "exporter {} channel full, dropping snapshot (tick {})",
                                 i,
                                 tick_id
@@ -281,7 +281,7 @@ fn run_loop(
                     }
                 }
                 Err(e) => {
-                    log::warn!("snapshot_and_clear failed: {} — disconnecting", e);
+                    tracing::warn!("snapshot_and_clear failed: {} — disconnecting", e);
                     client = None;
                     continue;
                 }
@@ -295,7 +295,7 @@ fn run_loop(
         }
     }
 
-    log::info!("poller stopped after {} ticks", tick_id);
+    tracing::info!("poller stopped after {} ticks", tick_id);
 }
 
 /// Sleep for `dur`, but wake early if `stop` is set.


### PR DESCRIPTION
## Summary
Mechanical replacement of all `log::` macro calls with `tracing::` equivalents across frontend source files, and removal of `env_logger` dependency.

## Changes
- Replace `log::info!/warn!/error!/debug!` with `tracing::` equivalents in `main.rs`, `exporter.rs`, `otlp.rs`, `poller.rs`, and `lifecycle.rs`
- Remove `env_logger::init()` from `main.rs`, replace with `logging::init_bootstrap()`
- Remove `env_logger` and `log` dependencies from `Cargo.toml`

## Verification
- `cargo build -p infmon-frontend` ✅
- `cargo test -p infmon-frontend` — 78 passed ✅
- `cargo clippy -p infmon-frontend` — clean ✅

Closes #119