### PR TITLE
feat: add flow-rule and stats CLI commands with control socket IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror 2.0.18",
@@ -685,6 +686,7 @@ dependencies = [
  "libc",
  "opentelemetry-proto",
  "rand",
+ "serde_json",
  "serde_yaml",
  "signal-hook",
  "syslog-tracing",

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -1,10 +1,18 @@
+use std::path::Path;
 use std::process;
+use std::time::Duration;
 
 use clap::Parser;
 
 use infmon_cli::exit_codes::*;
+use infmon_cli::output::{print_output, TableDisplay};
 use infmon_cli::{
-    Cli, Commands, ConfigCommands, FlowCommands, FlowRuleCommands, LogCommands, StatsCommands,
+    Cli, Commands, ConfigCommands, FlowCommands, FlowRuleCommands, LogCommands, OutputFormat,
+    StatsCommands,
+};
+use infmon_common::ipc::control_client::InFMonControlClient;
+use infmon_common::ipc::protocol::{
+    FlowRuleData, FlowRuleDetailData, StatsShowData,
 };
 
 fn main() {
@@ -137,12 +145,22 @@ async fn run(cli: Cli) -> i32 {
 }
 
 // ---------------------------------------------------------------------------
-// Subcommand implementations (stubs — will await IPC client when wired)
+// Helper: create a control client from CLI args
+// ---------------------------------------------------------------------------
+
+fn make_client(cli: &Cli) -> InFMonControlClient {
+    InFMonControlClient::with_timeout(
+        Path::new(&cli.socket),
+        Duration::from_secs(cli.timeout),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand implementations
 // ---------------------------------------------------------------------------
 
 async fn run_install(force: bool) -> i32 {
     let _ = force;
-    // Check privilege
     if !is_root() {
         eprintln!("infmonctl: install requires root privileges");
         return EXIT_PERMISSION_DENIED;
@@ -213,34 +231,172 @@ async fn run_config(cmd: &ConfigCommands, cli: &Cli) -> i32 {
 }
 
 async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
+    let client = make_client(cli);
+    let output = cli.effective_output();
+
     match cmd {
         FlowRuleCommands::Add { ref spec } => {
             if !is_root() {
                 eprintln!("infmonctl: flow-rule add requires root privileges");
                 return EXIT_PERMISSION_DENIED;
             }
-            let _ = (spec, cli);
-            eprintln!("infmonctl: flow-rule add: not yet implemented (stub)");
-            EXIT_FAILURE
+
+            // Parse spec: name=<name> fields=<f1,f2,...> max_keys=<N>
+            let mut name = None;
+            let mut fields = Vec::new();
+            let mut max_keys = 1024u32;
+
+            for kv in spec {
+                if let Some((k, v)) = kv.split_once('=') {
+                    match k {
+                        "name" => name = Some(v.to_string()),
+                        "fields" => {
+                            for f in v.split(',') {
+                                match f.trim() {
+                                    "src_ip" => fields.push(infmon_common::config::model::Field::SrcIp),
+                                    "dst_ip" => fields.push(infmon_common::config::model::Field::DstIp),
+                                    "ip_proto" => fields.push(infmon_common::config::model::Field::IpProto),
+                                    "dscp" => fields.push(infmon_common::config::model::Field::Dscp),
+                                    "mirror_src_ip" => fields.push(infmon_common::config::model::Field::MirrorSrcIp),
+                                    other => {
+                                        eprintln!("infmonctl: unknown field: {other}");
+                                        return EXIT_USAGE;
+                                    }
+                                }
+                            }
+                        }
+                        "max_keys" => {
+                            max_keys = match v.parse() {
+                                Ok(n) => n,
+                                Err(_) => {
+                                    eprintln!("infmonctl: invalid max_keys: {v}");
+                                    return EXIT_USAGE;
+                                }
+                            };
+                        }
+                        _ => {
+                            eprintln!("infmonctl: unknown spec key: {k}");
+                            return EXIT_USAGE;
+                        }
+                    }
+                } else {
+                    eprintln!("infmonctl: invalid spec format, expected key=value: {kv}");
+                    return EXIT_USAGE;
+                }
+            }
+
+            let name = match name {
+                Some(n) => n,
+                None => {
+                    eprintln!("infmonctl: flow-rule add: name=<name> is required");
+                    return EXIT_USAGE;
+                }
+            };
+
+            if fields.is_empty() {
+                eprintln!("infmonctl: flow-rule add: fields=<field,...> is required");
+                return EXIT_USAGE;
+            }
+
+            let def = infmon_common::ipc::control_client::FlowRuleDef {
+                name: name.clone(),
+                fields,
+                max_keys,
+                eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
+            };
+
+            match client.flow_rule_add(def).await {
+                Ok(id) => {
+                    match output {
+                        OutputFormat::Json => {
+                            println!(
+                                "{}",
+                                serde_json::json!({"id": id.to_string(), "name": name})
+                            );
+                        }
+                        OutputFormat::Table => {
+                            println!("Added flow rule '{}' (id: {})", name, id);
+                        }
+                    }
+                    EXIT_SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("infmonctl: flow-rule add: {e}");
+                    ctl_error_to_exit_code(&e)
+                }
+            }
         }
         FlowRuleCommands::Rm { ref target, all } => {
             if !is_root() {
                 eprintln!("infmonctl: flow-rule rm requires root privileges");
                 return EXIT_PERMISSION_DENIED;
             }
-            let _ = (target, all, cli);
-            eprintln!("infmonctl: flow-rule rm: not yet implemented (stub)");
-            EXIT_FAILURE
+            let _ = all;
+
+            match client.flow_rule_rm(target).await {
+                Ok(()) => {
+                    if !cli.quiet {
+                        eprintln!("Removed flow rule '{target}'");
+                    }
+                    EXIT_SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("infmonctl: flow-rule rm: {e}");
+                    ctl_error_to_exit_code(&e)
+                }
+            }
         }
         FlowRuleCommands::List => {
-            let _ = cli;
-            eprintln!("infmonctl: flow-rule list: not yet implemented (stub)");
-            EXIT_FAILURE
+            match client.flow_rule_list().await {
+                Ok(rules) => {
+                    let data: Vec<FlowRuleData> = rules.iter().map(|r| FlowRuleData {
+                        name: r.name.clone(),
+                        fields: r.fields.clone(),
+                        max_keys: r.max_keys,
+                        eviction_policy: r.eviction_policy,
+                    }).collect();
+                    print_output(&FlowRuleListOutput(data), &output, cli.compact);
+                    EXIT_SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("infmonctl: flow-rule list: {e}");
+                    ctl_error_to_exit_code(&e)
+                }
+            }
         }
         FlowRuleCommands::Show { ref target } => {
-            let _ = (target, cli);
-            eprintln!("infmonctl: flow-rule show: not yet implemented (stub)");
-            EXIT_FAILURE
+            match client.flow_rule_show(target).await {
+                Ok(stats) => {
+                    // Use protocol types for JSON output
+                    let detail = FlowRuleDetailData {
+                        name: stats.name,
+                        fields: stats.fields.iter().filter_map(field_id_to_field).collect(),
+                        max_keys: 0, // not available from FlowRuleStats
+                        eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
+                        counters: infmon_common::ipc::protocol::FlowRuleCountersData {
+                            packets: stats.counters.packets,
+                            bytes: stats.counters.bytes,
+                            evictions: stats.counters.evictions,
+                            drops: stats.counters.drops,
+                        },
+                        flows: stats.flows.iter().map(|f| {
+                            infmon_common::ipc::protocol::FlowEntryData {
+                                key: f.key.iter().map(|v| format!("{:?}", v)).collect(),
+                                packets: f.counters.packets,
+                                bytes: f.counters.bytes,
+                                first_seen_ns: f.counters.first_seen_ns,
+                                last_seen_ns: f.counters.last_seen_ns,
+                            }
+                        }).collect(),
+                    };
+                    print_output(&FlowRuleShowOutput(detail), &output, cli.compact);
+                    EXIT_SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("infmonctl: flow-rule show: {e}");
+                    ctl_error_to_exit_code(&e)
+                }
+            }
         }
     }
 }
@@ -265,15 +421,27 @@ async fn run_flow(cmd: &FlowCommands, cli: &Cli) -> i32 {
 }
 
 async fn run_stats(cmd: &StatsCommands, cli: &Cli) -> i32 {
+    let client = make_client(cli);
+    let output = cli.effective_output();
+
     match cmd {
         StatsCommands::Show {
             ref name,
             top,
             ref watch,
         } => {
-            let _ = (name, top, watch, cli);
-            eprintln!("infmonctl: stats show: not yet implemented (stub)");
-            EXIT_FAILURE
+            let _ = (top, watch);
+
+            match client.stats_show(name.as_deref()).await {
+                Ok(data) => {
+                    print_output(&StatsShowOutput(data), &output, cli.compact);
+                    EXIT_SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("infmonctl: stats show: {e}");
+                    ctl_error_to_exit_code(&e)
+                }
+            }
         }
         StatsCommands::Export { ref format } => {
             let _ = (format, cli);
@@ -312,6 +480,73 @@ async fn run_health(cli: &Cli) -> i32 {
 }
 
 // ---------------------------------------------------------------------------
+// Output types with TableDisplay + Serialize
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Serialize)]
+struct FlowRuleListOutput(Vec<FlowRuleData>);
+
+impl TableDisplay for FlowRuleListOutput {
+    fn print_table(&self) {
+        if self.0.is_empty() {
+            println!("No flow rules configured.");
+            return;
+        }
+        println!("{:<20} {:<30} {:>10}", "NAME", "FIELDS", "MAX_KEYS");
+        for r in &self.0 {
+            let fields: Vec<String> = r.fields.iter().map(|f| format!("{:?}", f).to_lowercase()).collect();
+            println!("{:<20} {:<30} {:>10}", r.name, fields.join(","), r.max_keys);
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct FlowRuleShowOutput(FlowRuleDetailData);
+
+impl TableDisplay for FlowRuleShowOutput {
+    fn print_table(&self) {
+        let d = &self.0;
+        println!("Name:       {}", d.name);
+        let fields: Vec<String> = d.fields.iter().map(|f| format!("{:?}", f).to_lowercase()).collect();
+        println!("Fields:     {}", fields.join(", "));
+        println!("Max keys:   {}", d.max_keys);
+        println!("Counters:");
+        println!("  Packets:    {}", d.counters.packets);
+        println!("  Bytes:      {}", d.counters.bytes);
+        println!("  Evictions:  {}", d.counters.evictions);
+        println!("  Drops:      {}", d.counters.drops);
+        if !d.flows.is_empty() {
+            println!("Flows ({}):", d.flows.len());
+            for f in &d.flows {
+                println!("  Key: {}  Pkts: {}  Bytes: {}", f.key.join(","), f.packets, f.bytes);
+            }
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct StatsShowOutput(StatsShowData);
+
+impl TableDisplay for StatsShowOutput {
+    fn print_table(&self) {
+        if self.0.flow_rules.is_empty() {
+            println!("No flow rule stats available.");
+            return;
+        }
+        println!(
+            "{:<20} {:>12} {:>12} {:>10} {:>8} {:>8}",
+            "RULE", "PACKETS", "BYTES", "FLOWS", "EVICT", "DROPS"
+        );
+        for r in &self.0.flow_rules {
+            println!(
+                "{:<20} {:>12} {:>12} {:>10} {:>8} {:>8}",
+                r.name, r.packets, r.bytes, r.active_flows, r.evictions, r.drops
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -323,5 +558,32 @@ fn is_root() -> bool {
     #[cfg(not(unix))]
     {
         false
+    }
+}
+
+fn ctl_error_to_exit_code(e: &infmon_common::ipc::CtlError) -> i32 {
+    use infmon_common::ipc::CtlError;
+    match e {
+        CtlError::Connect(_) => EXIT_FRONTEND_UNREACHABLE,
+        CtlError::Backend { code, .. } => {
+            match *code {
+                3 => EXIT_NOT_FOUND,
+                6 => EXIT_CONFLICT,
+                _ => EXIT_FAILURE,
+            }
+        }
+        _ => EXIT_FAILURE,
+    }
+}
+
+fn field_id_to_field(id: &infmon_common::ipc::types::FieldId) -> Option<infmon_common::config::model::Field> {
+    use infmon_common::config::model::Field;
+    use infmon_common::ipc::types::FieldId;
+    match id {
+        FieldId::SrcIp => Some(Field::SrcIp),
+        FieldId::DstIp => Some(Field::DstIp),
+        FieldId::IpProto => Some(Field::IpProto),
+        FieldId::Dscp => Some(Field::Dscp),
+        FieldId::MirrorSrcIp => Some(Field::MirrorSrcIp),
     }
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -11,9 +11,7 @@ use infmon_cli::{
     StatsCommands,
 };
 use infmon_common::ipc::control_client::InFMonControlClient;
-use infmon_common::ipc::protocol::{
-    FlowRuleData, FlowRuleDetailData, StatsShowData,
-};
+use infmon_common::ipc::protocol::{FlowRuleData, FlowRuleDetailData, StatsShowData};
 
 fn main() {
     // Handle --generate-completions and --generate-manpage before clap
@@ -149,10 +147,7 @@ async fn run(cli: Cli) -> i32 {
 // ---------------------------------------------------------------------------
 
 fn make_client(cli: &Cli) -> InFMonControlClient {
-    InFMonControlClient::with_timeout(
-        Path::new(&cli.socket),
-        Duration::from_secs(cli.timeout),
-    )
+    InFMonControlClient::with_timeout(Path::new(&cli.socket), Duration::from_secs(cli.timeout))
 }
 
 // ---------------------------------------------------------------------------
@@ -253,11 +248,20 @@ async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
                         "fields" => {
                             for f in v.split(',') {
                                 match f.trim() {
-                                    "src_ip" => fields.push(infmon_common::config::model::Field::SrcIp),
-                                    "dst_ip" => fields.push(infmon_common::config::model::Field::DstIp),
-                                    "ip_proto" => fields.push(infmon_common::config::model::Field::IpProto),
-                                    "dscp" => fields.push(infmon_common::config::model::Field::Dscp),
-                                    "mirror_src_ip" => fields.push(infmon_common::config::model::Field::MirrorSrcIp),
+                                    "src_ip" => {
+                                        fields.push(infmon_common::config::model::Field::SrcIp)
+                                    }
+                                    "dst_ip" => {
+                                        fields.push(infmon_common::config::model::Field::DstIp)
+                                    }
+                                    "ip_proto" => {
+                                        fields.push(infmon_common::config::model::Field::IpProto)
+                                    }
+                                    "dscp" => {
+                                        fields.push(infmon_common::config::model::Field::Dscp)
+                                    }
+                                    "mirror_src_ip" => fields
+                                        .push(infmon_common::config::model::Field::MirrorSrcIp),
                                     other => {
                                         eprintln!("infmonctl: unknown field: {other}");
                                         return EXIT_USAGE;
@@ -346,24 +350,25 @@ async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
                 }
             }
         }
-        FlowRuleCommands::List => {
-            match client.flow_rule_list().await {
-                Ok(rules) => {
-                    let data: Vec<FlowRuleData> = rules.iter().map(|r| FlowRuleData {
+        FlowRuleCommands::List => match client.flow_rule_list().await {
+            Ok(rules) => {
+                let data: Vec<FlowRuleData> = rules
+                    .iter()
+                    .map(|r| FlowRuleData {
                         name: r.name.clone(),
                         fields: r.fields.clone(),
                         max_keys: r.max_keys,
                         eviction_policy: r.eviction_policy,
-                    }).collect();
-                    print_output(&FlowRuleListOutput(data), &output, cli.compact);
-                    EXIT_SUCCESS
-                }
-                Err(e) => {
-                    eprintln!("infmonctl: flow-rule list: {e}");
-                    ctl_error_to_exit_code(&e)
-                }
+                    })
+                    .collect();
+                print_output(&FlowRuleListOutput(data), &output, cli.compact);
+                EXIT_SUCCESS
             }
-        }
+            Err(e) => {
+                eprintln!("infmonctl: flow-rule list: {e}");
+                ctl_error_to_exit_code(&e)
+            }
+        },
         FlowRuleCommands::Show { ref target } => {
             match client.flow_rule_show(target).await {
                 Ok(stats) => {
@@ -379,15 +384,17 @@ async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
                             evictions: stats.counters.evictions,
                             drops: stats.counters.drops,
                         },
-                        flows: stats.flows.iter().map(|f| {
-                            infmon_common::ipc::protocol::FlowEntryData {
+                        flows: stats
+                            .flows
+                            .iter()
+                            .map(|f| infmon_common::ipc::protocol::FlowEntryData {
                                 key: f.key.iter().map(|v| format!("{:?}", v)).collect(),
                                 packets: f.counters.packets,
                                 bytes: f.counters.bytes,
                                 first_seen_ns: f.counters.first_seen_ns,
                                 last_seen_ns: f.counters.last_seen_ns,
-                            }
-                        }).collect(),
+                            })
+                            .collect(),
                     };
                     print_output(&FlowRuleShowOutput(detail), &output, cli.compact);
                     EXIT_SUCCESS
@@ -494,7 +501,11 @@ impl TableDisplay for FlowRuleListOutput {
         }
         println!("{:<20} {:<30} {:>10}", "NAME", "FIELDS", "MAX_KEYS");
         for r in &self.0 {
-            let fields: Vec<String> = r.fields.iter().map(|f| format!("{:?}", f).to_lowercase()).collect();
+            let fields: Vec<String> = r
+                .fields
+                .iter()
+                .map(|f| format!("{:?}", f).to_lowercase())
+                .collect();
             println!("{:<20} {:<30} {:>10}", r.name, fields.join(","), r.max_keys);
         }
     }
@@ -507,7 +518,11 @@ impl TableDisplay for FlowRuleShowOutput {
     fn print_table(&self) {
         let d = &self.0;
         println!("Name:       {}", d.name);
-        let fields: Vec<String> = d.fields.iter().map(|f| format!("{:?}", f).to_lowercase()).collect();
+        let fields: Vec<String> = d
+            .fields
+            .iter()
+            .map(|f| format!("{:?}", f).to_lowercase())
+            .collect();
         println!("Fields:     {}", fields.join(", "));
         println!("Max keys:   {}", d.max_keys);
         println!("Counters:");
@@ -518,7 +533,12 @@ impl TableDisplay for FlowRuleShowOutput {
         if !d.flows.is_empty() {
             println!("Flows ({}):", d.flows.len());
             for f in &d.flows {
-                println!("  Key: {}  Pkts: {}  Bytes: {}", f.key.join(","), f.packets, f.bytes);
+                println!(
+                    "  Key: {}  Pkts: {}  Bytes: {}",
+                    f.key.join(","),
+                    f.packets,
+                    f.bytes
+                );
             }
         }
     }
@@ -565,18 +585,18 @@ fn ctl_error_to_exit_code(e: &infmon_common::ipc::CtlError) -> i32 {
     use infmon_common::ipc::CtlError;
     match e {
         CtlError::Connect(_) => EXIT_FRONTEND_UNREACHABLE,
-        CtlError::Backend { code, .. } => {
-            match *code {
-                3 => EXIT_NOT_FOUND,
-                6 => EXIT_CONFLICT,
-                _ => EXIT_FAILURE,
-            }
-        }
+        CtlError::Backend { code, .. } => match *code {
+            3 => EXIT_NOT_FOUND,
+            6 => EXIT_CONFLICT,
+            _ => EXIT_FAILURE,
+        },
         _ => EXIT_FAILURE,
     }
 }
 
-fn field_id_to_field(id: &infmon_common::ipc::types::FieldId) -> Option<infmon_common::config::model::Field> {
+fn field_id_to_field(
+    id: &infmon_common::ipc::types::FieldId,
+) -> Option<infmon_common::config::model::Field> {
     use infmon_common::config::model::Field;
     use infmon_common::ipc::types::FieldId;
     match id {

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -335,7 +335,10 @@ async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
                 eprintln!("infmonctl: flow-rule rm requires root privileges");
                 return EXIT_PERMISSION_DENIED;
             }
-            let _ = all;
+            if *all {
+                eprintln!("infmonctl: flow-rule rm --all: not yet implemented");
+                return EXIT_FAILURE;
+            }
 
             match client.flow_rule_rm(target).await {
                 Ok(()) => {
@@ -369,42 +372,39 @@ async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
                 ctl_error_to_exit_code(&e)
             }
         },
-        FlowRuleCommands::Show { ref target } => {
-            match client.flow_rule_show(target).await {
-                Ok(stats) => {
-                    // Use protocol types for JSON output
-                    let detail = FlowRuleDetailData {
-                        name: stats.name,
-                        fields: stats.fields.iter().filter_map(field_id_to_field).collect(),
-                        max_keys: 0, // not available from FlowRuleStats
-                        eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
-                        counters: infmon_common::ipc::protocol::FlowRuleCountersData {
-                            packets: stats.counters.packets,
-                            bytes: stats.counters.bytes,
-                            evictions: stats.counters.evictions,
-                            drops: stats.counters.drops,
-                        },
-                        flows: stats
-                            .flows
-                            .iter()
-                            .map(|f| infmon_common::ipc::protocol::FlowEntryData {
-                                key: f.key.iter().map(|v| format!("{:?}", v)).collect(),
-                                packets: f.counters.packets,
-                                bytes: f.counters.bytes,
-                                first_seen_ns: f.counters.first_seen_ns,
-                                last_seen_ns: f.counters.last_seen_ns,
-                            })
-                            .collect(),
-                    };
-                    print_output(&FlowRuleShowOutput(detail), &output, cli.compact);
-                    EXIT_SUCCESS
-                }
-                Err(e) => {
-                    eprintln!("infmonctl: flow-rule show: {e}");
-                    ctl_error_to_exit_code(&e)
-                }
+        FlowRuleCommands::Show { ref target } => match client.flow_rule_show(target).await {
+            Ok(stats) => {
+                let detail = FlowRuleDetailData {
+                    name: stats.name,
+                    fields: stats.fields.iter().map(field_id_to_field).collect(),
+                    max_keys: stats.max_keys,
+                    eviction_policy: stats.eviction_policy,
+                    counters: infmon_common::ipc::protocol::FlowRuleCountersData {
+                        packets: stats.counters.packets,
+                        bytes: stats.counters.bytes,
+                        evictions: stats.counters.evictions,
+                        drops: stats.counters.drops,
+                    },
+                    flows: stats
+                        .flows
+                        .iter()
+                        .map(|f| infmon_common::ipc::protocol::FlowEntryData {
+                            key: f.key.iter().map(|v| format!("{:?}", v)).collect(),
+                            packets: f.counters.packets,
+                            bytes: f.counters.bytes,
+                            first_seen_ns: f.counters.first_seen_ns,
+                            last_seen_ns: f.counters.last_seen_ns,
+                        })
+                        .collect(),
+                };
+                print_output(&FlowRuleShowOutput(detail), &output, cli.compact);
+                EXIT_SUCCESS
             }
-        }
+            Err(e) => {
+                eprintln!("infmonctl: flow-rule show: {e}");
+                ctl_error_to_exit_code(&e)
+            }
+        },
     }
 }
 
@@ -437,7 +437,12 @@ async fn run_stats(cmd: &StatsCommands, cli: &Cli) -> i32 {
             top,
             ref watch,
         } => {
-            let _ = (top, watch);
+            if *top > 0 {
+                eprintln!("infmonctl: stats show --top: not yet implemented, showing all");
+            }
+            if watch.is_some() {
+                eprintln!("infmonctl: stats show --watch: not yet implemented, showing once");
+            }
 
             match client.stats_show(name.as_deref()).await {
                 Ok(data) => {
@@ -596,14 +601,14 @@ fn ctl_error_to_exit_code(e: &infmon_common::ipc::CtlError) -> i32 {
 
 fn field_id_to_field(
     id: &infmon_common::ipc::types::FieldId,
-) -> Option<infmon_common::config::model::Field> {
+) -> infmon_common::config::model::Field {
     use infmon_common::config::model::Field;
     use infmon_common::ipc::types::FieldId;
     match id {
-        FieldId::SrcIp => Some(Field::SrcIp),
-        FieldId::DstIp => Some(Field::DstIp),
-        FieldId::IpProto => Some(Field::IpProto),
-        FieldId::Dscp => Some(Field::Dscp),
-        FieldId::MirrorSrcIp => Some(Field::MirrorSrcIp),
+        FieldId::SrcIp => Field::SrcIp,
+        FieldId::DstIp => Field::DstIp,
+        FieldId::IpProto => Field::IpProto,
+        FieldId::Dscp => Field::Dscp,
+        FieldId::MirrorSrcIp => Field::MirrorSrcIp,
     }
 }

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -240,6 +240,7 @@ async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
             let mut name = None;
             let mut fields = Vec::new();
             let mut max_keys = 1024u32;
+            let mut eviction_policy = infmon_common::config::model::EvictionPolicy::LruDrop;
 
             for kv in spec {
                 if let Some((k, v)) = kv.split_once('=') {
@@ -278,6 +279,15 @@ async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
                                 }
                             };
                         }
+                        "eviction_policy" => {
+                            eviction_policy = match v {
+                                "lru_drop" => infmon_common::config::model::EvictionPolicy::LruDrop,
+                                other => {
+                                    eprintln!("infmonctl: unknown eviction_policy: {other} (supported: lru_drop)");
+                                    return EXIT_USAGE;
+                                }
+                            };
+                        }
                         _ => {
                             eprintln!("infmonctl: unknown spec key: {k}");
                             return EXIT_USAGE;
@@ -306,7 +316,7 @@ async fn run_flow_rule(cmd: &FlowRuleCommands, cli: &Cli) -> i32 {
                 name: name.clone(),
                 fields,
                 max_keys,
-                eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
+                eviction_policy,
             };
 
             match client.flow_rule_add(def).await {

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -14,9 +14,10 @@ control = ["dep:tokio"]
 [dependencies]
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_yaml = "0.9"
 thiserror = "2"
-tokio = { version = "1", features = ["net", "rt", "sync"], optional = true }
+tokio = { version = "1", features = ["net", "rt", "sync", "io-util", "time"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/common/src/ipc/control_client.rs
+++ b/src/common/src/ipc/control_client.rs
@@ -48,6 +48,23 @@ impl InFMonControlClient {
         }
     }
 
+    /// Send a request, receive a response, and check for errors.
+    /// Returns the optional response data on success, or a `CtlError` on failure.
+    async fn rpc_ok(&self, request: &Request) -> Result<Option<ResponseData>, CtlError> {
+        let resp = self.rpc(request).await?;
+        if !resp.ok {
+            let err = resp.error.unwrap_or(ErrorData {
+                code: -1,
+                message: "unknown error".into(),
+            });
+            return Err(CtlError::Backend {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        Ok(resp.data)
+    }
+
     /// Send a request and receive a response over the Unix socket.
     async fn rpc(&self, request: &Request) -> Result<Response, CtlError> {
         let stream = tokio::time::timeout(self.timeout, UnixStream::connect(&self.socket_path))
@@ -102,18 +119,7 @@ impl InFMonControlClient {
             max_keys: def.max_keys,
             eviction_policy: def.eviction_policy,
         });
-        let resp = self.rpc(&request).await?;
-        if !resp.ok {
-            let err = resp.error.unwrap_or(ErrorData {
-                code: -1,
-                message: "unknown error".into(),
-            });
-            return Err(CtlError::Backend {
-                code: err.code,
-                message: err.message,
-            });
-        }
-        match resp.data {
+        match self.rpc_ok(&request).await? {
             Some(ResponseData::FlowRuleId(id_data)) => id_data
                 .id
                 .parse::<FlowRuleId>()
@@ -127,35 +133,14 @@ impl InFMonControlClient {
         let request = Request::FlowRuleRm(FlowRuleRmParams {
             name: name.to_string(),
         });
-        let resp = self.rpc(&request).await?;
-        if !resp.ok {
-            let err = resp.error.unwrap_or(ErrorData {
-                code: -1,
-                message: "unknown error".into(),
-            });
-            return Err(CtlError::Backend {
-                code: err.code,
-                message: err.message,
-            });
-        }
+        self.rpc_ok(&request).await?;
         Ok(())
     }
 
     /// List all flow rules.
     pub async fn flow_rule_list(&self) -> Result<Vec<FlowRuleDef>, CtlError> {
         let request = Request::FlowRuleList;
-        let resp = self.rpc(&request).await?;
-        if !resp.ok {
-            let err = resp.error.unwrap_or(ErrorData {
-                code: -1,
-                message: "unknown error".into(),
-            });
-            return Err(CtlError::Backend {
-                code: err.code,
-                message: err.message,
-            });
-        }
-        match resp.data {
+        match self.rpc_ok(&request).await? {
             Some(ResponseData::FlowRuleList(rules)) => Ok(rules
                 .into_iter()
                 .map(|r| FlowRuleDef {
@@ -174,26 +159,17 @@ impl InFMonControlClient {
         let request = Request::FlowRuleShow(FlowRuleShowParams {
             name: name.to_string(),
         });
-        let resp = self.rpc(&request).await?;
-        if !resp.ok {
-            let err = resp.error.unwrap_or(ErrorData {
-                code: -1,
-                message: "unknown error".into(),
-            });
-            return Err(CtlError::Backend {
-                code: err.code,
-                message: err.message,
-            });
-        }
-        match resp.data {
+        match self.rpc_ok(&request).await? {
             Some(ResponseData::FlowRuleDetail(detail)) => Ok(FlowRuleStats {
                 name: detail.name,
                 fields: detail.fields.iter().filter_map(field_to_field_id).collect(),
+                max_keys: detail.max_keys,
+                eviction_policy: detail.eviction_policy,
                 flows: detail
                     .flows
                     .into_iter()
                     .map(|f| FlowStats {
-                        key: f.key.iter().map(|_k| FieldValue::Proto(0)).collect(), // simplified
+                        key: f.key.iter().map(|_k| FieldValue::Proto(0)).collect(), // simplified: wire keys are strings, lossless round-trip deferred
                         counters: FlowCounters {
                             packets: f.packets,
                             bytes: f.bytes,
@@ -218,18 +194,7 @@ impl InFMonControlClient {
         let request = Request::StatsShow(StatsShowParams {
             name: name.map(|s| s.to_string()),
         });
-        let resp = self.rpc(&request).await?;
-        if !resp.ok {
-            let err = resp.error.unwrap_or(ErrorData {
-                code: -1,
-                message: "unknown error".into(),
-            });
-            return Err(CtlError::Backend {
-                code: err.code,
-                message: err.message,
-            });
-        }
-        match resp.data {
+        match self.rpc_ok(&request).await? {
             Some(ResponseData::StatsShow(data)) => Ok(data),
             _ => Err(CtlError::Protocol("unexpected response data".into())),
         }

--- a/src/common/src/ipc/control_client.rs
+++ b/src/common/src/ipc/control_client.rs
@@ -1,7 +1,14 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
 
 use super::error::CtlError;
-use super::types::{FlowRuleId, FlowRuleStats};
+use super::protocol::*;
+use super::types::{
+    FieldId, FieldValue, FlowCounters, FlowRuleCounters, FlowRuleId, FlowRuleStats, FlowStats,
+};
 
 // Re-export FlowRule from infmon-config so CLI/frontend use one type
 pub use crate::config::model::{EvictionPolicy, Field, FlowRule as FlowRuleDef};
@@ -18,6 +25,7 @@ pub struct ExporterStatus {
 
 pub struct InFMonControlClient {
     socket_path: PathBuf,
+    timeout: Duration,
 }
 
 impl InFMonControlClient {
@@ -28,31 +36,210 @@ impl InFMonControlClient {
     pub fn new(path: &Path) -> Self {
         Self {
             socket_path: path.to_path_buf(),
+            timeout: Duration::from_secs(5),
         }
+    }
+
+    /// Create a new control client with a custom timeout.
+    pub fn with_timeout(path: &Path, timeout: Duration) -> Self {
+        Self {
+            socket_path: path.to_path_buf(),
+            timeout,
+        }
+    }
+
+    /// Send a request and receive a response over the Unix socket.
+    async fn rpc(&self, request: &Request) -> Result<Response, CtlError> {
+        let stream = tokio::time::timeout(self.timeout, UnixStream::connect(&self.socket_path))
+            .await
+            .map_err(|_| {
+                CtlError::Connect(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "connection timed out",
+                ))
+            })?
+            .map_err(CtlError::Connect)?;
+
+        let (reader, mut writer) = stream.into_split();
+
+        let mut line = serde_json::to_string(request)
+            .map_err(|e| CtlError::Protocol(format!("serialize request: {e}")))?;
+        line.push('\n');
+
+        tokio::time::timeout(self.timeout, writer.write_all(line.as_bytes()))
+            .await
+            .map_err(|_| {
+                CtlError::Io(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "write timed out",
+                ))
+            })?
+            .map_err(CtlError::Io)?;
+
+        let mut buf_reader = BufReader::new(reader);
+        let mut response_line = String::new();
+        tokio::time::timeout(self.timeout, buf_reader.read_line(&mut response_line))
+            .await
+            .map_err(|_| {
+                CtlError::Io(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "read timed out",
+                ))
+            })?
+            .map_err(CtlError::Io)?;
+
+        let response: Response = serde_json::from_str(&response_line)
+            .map_err(|e| CtlError::Protocol(format!("deserialize response: {e}")))?;
+
+        Ok(response)
     }
 
     /// Add a flow rule to the backend.
     pub async fn flow_rule_add(&self, def: FlowRuleDef) -> Result<FlowRuleId, CtlError> {
-        let _ = (&self.socket_path, &def);
-        Err(CtlError::Request("not implemented (stub)".into()))
+        let request = Request::FlowRuleAdd(FlowRuleAddParams {
+            name: def.name,
+            fields: def.fields,
+            max_keys: def.max_keys,
+            eviction_policy: def.eviction_policy,
+        });
+        let resp = self.rpc(&request).await?;
+        if !resp.ok {
+            let err = resp.error.unwrap_or(ErrorData {
+                code: -1,
+                message: "unknown error".into(),
+            });
+            return Err(CtlError::Backend {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        match resp.data {
+            Some(ResponseData::FlowRuleId(id_data)) => id_data
+                .id
+                .parse::<FlowRuleId>()
+                .map_err(|e| CtlError::Protocol(format!("invalid FlowRuleId: {e}"))),
+            _ => Err(CtlError::Protocol("unexpected response data".into())),
+        }
     }
 
     /// Remove a flow rule by name.
     pub async fn flow_rule_rm(&self, name: &str) -> Result<(), CtlError> {
-        let _ = (&self.socket_path, name);
-        Err(CtlError::Request("not implemented (stub)".into()))
+        let request = Request::FlowRuleRm(FlowRuleRmParams {
+            name: name.to_string(),
+        });
+        let resp = self.rpc(&request).await?;
+        if !resp.ok {
+            let err = resp.error.unwrap_or(ErrorData {
+                code: -1,
+                message: "unknown error".into(),
+            });
+            return Err(CtlError::Backend {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        Ok(())
     }
 
     /// List all flow rules.
     pub async fn flow_rule_list(&self) -> Result<Vec<FlowRuleDef>, CtlError> {
-        let _ = &self.socket_path;
-        Err(CtlError::Request("not implemented (stub)".into()))
+        let request = Request::FlowRuleList;
+        let resp = self.rpc(&request).await?;
+        if !resp.ok {
+            let err = resp.error.unwrap_or(ErrorData {
+                code: -1,
+                message: "unknown error".into(),
+            });
+            return Err(CtlError::Backend {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        match resp.data {
+            Some(ResponseData::FlowRuleList(rules)) => Ok(rules
+                .into_iter()
+                .map(|r| FlowRuleDef {
+                    name: r.name,
+                    fields: r.fields,
+                    max_keys: r.max_keys,
+                    eviction_policy: r.eviction_policy,
+                })
+                .collect()),
+            _ => Err(CtlError::Protocol("unexpected response data".into())),
+        }
     }
 
     /// Show detailed stats for one flow rule.
     pub async fn flow_rule_show(&self, name: &str) -> Result<FlowRuleStats, CtlError> {
-        let _ = (&self.socket_path, name);
-        Err(CtlError::Request("not implemented (stub)".into()))
+        let request = Request::FlowRuleShow(FlowRuleShowParams {
+            name: name.to_string(),
+        });
+        let resp = self.rpc(&request).await?;
+        if !resp.ok {
+            let err = resp.error.unwrap_or(ErrorData {
+                code: -1,
+                message: "unknown error".into(),
+            });
+            return Err(CtlError::Backend {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        match resp.data {
+            Some(ResponseData::FlowRuleDetail(detail)) => Ok(FlowRuleStats {
+                name: detail.name,
+                fields: detail
+                    .fields
+                    .iter()
+                    .filter_map(field_to_field_id)
+                    .collect(),
+                flows: detail
+                    .flows
+                    .into_iter()
+                    .map(|f| FlowStats {
+                        key: f.key.iter().map(|_k| FieldValue::Proto(0)).collect(), // simplified
+                        counters: FlowCounters {
+                            packets: f.packets,
+                            bytes: f.bytes,
+                            first_seen_ns: f.first_seen_ns,
+                            last_seen_ns: f.last_seen_ns,
+                        },
+                    })
+                    .collect(),
+                counters: FlowRuleCounters {
+                    packets: detail.counters.packets,
+                    bytes: detail.counters.bytes,
+                    evictions: detail.counters.evictions,
+                    drops: detail.counters.drops,
+                },
+            }),
+            _ => Err(CtlError::Protocol("unexpected response data".into())),
+        }
+    }
+
+    /// Show aggregate stats (optionally filtered by name).
+    pub async fn stats_show(
+        &self,
+        name: Option<&str>,
+    ) -> Result<StatsShowData, CtlError> {
+        let request = Request::StatsShow(StatsShowParams {
+            name: name.map(|s| s.to_string()),
+        });
+        let resp = self.rpc(&request).await?;
+        if !resp.ok {
+            let err = resp.error.unwrap_or(ErrorData {
+                code: -1,
+                message: "unknown error".into(),
+            });
+            return Err(CtlError::Backend {
+                code: err.code,
+                message: err.message,
+            });
+        }
+        match resp.data {
+            Some(ResponseData::StatsShow(data)) => Ok(data),
+            _ => Err(CtlError::Protocol("unexpected response data".into())),
+        }
     }
 
     /// Trigger a config reload on the frontend.
@@ -70,6 +257,16 @@ impl InFMonControlClient {
     /// Path to the control socket.
     pub fn path(&self) -> &Path {
         &self.socket_path
+    }
+}
+
+fn field_to_field_id(f: &Field) -> Option<FieldId> {
+    match f {
+        Field::SrcIp => Some(FieldId::SrcIp),
+        Field::DstIp => Some(FieldId::DstIp),
+        Field::IpProto => Some(FieldId::IpProto),
+        Field::Dscp => Some(FieldId::Dscp),
+        Field::MirrorSrcIp => Some(FieldId::MirrorSrcIp),
     }
 }
 

--- a/src/common/src/ipc/control_client.rs
+++ b/src/common/src/ipc/control_client.rs
@@ -188,11 +188,7 @@ impl InFMonControlClient {
         match resp.data {
             Some(ResponseData::FlowRuleDetail(detail)) => Ok(FlowRuleStats {
                 name: detail.name,
-                fields: detail
-                    .fields
-                    .iter()
-                    .filter_map(field_to_field_id)
-                    .collect(),
+                fields: detail.fields.iter().filter_map(field_to_field_id).collect(),
                 flows: detail
                     .flows
                     .into_iter()
@@ -218,10 +214,7 @@ impl InFMonControlClient {
     }
 
     /// Show aggregate stats (optionally filtered by name).
-    pub async fn stats_show(
-        &self,
-        name: Option<&str>,
-    ) -> Result<StatsShowData, CtlError> {
+    pub async fn stats_show(&self, name: Option<&str>) -> Result<StatsShowData, CtlError> {
         let request = Request::StatsShow(StatsShowParams {
             name: name.map(|s| s.to_string()),
         });

--- a/src/common/src/ipc/control_client.rs
+++ b/src/common/src/ipc/control_client.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
 
 use super::error::CtlError;
@@ -93,7 +93,10 @@ impl InFMonControlClient {
             })?
             .map_err(CtlError::Io)?;
 
-        let mut buf_reader = BufReader::new(reader);
+        // Cap response read at 64 KiB to prevent OOM from a buggy/compromised server.
+        const MAX_RESPONSE: u64 = 64 * 1024;
+        let limited_reader = reader.take(MAX_RESPONSE);
+        let mut buf_reader = BufReader::new(limited_reader);
         let mut response_line = String::new();
         tokio::time::timeout(self.timeout, buf_reader.read_line(&mut response_line))
             .await

--- a/src/common/src/ipc/mod.rs
+++ b/src/common/src/ipc/mod.rs
@@ -2,6 +2,7 @@
 pub mod control_client;
 pub mod decode;
 pub mod error;
+pub mod protocol;
 pub mod stats_client;
 pub mod types;
 

--- a/src/common/src/ipc/protocol.rs
+++ b/src/common/src/ipc/protocol.rs
@@ -60,7 +60,7 @@ pub struct ErrorData {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
 pub enum ResponseData {
     FlowRuleId(FlowRuleIdData),
     FlowRuleList(Vec<FlowRuleData>),

--- a/src/common/src/ipc/protocol.rs
+++ b/src/common/src/ipc/protocol.rs
@@ -1,0 +1,166 @@
+//! JSON-line protocol for CLI ↔ frontend control socket.
+//!
+//! Each message is a single JSON object terminated by `\n`.
+//! The client sends a [`Request`], the server replies with a [`Response`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::model::{EvictionPolicy, Field, FlowRule};
+
+// ── Requests ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "method", content = "params", rename_all = "snake_case")]
+pub enum Request {
+    FlowRuleAdd(FlowRuleAddParams),
+    FlowRuleRm(FlowRuleRmParams),
+    FlowRuleList,
+    FlowRuleShow(FlowRuleShowParams),
+    StatsShow(StatsShowParams),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowRuleAddParams {
+    pub name: String,
+    pub fields: Vec<Field>,
+    pub max_keys: u32,
+    pub eviction_policy: EvictionPolicy,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowRuleRmParams {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowRuleShowParams {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatsShowParams {
+    pub name: Option<String>,
+}
+
+// ── Responses ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Response {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<ResponseData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorData>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ErrorData {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ResponseData {
+    FlowRuleId(FlowRuleIdData),
+    FlowRuleList(Vec<FlowRuleData>),
+    FlowRuleDetail(FlowRuleDetailData),
+    StatsShow(StatsShowData),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowRuleIdData {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlowRuleData {
+    pub name: String,
+    pub fields: Vec<Field>,
+    pub max_keys: u32,
+    pub eviction_policy: EvictionPolicy,
+}
+
+impl From<&FlowRule> for FlowRuleData {
+    fn from(r: &FlowRule) -> Self {
+        Self {
+            name: r.name.clone(),
+            fields: r.fields.clone(),
+            max_keys: r.max_keys,
+            eviction_policy: r.eviction_policy,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowRuleDetailData {
+    pub name: String,
+    pub fields: Vec<Field>,
+    pub max_keys: u32,
+    pub eviction_policy: EvictionPolicy,
+    pub counters: FlowRuleCountersData,
+    pub flows: Vec<FlowEntryData>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowRuleCountersData {
+    pub packets: u64,
+    pub bytes: u64,
+    pub evictions: u64,
+    pub drops: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowEntryData {
+    pub key: Vec<String>,
+    pub packets: u64,
+    pub bytes: u64,
+    pub first_seen_ns: u64,
+    pub last_seen_ns: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatsShowData {
+    pub flow_rules: Vec<FlowRuleStatsData>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowRuleStatsData {
+    pub name: String,
+    pub packets: u64,
+    pub bytes: u64,
+    pub evictions: u64,
+    pub drops: u64,
+    pub active_flows: u64,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+impl Response {
+    pub fn ok(data: ResponseData) -> Self {
+        Self {
+            ok: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    pub fn ok_empty() -> Self {
+        Self {
+            ok: true,
+            data: None,
+            error: None,
+        }
+    }
+
+    pub fn err(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            data: None,
+            error: Some(ErrorData {
+                code,
+                message: message.into(),
+            }),
+        }
+    }
+}

--- a/src/common/src/ipc/types.rs
+++ b/src/common/src/ipc/types.rs
@@ -86,6 +86,8 @@ pub struct FlowRuleCounters {
 pub struct FlowRuleStats {
     pub name: String,
     pub fields: Vec<FieldId>,
+    pub max_keys: u32,
+    pub eviction_policy: crate::config::model::EvictionPolicy,
     pub flows: Vec<FlowStats>,
     pub counters: FlowRuleCounters,
 }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -11,9 +11,10 @@ path = "src/main.rs"
 
 [dependencies]
 hostname = "0.4"
-infmon-common = { path = "../common", default-features = false }
+infmon-common = { path = "../common" }
 inventory = "0.3"
 libc = "0.2"
+serde_json = "1"
 syslog-tracing = "0.3"
 tracing = "0.1"
 tracing-appender = "0.2"

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -79,6 +79,14 @@ pub fn spawn(socket_path: &Path, state: Arc<ControlState>) -> std::io::Result<Co
     let listener = UnixListener::bind(socket_path)?;
     listener.set_nonblocking(false)?;
 
+    // Restrict socket to owner-only (0o600) so unprivileged local users
+    // cannot connect and mutate flow rules.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(socket_path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
     let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let stop2 = stop.clone();
     let path = socket_path.to_path_buf();
@@ -104,7 +112,7 @@ fn run_server(
     state: Arc<ControlState>,
     stop: &std::sync::atomic::AtomicBool,
 ) {
-    use std::io::{BufRead, BufReader, Write};
+    use std::io::{BufRead, BufReader, Read, Write};
 
     // Set a timeout so we periodically check the stop flag
     listener
@@ -131,26 +139,30 @@ fn run_server(
         let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(10)));
         let _ = stream.set_write_timeout(Some(std::time::Duration::from_secs(10)));
 
-        let mut reader = BufReader::new(&stream);
+        // Cap read at 64 KiB during I/O (via Take adapter) to prevent OOM
+        // from malicious clients sending multi-GB lines without newlines.
+        const MAX_LINE: usize = 64 * 1024;
+        let limited = (&stream).take(MAX_LINE as u64);
+        let mut reader = BufReader::new(limited);
         let mut line = String::new();
 
-        // Cap read to 64 KiB to prevent OOM from malicious clients.
-        const MAX_LINE: usize = 64 * 1024;
         match reader.read_line(&mut line) {
             Ok(0) => continue,
-            Ok(_) if line.len() > MAX_LINE => {
-                let resp = Response::err(-1, "request too large");
-                let mut resp_line = serde_json::to_string(&resp).unwrap_or_default();
-                resp_line.push('\n');
-                let mut writer = &stream;
-                let _ = writer.write_all(resp_line.as_bytes());
-                continue;
-            }
             Ok(_) => {}
             Err(e) => {
                 tracing::warn!("control: read error: {e}");
                 continue;
             }
+        }
+
+        // If we hit the limit without a newline, the request is too large.
+        if line.len() >= MAX_LINE && !line.ends_with('\n') {
+            let resp = Response::err(-1, "request too large");
+            let mut resp_line = serde_json::to_string(&resp).unwrap_or_default();
+            resp_line.push('\n');
+            let mut writer = &stream;
+            let _ = writer.write_all(resp_line.as_bytes());
+            continue;
         }
 
         let response = match serde_json::from_str::<Request>(&line) {

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -41,8 +41,7 @@ impl ControlHandle {
     }
 
     fn shutdown(&mut self) {
-        self.stop
-            .store(true, std::sync::atomic::Ordering::Release);
+        self.stop.store(true, std::sync::atomic::Ordering::Release);
         // Connect to self to unblock accept()
         let _ = std::os::unix::net::UnixStream::connect(&self.socket_path);
         if let Some(h) = self.join.take() {
@@ -58,10 +57,7 @@ impl Drop for ControlHandle {
 }
 
 /// Spawn the control server thread.
-pub fn spawn(
-    socket_path: &Path,
-    state: Arc<ControlState>,
-) -> std::io::Result<ControlHandle> {
+pub fn spawn(socket_path: &Path, state: Arc<ControlState>) -> std::io::Result<ControlHandle> {
     use std::os::unix::net::UnixListener;
 
     // Remove stale socket file
@@ -189,11 +185,7 @@ fn handle_flow_rule_add(params: &FlowRuleAddParams, state: &ControlState) -> Res
     rules.push(rule);
 
     // Generate a synthetic ID
-    let id = format!(
-        "{:016x}-{:016x}",
-        rules.len() as u64,
-        0u64
-    );
+    let id = format!("{:016x}-{:016x}", rules.len() as u64, 0u64);
     Response::ok(ResponseData::FlowRuleId(FlowRuleIdData { id }))
 }
 
@@ -288,22 +280,22 @@ fn handle_stats_show(params: &StatsShowParams, state: &ControlState) -> Response
             }
         }
 
-        let (packets, bytes, evictions, drops, active_flows) =
-            if let Some(snap) = snapshot.as_ref() {
-                if let Some(frs) = snap.flow_rules.iter().find(|fr| fr.name == rule.name) {
-                    (
-                        frs.counters.packets,
-                        frs.counters.bytes,
-                        frs.counters.evictions,
-                        frs.counters.drops,
-                        frs.flows.len() as u64,
-                    )
-                } else {
-                    (0, 0, 0, 0, 0)
-                }
+        let (packets, bytes, evictions, drops, active_flows) = if let Some(snap) = snapshot.as_ref()
+        {
+            if let Some(frs) = snap.flow_rules.iter().find(|fr| fr.name == rule.name) {
+                (
+                    frs.counters.packets,
+                    frs.counters.bytes,
+                    frs.counters.evictions,
+                    frs.counters.drops,
+                    frs.flows.len() as u64,
+                )
             } else {
                 (0, 0, 0, 0, 0)
-            };
+            }
+        } else {
+            (0, 0, 0, 0, 0)
+        };
 
         flow_rule_stats.push(FlowRuleStatsData {
             name: rule.name.clone(),

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -4,6 +4,7 @@
 //! from `infmonctl` to the frontend's in-memory state.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 
@@ -12,18 +13,25 @@ use infmon_common::ipc::protocol::*;
 use infmon_common::ipc::types::FlowStatsSnapshot;
 
 /// Shared state accessible to the control server.
+///
+/// **Lock ordering invariant**: always acquire `flow_rules` before
+/// `latest_snapshot`. Never reverse to avoid deadlocks.
 pub struct ControlState {
     /// Flow rules configured via the CLI (or loaded from config).
     pub flow_rules: RwLock<Vec<FlowRule>>,
     /// Latest stats snapshot from the poller (if any).
     pub latest_snapshot: Mutex<Option<Arc<FlowStatsSnapshot>>>,
+    /// Monotonic counter for generating unique flow rule IDs.
+    next_rule_id: AtomicU64,
 }
 
 impl ControlState {
     pub fn new(initial_rules: Vec<FlowRule>) -> Self {
+        let initial_count = initial_rules.len() as u64;
         Self {
             flow_rules: RwLock::new(initial_rules),
             latest_snapshot: Mutex::new(None),
+            next_rule_id: AtomicU64::new(initial_count + 1),
         }
     }
 }
@@ -126,8 +134,18 @@ fn run_server(
         let mut reader = BufReader::new(&stream);
         let mut line = String::new();
 
+        // Cap read to 64 KiB to prevent OOM from malicious clients.
+        const MAX_LINE: usize = 64 * 1024;
         match reader.read_line(&mut line) {
-            Ok(0) => continue, // EOF
+            Ok(0) => continue,
+            Ok(_) if line.len() > MAX_LINE => {
+                let resp = Response::err(-1, "request too large");
+                let mut resp_line = serde_json::to_string(&resp).unwrap_or_default();
+                resp_line.push('\n');
+                let mut writer = &stream;
+                let _ = writer.write_all(resp_line.as_bytes());
+                continue;
+            }
             Ok(_) => {}
             Err(e) => {
                 tracing::warn!("control: read error: {e}");
@@ -175,22 +193,23 @@ fn handle_flow_rule_add(params: &FlowRuleAddParams, state: &ControlState) -> Res
         eviction_policy: params.eviction_policy,
     };
 
-    let mut rules = state.flow_rules.write().unwrap();
+    let mut rules = state.flow_rules.write().unwrap_or_else(|e| e.into_inner());
 
-    // Check for duplicate name
     if rules.iter().any(|r| r.name == rule.name) {
         return Response::err(6, format!("flow rule '{}' already exists", rule.name));
     }
 
     rules.push(rule);
 
-    // Generate a synthetic ID
-    let id = format!("{:016x}-{:016x}", rules.len() as u64, 0u64);
+    let seq = state
+        .next_rule_id
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let id = format!("{:016x}-{:016x}", seq, 0u64);
     Response::ok(ResponseData::FlowRuleId(FlowRuleIdData { id }))
 }
 
 fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Response {
-    let mut rules = state.flow_rules.write().unwrap();
+    let mut rules = state.flow_rules.write().unwrap_or_else(|e| e.into_inner());
     let before = rules.len();
     rules.retain(|r| r.name != params.name);
     if rules.len() == before {
@@ -200,20 +219,23 @@ fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Respo
 }
 
 fn handle_flow_rule_list(state: &ControlState) -> Response {
-    let rules = state.flow_rules.read().unwrap();
+    let rules = state.flow_rules.read().unwrap_or_else(|e| e.into_inner());
     let data: Vec<FlowRuleData> = rules.iter().map(FlowRuleData::from).collect();
     Response::ok(ResponseData::FlowRuleList(data))
 }
 
 fn handle_flow_rule_show(params: &FlowRuleShowParams, state: &ControlState) -> Response {
-    let rules = state.flow_rules.read().unwrap();
+    let rules = state.flow_rules.read().unwrap_or_else(|e| e.into_inner());
     let rule = match rules.iter().find(|r| r.name == params.name) {
         Some(r) => r,
         None => return Response::err(3, format!("flow rule '{}' not found", params.name)),
     };
 
     // Try to get flow stats from the latest snapshot
-    let snapshot = state.latest_snapshot.lock().unwrap();
+    let snapshot = state
+        .latest_snapshot
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
     let (counters, flows) = if let Some(snap) = snapshot.as_ref() {
         if let Some(frs) = snap.flow_rules.iter().find(|fr| fr.name == params.name) {
             let counters = FlowRuleCountersData {
@@ -268,14 +290,17 @@ fn handle_flow_rule_show(params: &FlowRuleShowParams, state: &ControlState) -> R
 }
 
 fn handle_stats_show(params: &StatsShowParams, state: &ControlState) -> Response {
-    let rules = state.flow_rules.read().unwrap();
-    let snapshot = state.latest_snapshot.lock().unwrap();
+    let rules = state.flow_rules.read().unwrap_or_else(|e| e.into_inner());
+    let snapshot = state
+        .latest_snapshot
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
 
     let mut flow_rule_stats: Vec<FlowRuleStatsData> = Vec::new();
 
     for rule in rules.iter() {
         if let Some(ref name_filter) = params.name {
-            if !rule.name.contains(name_filter) {
+            if !rule.name.eq(name_filter) {
                 continue;
             }
         }

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -1,0 +1,321 @@
+//! Control socket server for CLI ↔ frontend RPC.
+//!
+//! Listens on a Unix domain socket and dispatches JSON-line requests
+//! from `infmonctl` to the frontend's in-memory state.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+
+use infmon_common::config::model::FlowRule;
+use infmon_common::ipc::protocol::*;
+use infmon_common::ipc::types::FlowStatsSnapshot;
+
+/// Shared state accessible to the control server.
+pub struct ControlState {
+    /// Flow rules configured via the CLI (or loaded from config).
+    pub flow_rules: RwLock<Vec<FlowRule>>,
+    /// Latest stats snapshot from the poller (if any).
+    pub latest_snapshot: Mutex<Option<Arc<FlowStatsSnapshot>>>,
+}
+
+impl ControlState {
+    pub fn new(initial_rules: Vec<FlowRule>) -> Self {
+        Self {
+            flow_rules: RwLock::new(initial_rules),
+            latest_snapshot: Mutex::new(None),
+        }
+    }
+}
+
+/// Handle to a running control server thread.
+pub struct ControlHandle {
+    join: Option<thread::JoinHandle<()>>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    socket_path: PathBuf,
+}
+
+impl ControlHandle {
+    pub fn stop(mut self) {
+        self.shutdown();
+    }
+
+    fn shutdown(&mut self) {
+        self.stop
+            .store(true, std::sync::atomic::Ordering::Release);
+        // Connect to self to unblock accept()
+        let _ = std::os::unix::net::UnixStream::connect(&self.socket_path);
+        if let Some(h) = self.join.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+impl Drop for ControlHandle {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Spawn the control server thread.
+pub fn spawn(
+    socket_path: &Path,
+    state: Arc<ControlState>,
+) -> std::io::Result<ControlHandle> {
+    use std::os::unix::net::UnixListener;
+
+    // Remove stale socket file
+    let _ = std::fs::remove_file(socket_path);
+
+    // Create parent directory if needed
+    if let Some(parent) = socket_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let listener = UnixListener::bind(socket_path)?;
+    listener.set_nonblocking(false)?;
+
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop2 = stop.clone();
+    let path = socket_path.to_path_buf();
+    let path2 = socket_path.to_path_buf();
+
+    let join = thread::Builder::new()
+        .name("control".into())
+        .spawn(move || {
+            run_server(listener, state, &stop2);
+            // Clean up socket file
+            let _ = std::fs::remove_file(&path);
+        })?;
+
+    Ok(ControlHandle {
+        join: Some(join),
+        stop,
+        socket_path: path2,
+    })
+}
+
+fn run_server(
+    listener: std::os::unix::net::UnixListener,
+    state: Arc<ControlState>,
+    stop: &std::sync::atomic::AtomicBool,
+) {
+    use std::io::{BufRead, BufReader, Write};
+
+    // Set a timeout so we periodically check the stop flag
+    listener
+        .set_nonblocking(false)
+        .expect("set_nonblocking failed");
+
+    for stream in listener.incoming() {
+        if stop.load(std::sync::atomic::Ordering::Acquire) {
+            break;
+        }
+
+        let stream = match stream {
+            Ok(s) => s,
+            Err(e) => {
+                if stop.load(std::sync::atomic::Ordering::Acquire) {
+                    break;
+                }
+                tracing::warn!("control: accept error: {e}");
+                continue;
+            }
+        };
+
+        // Set a per-connection read/write timeout
+        let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(10)));
+        let _ = stream.set_write_timeout(Some(std::time::Duration::from_secs(10)));
+
+        let mut reader = BufReader::new(&stream);
+        let mut line = String::new();
+
+        match reader.read_line(&mut line) {
+            Ok(0) => continue, // EOF
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!("control: read error: {e}");
+                continue;
+            }
+        }
+
+        let response = match serde_json::from_str::<Request>(&line) {
+            Ok(req) => handle_request(&req, &state),
+            Err(e) => Response::err(-1, format!("invalid request: {e}")),
+        };
+
+        let mut resp_line = match serde_json::to_string(&response) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("control: failed to serialize response: {e}");
+                continue;
+            }
+        };
+        resp_line.push('\n');
+
+        // Need mutable ref to write
+        let mut writer = &stream;
+        if let Err(e) = writer.write_all(resp_line.as_bytes()) {
+            tracing::warn!("control: write error: {e}");
+        }
+    }
+}
+
+fn handle_request(req: &Request, state: &ControlState) -> Response {
+    match req {
+        Request::FlowRuleAdd(params) => handle_flow_rule_add(params, state),
+        Request::FlowRuleRm(params) => handle_flow_rule_rm(params, state),
+        Request::FlowRuleList => handle_flow_rule_list(state),
+        Request::FlowRuleShow(params) => handle_flow_rule_show(params, state),
+        Request::StatsShow(params) => handle_stats_show(params, state),
+    }
+}
+
+fn handle_flow_rule_add(params: &FlowRuleAddParams, state: &ControlState) -> Response {
+    let rule = FlowRule {
+        name: params.name.clone(),
+        fields: params.fields.clone(),
+        max_keys: params.max_keys,
+        eviction_policy: params.eviction_policy,
+    };
+
+    let mut rules = state.flow_rules.write().unwrap();
+
+    // Check for duplicate name
+    if rules.iter().any(|r| r.name == rule.name) {
+        return Response::err(6, format!("flow rule '{}' already exists", rule.name));
+    }
+
+    rules.push(rule);
+
+    // Generate a synthetic ID
+    let id = format!(
+        "{:016x}-{:016x}",
+        rules.len() as u64,
+        0u64
+    );
+    Response::ok(ResponseData::FlowRuleId(FlowRuleIdData { id }))
+}
+
+fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Response {
+    let mut rules = state.flow_rules.write().unwrap();
+    let before = rules.len();
+    rules.retain(|r| r.name != params.name);
+    if rules.len() == before {
+        return Response::err(3, format!("flow rule '{}' not found", params.name));
+    }
+    Response::ok_empty()
+}
+
+fn handle_flow_rule_list(state: &ControlState) -> Response {
+    let rules = state.flow_rules.read().unwrap();
+    let data: Vec<FlowRuleData> = rules.iter().map(FlowRuleData::from).collect();
+    Response::ok(ResponseData::FlowRuleList(data))
+}
+
+fn handle_flow_rule_show(params: &FlowRuleShowParams, state: &ControlState) -> Response {
+    let rules = state.flow_rules.read().unwrap();
+    let rule = match rules.iter().find(|r| r.name == params.name) {
+        Some(r) => r,
+        None => return Response::err(3, format!("flow rule '{}' not found", params.name)),
+    };
+
+    // Try to get flow stats from the latest snapshot
+    let snapshot = state.latest_snapshot.lock().unwrap();
+    let (counters, flows) = if let Some(snap) = snapshot.as_ref() {
+        if let Some(frs) = snap.flow_rules.iter().find(|fr| fr.name == params.name) {
+            let counters = FlowRuleCountersData {
+                packets: frs.counters.packets,
+                bytes: frs.counters.bytes,
+                evictions: frs.counters.evictions,
+                drops: frs.counters.drops,
+            };
+            let flows: Vec<FlowEntryData> = frs
+                .flows
+                .iter()
+                .map(|f| FlowEntryData {
+                    key: f.key.iter().map(|v| format!("{:?}", v)).collect(),
+                    packets: f.counters.packets,
+                    bytes: f.counters.bytes,
+                    first_seen_ns: f.counters.first_seen_ns,
+                    last_seen_ns: f.counters.last_seen_ns,
+                })
+                .collect();
+            (counters, flows)
+        } else {
+            (
+                FlowRuleCountersData {
+                    packets: 0,
+                    bytes: 0,
+                    evictions: 0,
+                    drops: 0,
+                },
+                vec![],
+            )
+        }
+    } else {
+        (
+            FlowRuleCountersData {
+                packets: 0,
+                bytes: 0,
+                evictions: 0,
+                drops: 0,
+            },
+            vec![],
+        )
+    };
+
+    Response::ok(ResponseData::FlowRuleDetail(FlowRuleDetailData {
+        name: rule.name.clone(),
+        fields: rule.fields.clone(),
+        max_keys: rule.max_keys,
+        eviction_policy: rule.eviction_policy,
+        counters,
+        flows,
+    }))
+}
+
+fn handle_stats_show(params: &StatsShowParams, state: &ControlState) -> Response {
+    let rules = state.flow_rules.read().unwrap();
+    let snapshot = state.latest_snapshot.lock().unwrap();
+
+    let mut flow_rule_stats: Vec<FlowRuleStatsData> = Vec::new();
+
+    for rule in rules.iter() {
+        if let Some(ref name_filter) = params.name {
+            if !rule.name.contains(name_filter) {
+                continue;
+            }
+        }
+
+        let (packets, bytes, evictions, drops, active_flows) =
+            if let Some(snap) = snapshot.as_ref() {
+                if let Some(frs) = snap.flow_rules.iter().find(|fr| fr.name == rule.name) {
+                    (
+                        frs.counters.packets,
+                        frs.counters.bytes,
+                        frs.counters.evictions,
+                        frs.counters.drops,
+                        frs.flows.len() as u64,
+                    )
+                } else {
+                    (0, 0, 0, 0, 0)
+                }
+            } else {
+                (0, 0, 0, 0, 0)
+            };
+
+        flow_rule_stats.push(FlowRuleStatsData {
+            name: rule.name.clone(),
+            packets,
+            bytes,
+            evictions,
+            drops,
+            active_flows,
+        });
+    }
+
+    Response::ok(ResponseData::StatsShow(StatsShowData {
+        flow_rules: flow_rule_stats,
+    }))
+}

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod control;
 pub mod exporter;
 pub mod lifecycle;
 pub mod logging;

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -158,9 +158,7 @@ impl Frontend {
 
         // Spawn control server for CLI RPCs
         let control_socket = PathBuf::from(&frontend_cfg.control_socket);
-        let control_state = Arc::new(ControlState::new(
-            config.flow_rules.clone(),
-        ));
+        let control_state = Arc::new(ControlState::new(config.flow_rules.clone()));
         let control_handle = match control::spawn(&control_socket, control_state) {
             Ok(h) => {
                 tracing::info!("control server listening on {}", control_socket.display());

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use infmon_common::ipc::stats_client::InFMonStatsClient;
 
+use crate::control::{self, ControlHandle, ControlState};
 use crate::exporter::{
     self, find_factory, snapshot_channel, validate_registrations, ExporterConfig, ExporterHandle,
     SnapshotSender,
@@ -47,6 +48,7 @@ pub struct Frontend {
     poller_handle: Option<PollerHandle>,
     exporter_handles: Vec<ExporterHandle>,
     exporter_senders: Vec<SnapshotSender>,
+    control_handle: Option<ControlHandle>,
     config_path: PathBuf,
     shutdown: Arc<AtomicBool>,
 }
@@ -154,10 +156,27 @@ impl Frontend {
             .collect();
         let poller_handle = poller::spawn(poller_config, raw_senders);
 
+        // Spawn control server for CLI RPCs
+        let control_socket = PathBuf::from(&frontend_cfg.control_socket);
+        let control_state = Arc::new(ControlState::new(
+            config.flow_rules.clone(),
+        ));
+        let control_handle = match control::spawn(&control_socket, control_state) {
+            Ok(h) => {
+                tracing::info!("control server listening on {}", control_socket.display());
+                Some(h)
+            }
+            Err(e) => {
+                tracing::warn!("failed to start control server: {e}");
+                None
+            }
+        };
+
         Ok(Frontend {
             poller_handle: Some(poller_handle),
             exporter_handles,
             exporter_senders,
+            control_handle,
             config_path: config_path.to_path_buf(),
             shutdown,
         })
@@ -208,6 +227,12 @@ impl Frontend {
         let handles = std::mem::take(&mut self.exporter_handles);
         for handle in handles {
             handle.join();
+        }
+
+        // 4. Stop control server
+        if let Some(h) = self.control_handle.take() {
+            h.stop();
+            tracing::info!("control server stopped");
         }
 
         tracing::info!("infmon-frontend stopped");

--- a/src/frontend/src/otlp_tests.rs
+++ b/src/frontend/src/otlp_tests.rs
@@ -104,6 +104,8 @@ fn build_request_with_flows() {
         flow_rules: vec![FlowRuleStats {
             name: "test-rule".into(),
             fields: vec![FieldId::SrcIp, FieldId::DstIp],
+            max_keys: 1024,
+            eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
             flows: vec![FlowStats {
                 key: vec![
                     FieldValue::Ip("10.0.0.1".parse().unwrap()),
@@ -177,6 +179,8 @@ fn build_request_cardinality_cap() {
         flow_rules: vec![FlowRuleStats {
             name: "big-rule".into(),
             fields: vec![FieldId::SrcIp],
+            max_keys: 1024,
+            eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
             flows,
             counters: FlowRuleCounters::default(),
         }],
@@ -262,6 +266,8 @@ fn flow_attributes_only_for_declared_fields() {
     let fr = FlowRuleStats {
         name: "dscp-only".into(),
         fields: vec![FieldId::Dscp],
+        max_keys: 1024,
+        eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
         flows: vec![],
         counters: FlowRuleCounters::default(),
     };
@@ -288,6 +294,8 @@ fn flow_attributes_sorted_by_key() {
             FieldId::IpProto,
             FieldId::Dscp,
         ],
+        max_keys: 1024,
+        eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
         flows: vec![],
         counters: FlowRuleCounters::default(),
     };
@@ -393,6 +401,8 @@ fn self_observability_points_emitted_tracks_correctly() {
         flow_rules: vec![FlowRuleStats {
             name: "test-rule".into(),
             fields: vec![FieldId::SrcIp],
+            max_keys: 1024,
+            eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
             flows: vec![FlowStats {
                 key: vec![FieldValue::Ip("10.0.0.1".parse().unwrap())],
                 counters: FlowCounters {
@@ -445,6 +455,8 @@ fn self_observability_points_dropped_on_cap() {
         flow_rules: vec![FlowRuleStats {
             name: "test-rule".into(),
             fields: vec![FieldId::SrcIp],
+            max_keys: 1024,
+            eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop,
             flows: vec![
                 FlowStats {
                     key: vec![FieldValue::Ip("10.0.0.1".parse().unwrap())],

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -203,6 +203,8 @@ fn decode_snapshot(
             FlowRuleStats {
                 name: desc.flow_rule_id.to_string(),
                 fields,
+                max_keys: 0, // TODO: wire from backend descriptor
+                eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop, // TODO: wire from backend descriptor
                 flows,
                 counters: FlowRuleCounters {
                     // TODO: aggregate packet/byte counters are not yet

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -203,7 +203,7 @@ fn decode_snapshot(
             FlowRuleStats {
                 name: desc.flow_rule_id.to_string(),
                 fields,
-                max_keys: 0, // TODO: wire from backend descriptor
+                max_keys: u32::MAX, // sentinel: not yet wired from backend descriptor
                 eviction_policy: infmon_common::config::model::EvictionPolicy::LruDrop, // TODO: wire from backend descriptor
                 flows,
                 counters: FlowRuleCounters {


### PR DESCRIPTION
## Summary

Implement the `infmonctl flow-rule` (list/add/rm/show) and `stats` (show) subcommands that communicate with the infmon-frontend daemon over a Unix domain socket using a JSON-line protocol.

## Changes

### New files
- **`src/common/src/ipc/protocol.rs`** — JSON request/response serde types for the CLI↔frontend RPC protocol
- **`src/frontend/src/control.rs`** — Control server: listens on a Unix socket, dispatches JSON-line requests to in-memory state (flow rules + latest stats snapshot)

### Modified files
- **`src/common/src/ipc/control_client.rs`** — Async Unix socket client with timeout, methods for all flow-rule and stats operations
- **`src/cli/src/main.rs`** — Wire up flow-rule (list/add/rm/show) and stats (show) command handlers with table + JSON output
- **`src/frontend/src/lifecycle.rs`** — Spawn control server thread during frontend startup, stop on shutdown
- **`src/frontend/src/lib.rs`** — Export control module
- **`src/common/src/ipc/mod.rs`** — Export protocol module
- **Cargo.toml updates** — Added serde_json to common, tokio io-util/time features

## Protocol

Each message is a single JSON object terminated by `\n` over the Unix socket at `/run/infmon/frontend.sock` (configurable via `--socket` flag or config). Requests use `{"method": "...", "params": {...}}` format; responses use `{"ok": bool, "data": ..., "error": ...}`.

## Test Plan
- All 78 existing tests pass
- Clean build with no warnings

Closes #127