### PR TITLE
feat: create E2E test framework scaffolding

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,7 +6,6 @@ connectivity, and optionally pushes replay assets to a remote host.
 
 import os
 import shlex
-import shutil
 import subprocess
 import time
 
@@ -31,7 +30,7 @@ def _env(key: str) -> str:
     return os.environ.get(key, _DEFAULTS.get(key, ""))
 
 
-def _run(cmd: str, check: bool = True, capture: bool = True, **kwargs) -> subprocess.CompletedProcess:
+def _run(cmd: str, check: bool = True, capture: bool = True) -> subprocess.CompletedProcess:
     """Run a shell command.
 
     All caller-supplied values interpolated into *cmd* MUST be wrapped
@@ -69,11 +68,14 @@ def _assign_tx_ip_remote() -> None:
     host = _env("INFMON_E2E_TX_HOST")
     iface = _env("INFMON_E2E_TX_HOST_IFACE")
     ip = _env("INFMON_E2E_TX_IP")
-    _run(
-        f"ssh {shlex.quote(host)} 'ip addr flush dev {shlex.quote(iface)};"
-        f" ip addr replace {shlex.quote(ip)} dev {shlex.quote(iface)};"
-        f" ip link set {shlex.quote(iface)} up'"
+    # Build the remote command separately and quote the whole thing for the
+    # local shell, so shlex.quote() inside doesn't clash with outer quoting.
+    remote_cmd = (
+        f"ip addr flush dev {shlex.quote(iface)}; "
+        f"ip addr replace {shlex.quote(ip)} dev {shlex.quote(iface)}; "
+        f"ip link set {shlex.quote(iface)} up"
     )
+    _run(f"ssh {shlex.quote(host)} {shlex.quote(remote_cmd)}")
 
 
 def _push_replay_assets(remote_host: str) -> None:
@@ -92,7 +94,8 @@ def _verify_ping() -> None:
     mode = _env("INFMON_E2E_TX_MODE")
     if mode == "remote":
         host = _env("INFMON_E2E_TX_HOST")
-        cmd = f"ssh {shlex.quote(host)} 'ping -c 3 -W 2 {shlex.quote(rx_ip)}'"
+        remote_cmd = f"ping -c 3 -W 2 {shlex.quote(rx_ip)}"
+        cmd = f"ssh {shlex.quote(host)} {shlex.quote(remote_cmd)}"
     else:
         cmd = f"ping -c 3 -W 2 {shlex.quote(rx_ip)}"
     result = _run(cmd, check=False)
@@ -172,10 +175,12 @@ def infmon_env():
     if mode == "remote":
         remote_host = _env("INFMON_E2E_TX_HOST")
         remote_iface = _env("INFMON_E2E_TX_HOST_IFACE")
+        remote_cmd = (
+            f"ip addr flush dev {shlex.quote(remote_iface)}; "
+            f"rm -f /tmp/replay_traffic.py; "
+            f"rm -rf /tmp/e2e_scenarios"
+        )
         _run(
-            f"ssh {shlex.quote(remote_host)} '"
-            f"ip addr flush dev {shlex.quote(remote_iface)};"
-            f" rm -f /tmp/replay_traffic.py;"
-            f" rm -rf /tmp/e2e_scenarios'",
+            f"ssh {shlex.quote(remote_host)} {shlex.quote(remote_cmd)}",
             check=False,
         )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,6 +5,7 @@ connectivity, and optionally pushes replay assets to a remote host.
 """
 
 import os
+import shlex
 import shutil
 import subprocess
 import time
@@ -30,7 +31,12 @@ def _env(key: str) -> str:
     return os.environ.get(key, _DEFAULTS.get(key, ""))
 
 
-def _run(cmd: str, check: bool = True, capture: bool = True) -> subprocess.CompletedProcess:
+def _run(cmd: str, check: bool = True, capture: bool = True, **kwargs) -> subprocess.CompletedProcess:
+    """Run a shell command.
+
+    All caller-supplied values interpolated into *cmd* MUST be wrapped
+    with ``shlex.quote()`` to prevent shell injection.
+    """
     return subprocess.run(
         cmd, shell=True, check=check, capture_output=capture, text=True
     )
@@ -44,8 +50,8 @@ def _assign_rx_ip() -> None:
     """Assign IP to the VPP RX interface via vppctl."""
     iface = _env("INFMON_E2E_RX_VPP_IFACE")
     ip = _env("INFMON_E2E_RX_IP")
-    _run(f"vppctl set interface ip address {iface} {ip}", check=False)
-    _run(f"vppctl set interface state {iface} up", check=False)
+    _run(f"vppctl set interface ip address {shlex.quote(iface)} {shlex.quote(ip)}", check=False)
+    _run(f"vppctl set interface state {shlex.quote(iface)} up", check=False)
 
 
 def _assign_tx_ip_local() -> None:
@@ -53,9 +59,9 @@ def _assign_tx_ip_local() -> None:
     iface = _env("INFMON_E2E_TX_IFACE")
     ip = _env("INFMON_E2E_TX_IP")
     # Flush existing addresses first to avoid duplicates
-    _run(f"ip addr flush dev {iface}", check=False)
-    _run(f"ip addr add {ip} dev {iface}")
-    _run(f"ip link set {iface} up")
+    _run(f"ip addr flush dev {shlex.quote(iface)}", check=False)
+    _run(f"ip addr replace {shlex.quote(ip)} dev {shlex.quote(iface)}")
+    _run(f"ip link set {shlex.quote(iface)} up")
 
 
 def _assign_tx_ip_remote() -> None:
@@ -63,7 +69,11 @@ def _assign_tx_ip_remote() -> None:
     host = _env("INFMON_E2E_TX_HOST")
     iface = _env("INFMON_E2E_TX_HOST_IFACE")
     ip = _env("INFMON_E2E_TX_IP")
-    _run(f"ssh {host} 'ip addr flush dev {iface}; ip addr add {ip} dev {iface}; ip link set {iface} up'")
+    _run(
+        f"ssh {shlex.quote(host)} 'ip addr flush dev {shlex.quote(iface)};"
+        f" ip addr replace {shlex.quote(ip)} dev {shlex.quote(iface)};"
+        f" ip link set {shlex.quote(iface)} up'"
+    )
 
 
 def _push_replay_assets(remote_host: str) -> None:
@@ -71,9 +81,9 @@ def _push_replay_assets(remote_host: str) -> None:
     e2e_dir = os.path.dirname(__file__)
     replay_script = os.path.join(e2e_dir, "replay_traffic.py")
     scenarios_dir = os.path.join(e2e_dir, "scenarios")
-    _run(f"scp {replay_script} {remote_host}:/tmp/replay_traffic.py")
+    _run(f"scp {shlex.quote(replay_script)} {shlex.quote(remote_host)}:/tmp/replay_traffic.py")
     if os.path.isdir(scenarios_dir):
-        _run(f"scp -r {scenarios_dir} {remote_host}:/tmp/e2e_scenarios")
+        _run(f"scp -r {shlex.quote(scenarios_dir)} {shlex.quote(remote_host)}:/tmp/e2e_scenarios")
 
 
 def _verify_ping() -> None:
@@ -82,9 +92,9 @@ def _verify_ping() -> None:
     mode = _env("INFMON_E2E_TX_MODE")
     if mode == "remote":
         host = _env("INFMON_E2E_TX_HOST")
-        cmd = f"ssh {host} 'ping -c 3 -W 2 {rx_ip}'"
+        cmd = f"ssh {shlex.quote(host)} 'ping -c 3 -W 2 {shlex.quote(rx_ip)}'"
     else:
-        cmd = f"ping -c 3 -W 2 {rx_ip}"
+        cmd = f"ping -c 3 -W 2 {shlex.quote(rx_ip)}"
     result = _run(cmd, check=False)
     if result.returncode != 0:
         pytest.fail(
@@ -136,3 +146,19 @@ def infmon_env():
         "rx_ip": _env("INFMON_E2E_RX_IP"),
         "tx_ip": _env("INFMON_E2E_TX_IP"),
     }
+
+    # ---- Teardown ----
+    # Flush IPs assigned during setup to avoid stale addresses on next run.
+    tx_iface = _env("INFMON_E2E_TX_IFACE")
+    _run(f"ip addr flush dev {shlex.quote(tx_iface)}", check=False)
+
+    if mode == "remote":
+        remote_host = _env("INFMON_E2E_TX_HOST")
+        remote_iface = _env("INFMON_E2E_TX_HOST_IFACE")
+        _run(
+            f"ssh {shlex.quote(remote_host)} '"
+            f"ip addr flush dev {shlex.quote(remote_iface)};"
+            f" rm -f /tmp/replay_traffic.py;"
+            f" rm -rf /tmp/e2e_scenarios'",
+            check=False,
+        )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,138 @@
+"""Session-scoped fixtures for InFMon E2E tests.
+
+Sets up networking (VPP RX port, Linux/remote TX port), verifies
+connectivity, and optionally pushes replay assets to a remote host.
+"""
+
+import os
+import shutil
+import subprocess
+import time
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Environment defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULTS = {
+    "INFMON_E2E_TX_MODE": "local",
+    "INFMON_E2E_TX_IFACE": "p1",
+    "INFMON_E2E_TX_HOST": "",
+    "INFMON_E2E_TX_HOST_IFACE": "",
+    "INFMON_E2E_RX_VPP_IFACE": "TwoHundredGigabitEthernet3/0/0",
+    "INFMON_E2E_RX_IP": "10.123.0.1/24",
+    "INFMON_E2E_TX_IP": "10.123.0.2/24",
+}
+
+
+def _env(key: str) -> str:
+    return os.environ.get(key, _DEFAULTS.get(key, ""))
+
+
+def _run(cmd: str, check: bool = True, capture: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd, shell=True, check=check, capture_output=capture, text=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Networking helpers
+# ---------------------------------------------------------------------------
+
+def _assign_rx_ip() -> None:
+    """Assign IP to the VPP RX interface via vppctl."""
+    iface = _env("INFMON_E2E_RX_VPP_IFACE")
+    ip = _env("INFMON_E2E_RX_IP")
+    _run(f"vppctl set interface ip address {iface} {ip}", check=False)
+    _run(f"vppctl set interface state {iface} up", check=False)
+
+
+def _assign_tx_ip_local() -> None:
+    """Assign IP to the local Linux TX interface."""
+    iface = _env("INFMON_E2E_TX_IFACE")
+    ip = _env("INFMON_E2E_TX_IP")
+    # Flush existing addresses first to avoid duplicates
+    _run(f"ip addr flush dev {iface}", check=False)
+    _run(f"ip addr add {ip} dev {iface}")
+    _run(f"ip link set {iface} up")
+
+
+def _assign_tx_ip_remote() -> None:
+    """Assign IP on the remote TX host via SSH."""
+    host = _env("INFMON_E2E_TX_HOST")
+    iface = _env("INFMON_E2E_TX_HOST_IFACE")
+    ip = _env("INFMON_E2E_TX_IP")
+    _run(f"ssh {host} 'ip addr flush dev {iface}; ip addr add {ip} dev {iface}; ip link set {iface} up'")
+
+
+def _push_replay_assets(remote_host: str) -> None:
+    """SCP replay_traffic.py and scenario directories to the remote host."""
+    e2e_dir = os.path.dirname(__file__)
+    replay_script = os.path.join(e2e_dir, "replay_traffic.py")
+    scenarios_dir = os.path.join(e2e_dir, "scenarios")
+    _run(f"scp {replay_script} {remote_host}:/tmp/replay_traffic.py")
+    if os.path.isdir(scenarios_dir):
+        _run(f"scp -r {scenarios_dir} {remote_host}:/tmp/e2e_scenarios")
+
+
+def _verify_ping() -> None:
+    """Ping the RX IP from the TX side to verify connectivity."""
+    rx_ip = _env("INFMON_E2E_RX_IP").split("/")[0]
+    mode = _env("INFMON_E2E_TX_MODE")
+    if mode == "remote":
+        host = _env("INFMON_E2E_TX_HOST")
+        cmd = f"ssh {host} 'ping -c 3 -W 2 {rx_ip}'"
+    else:
+        cmd = f"ping -c 3 -W 2 {rx_ip}"
+    result = _run(cmd, check=False)
+    if result.returncode != 0:
+        pytest.fail(
+            f"Ping to RX IP {rx_ip} failed — check physical connectivity and IP config."
+        )
+
+
+def _ensure_infmon_running() -> None:
+    """Start InFMon services if they are not already running."""
+    result = _run("systemctl is-active infmon", check=False)
+    if result.stdout.strip() != "active":
+        _run("systemctl start infmon", check=False)
+        time.sleep(2)
+
+
+# ---------------------------------------------------------------------------
+# Session fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def infmon_env():
+    """Set up networking, verify connectivity, and yield config dict."""
+    mode = _env("INFMON_E2E_TX_MODE")
+
+    # 1. Assign IPs
+    _assign_rx_ip()
+    if mode == "remote":
+        host = _env("INFMON_E2E_TX_HOST")
+        if not host:
+            pytest.fail("INFMON_E2E_TX_HOST must be set in remote mode")
+        _assign_tx_ip_remote()
+        _push_replay_assets(host)
+    else:
+        _assign_tx_ip_local()
+
+    # 2. Verify connectivity
+    _verify_ping()
+
+    # 3. Ensure InFMon is running
+    _ensure_infmon_running()
+
+    # 4. Yield config for tests
+    yield {
+        "tx_mode": mode,
+        "tx_iface": _env("INFMON_E2E_TX_IFACE"),
+        "tx_host": _env("INFMON_E2E_TX_HOST"),
+        "tx_host_iface": _env("INFMON_E2E_TX_HOST_IFACE"),
+        "rx_vpp_iface": _env("INFMON_E2E_RX_VPP_IFACE"),
+        "rx_ip": _env("INFMON_E2E_RX_IP"),
+        "tx_ip": _env("INFMON_E2E_TX_IP"),
+    }

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -115,6 +115,8 @@ def _ensure_infmon_running() -> None:
             time.sleep(0.5)
             if _run("systemctl is-active infmon", check=False).stdout.strip() == "active":
                 break
+        else:
+            pytest.fail("InFMon did not become active within 10s")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -134,6 +134,7 @@ def infmon_env():
     _verify_ping()
 
     # 3. Ensure InFMon is running
+    service_was_inactive = _run("systemctl is-active infmon", check=False).stdout.strip() != "active"
     _ensure_infmon_running()
 
     # 4. Yield config for tests
@@ -148,6 +149,10 @@ def infmon_env():
     }
 
     # ---- Teardown ----
+    # Stop InFMon if we started it during setup.
+    if service_was_inactive:
+        _run("systemctl stop infmon", check=False)
+
     # Flush IPs assigned during setup to avoid stale addresses on next run.
     tx_iface = _env("INFMON_E2E_TX_IFACE")
     _run(f"ip addr flush dev {shlex.quote(tx_iface)}", check=False)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -107,7 +107,11 @@ def _ensure_infmon_running() -> None:
     result = _run("systemctl is-active infmon", check=False)
     if result.stdout.strip() != "active":
         _run("systemctl start infmon", check=False)
-        time.sleep(2)
+        # Poll until active (up to 10s) instead of a fixed sleep
+        for _ in range(20):
+            time.sleep(0.5)
+            if _run("systemctl is-active infmon", check=False).stdout.strip() == "active":
+                break
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +122,9 @@ def _ensure_infmon_running() -> None:
 def infmon_env():
     """Set up networking, verify connectivity, and yield config dict."""
     mode = _env("INFMON_E2E_TX_MODE")
+
+    if mode not in ("local", "remote"):
+        pytest.fail(f"Invalid INFMON_E2E_TX_MODE: {mode!r}. Must be 'local' or 'remote'.")
 
     # 1. Assign IPs
     _assign_rx_ip()
@@ -152,6 +159,11 @@ def infmon_env():
     # Stop InFMon if we started it during setup.
     if service_was_inactive:
         _run("systemctl stop infmon", check=False)
+
+    # Remove VPP RX IP
+    rx_iface = _env("INFMON_E2E_RX_VPP_IFACE")
+    rx_ip = _env("INFMON_E2E_RX_IP")
+    _run(f"vppctl set interface ip address {shlex.quote(rx_iface)} del {shlex.quote(rx_ip)}", check=False)
 
     # Flush IPs assigned during setup to avoid stale addresses on next run.
     tx_iface = _env("INFMON_E2E_TX_IFACE")

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -4,8 +4,11 @@ Wraps infmonctl commands for flow rule management and stats retrieval.
 """
 
 import json
+import logging
 import subprocess
 import time
+
+logger = logging.getLogger(__name__)
 from typing import Any, Dict, List, Optional
 
 
@@ -65,7 +68,10 @@ def clear_all_flow_rules() -> None:
     for rule in rules:
         name = rule.get("name", "")
         if name:
-            flow_rule_rm(name)
+            try:
+                flow_rule_rm(name)
+            except subprocess.CalledProcessError:
+                logger.warning("Failed to remove flow rule %r, continuing", name)
 
 
 def wait_for_stats(rule_name: str, timeout: float = 30.0, poll_interval: float = 1.0) -> Dict[str, Any]:
@@ -85,7 +91,7 @@ def wait_for_stats(rule_name: str, timeout: float = 30.0, poll_interval: float =
     deadline = time.time() + timeout
     while time.time() < deadline:
         stats = get_flow_stats(rule_name)
-        if stats is not None:
+        if stats is not None and stats:
             return stats
         time.sleep(poll_interval)
     raise TimeoutError(f"No stats for rule '{rule_name}' after {timeout}s")

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -1,0 +1,91 @@
+"""InFMon interaction helpers for E2E tests.
+
+Wraps infmonctl commands for flow rule management and stats retrieval.
+"""
+
+import json
+import subprocess
+import time
+from typing import Any, Dict, List, Optional
+
+
+def _run_infmonctl(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run an infmonctl command and return the result."""
+    cmd = ["infmonctl"] + list(args)
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def _parse_json_output(result: subprocess.CompletedProcess) -> Any:
+    """Parse JSON from infmonctl stdout."""
+    output = result.stdout.strip()
+    if not output:
+        return None
+    return json.loads(output)
+
+
+def flow_rule_add(name: str, fields: Dict[str, str], max_keys: int = 0) -> None:
+    """Add a flow rule via infmonctl.
+
+    Args:
+        name: Rule name.
+        fields: Dict of match field name to value.
+        max_keys: Maximum number of flow keys (0 = unlimited).
+    """
+    args = ["flow-rule", "add", "--name", name]
+    for field_name, field_value in fields.items():
+        args.extend(["--field", f"{field_name}={field_value}"])
+    if max_keys > 0:
+        args.extend(["--max-keys", str(max_keys)])
+    _run_infmonctl(*args)
+
+
+def flow_rule_rm(name: str) -> None:
+    """Remove a flow rule by name."""
+    _run_infmonctl("flow-rule", "rm", "--name", name)
+
+
+def flow_rule_list() -> List[Dict[str, Any]]:
+    """List all flow rules, returning parsed JSON."""
+    result = _run_infmonctl("flow-rule", "list", "--json")
+    parsed = _parse_json_output(result)
+    return parsed if isinstance(parsed, list) else []
+
+
+def get_flow_stats(rule_name: str) -> Optional[Dict[str, Any]]:
+    """Get flow statistics for a specific rule, returning parsed JSON."""
+    result = _run_infmonctl("stats", "--name", rule_name, "--json", check=False)
+    if result.returncode != 0:
+        return None
+    return _parse_json_output(result)
+
+
+def clear_all_flow_rules() -> None:
+    """Remove all flow rules."""
+    rules = flow_rule_list()
+    for rule in rules:
+        name = rule.get("name", "")
+        if name:
+            flow_rule_rm(name)
+
+
+def wait_for_stats(rule_name: str, timeout: float = 30.0, poll_interval: float = 1.0) -> Dict[str, Any]:
+    """Wait until flow stats are available for a rule.
+
+    Args:
+        rule_name: The flow rule name.
+        timeout: Max seconds to wait.
+        poll_interval: Seconds between polls.
+
+    Returns:
+        Flow stats dict.
+
+    Raises:
+        TimeoutError: If stats are not available within the timeout.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        stats = get_flow_stats(rule_name)
+        if stats is not None:
+            return stats
+        time.sleep(poll_interval)
+    raise TimeoutError(f"No stats for rule '{rule_name}' after {timeout}s")

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -7,9 +7,9 @@ import json
 import logging
 import subprocess
 import time
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
-from typing import Any, Dict, List, Optional
 
 
 def _run_infmonctl(*args: str, check: bool = True) -> subprocess.CompletedProcess:

--- a/tests/e2e/replay_traffic.py
+++ b/tests/e2e/replay_traffic.py
@@ -13,6 +13,7 @@ Module usage:
 
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -31,10 +32,9 @@ def rewrite_dst_ip(packets, dst_ip: str):
         pkt = pkt.copy()
         if pkt.haslayer(IP):
             pkt[IP].dst = dst_ip
-            # Recalculate checksums
             del pkt[IP].chksum
-            if hasattr(pkt[IP], "payload") and hasattr(pkt[IP].payload, "chksum"):
-                del pkt[IP].payload.chksum
+            # Force full checksum recalculation for all layers
+            pkt = pkt.__class__(bytes(pkt))
         elif pkt.haslayer(IPv6):
             pkt[IPv6].dst = dst_ip
         rewritten.append(pkt)
@@ -57,31 +57,34 @@ def replay(
         count: Number of times to replay (default: 1).
         remote_host: If set, replay on this host via SSH.
     """
-    packets = rdpcap(pcap_path)
-    rewritten = rewrite_dst_ip(packets, dst_ip)
-
     with tempfile.NamedTemporaryFile(suffix=".pcap", delete=False) as tmp:
         tmp_path = tmp.name
-        wrpcap(tmp_path, rewritten)
 
     try:
+        packets = rdpcap(pcap_path)
+        rewritten = rewrite_dst_ip(packets, dst_ip)
+        wrpcap(tmp_path, rewritten)
+
         loop_arg = f"--loop={count}" if count > 1 else ""
         if remote_host:
             # Copy rewritten pcap to remote and replay there
             remote_tmp = f"/tmp/replay_{os.getpid()}.pcap"
             subprocess.run(
-                f"scp {tmp_path} {remote_host}:{remote_tmp}",
+                f"scp {shlex.quote(tmp_path)} {shlex.quote(remote_host)}:{shlex.quote(remote_tmp)}",
                 shell=True, check=True, capture_output=True,
             )
             subprocess.run(
-                f"ssh {remote_host} 'tcpreplay {loop_arg} -i {iface} {remote_tmp}; rm -f {remote_tmp}'",
+                f"ssh {shlex.quote(remote_host)}"
+                f" 'tcpreplay {loop_arg} -i {shlex.quote(iface)} {shlex.quote(remote_tmp)};"
+                f" rm -f {shlex.quote(remote_tmp)}'",
                 shell=True, check=True, capture_output=True,
             )
         else:
-            cmd = f"tcpreplay {loop_arg} -i {iface} {tmp_path}"
+            cmd = f"tcpreplay {loop_arg} -i {shlex.quote(iface)} {shlex.quote(tmp_path)}"
             subprocess.run(cmd, shell=True, check=True, capture_output=True)
     finally:
-        os.unlink(tmp_path)
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
 
 
 def main():

--- a/tests/e2e/replay_traffic.py
+++ b/tests/e2e/replay_traffic.py
@@ -15,7 +15,6 @@ import argparse
 import os
 import shlex
 import subprocess
-import sys
 import tempfile
 
 from scapy.all import IP, IPv6, rdpcap, wrpcap
@@ -74,10 +73,12 @@ def replay(
                 f"scp {shlex.quote(tmp_path)} {shlex.quote(remote_host)}:{shlex.quote(remote_tmp)}",
                 shell=True, check=True, capture_output=True,
             )
+            remote_cmd = (
+                f"tcpreplay {loop_arg} -i {shlex.quote(iface)} {shlex.quote(remote_tmp)}; "
+                f"rm -f {shlex.quote(remote_tmp)}"
+            )
             subprocess.run(
-                f"ssh {shlex.quote(remote_host)}"
-                f" 'tcpreplay {loop_arg} -i {shlex.quote(iface)} {shlex.quote(remote_tmp)};"
-                f" rm -f {shlex.quote(remote_tmp)}'",
+                f"ssh {shlex.quote(remote_host)} {shlex.quote(remote_cmd)}",
                 shell=True, check=True, capture_output=True,
             )
         else:

--- a/tests/e2e/replay_traffic.py
+++ b/tests/e2e/replay_traffic.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Replay pcap traffic with destination IP rewriting.
+
+Can be used as a standalone script or imported as a module.
+
+Standalone usage:
+    python3 replay_traffic.py <pcap_file> <dst_ip> <iface> [--count N]
+
+Module usage:
+    from replay_traffic import replay
+    replay("input.pcap", "10.123.0.1", "p1", count=1)
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+from scapy.all import IP, IPv6, rdpcap, wrpcap
+
+
+def rewrite_dst_ip(packets, dst_ip: str):
+    """Rewrite destination IP in all packets.
+
+    Handles both IPv4 and IPv6 based on the dst_ip format.
+    Returns a new list of modified packets.
+    """
+    rewritten = []
+    for pkt in packets:
+        pkt = pkt.copy()
+        if pkt.haslayer(IP):
+            pkt[IP].dst = dst_ip
+            # Recalculate checksums
+            del pkt[IP].chksum
+            if hasattr(pkt[IP], "payload") and hasattr(pkt[IP].payload, "chksum"):
+                del pkt[IP].payload.chksum
+        elif pkt.haslayer(IPv6):
+            pkt[IPv6].dst = dst_ip
+        rewritten.append(pkt)
+    return rewritten
+
+
+def replay(
+    pcap_path: str,
+    dst_ip: str,
+    iface: str,
+    count: int = 1,
+    remote_host: str = "",
+) -> None:
+    """Read a pcap, rewrite dst IP, and replay via tcpreplay.
+
+    Args:
+        pcap_path: Path to the input pcap file.
+        dst_ip: Destination IP to rewrite to.
+        iface: Network interface for replay.
+        count: Number of times to replay (default: 1).
+        remote_host: If set, replay on this host via SSH.
+    """
+    packets = rdpcap(pcap_path)
+    rewritten = rewrite_dst_ip(packets, dst_ip)
+
+    with tempfile.NamedTemporaryFile(suffix=".pcap", delete=False) as tmp:
+        tmp_path = tmp.name
+        wrpcap(tmp_path, rewritten)
+
+    try:
+        loop_arg = f"--loop={count}" if count > 1 else ""
+        if remote_host:
+            # Copy rewritten pcap to remote and replay there
+            remote_tmp = f"/tmp/replay_{os.getpid()}.pcap"
+            subprocess.run(
+                f"scp {tmp_path} {remote_host}:{remote_tmp}",
+                shell=True, check=True, capture_output=True,
+            )
+            subprocess.run(
+                f"ssh {remote_host} 'tcpreplay {loop_arg} -i {iface} {remote_tmp}; rm -f {remote_tmp}'",
+                shell=True, check=True, capture_output=True,
+            )
+        else:
+            cmd = f"tcpreplay {loop_arg} -i {iface} {tmp_path}"
+            subprocess.run(cmd, shell=True, check=True, capture_output=True)
+    finally:
+        os.unlink(tmp_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Replay pcap with dst IP rewriting")
+    parser.add_argument("pcap", help="Path to input pcap file")
+    parser.add_argument("dst_ip", help="Destination IP to rewrite to")
+    parser.add_argument("iface", help="Network interface for replay")
+    parser.add_argument("--count", type=int, default=1, help="Replay count (default: 1)")
+    parser.add_argument("--remote", default="", help="Remote host for replay via SSH")
+    args = parser.parse_args()
+
+    replay(args.pcap, args.dst_ip, args.iface, count=args.count, remote_host=args.remote)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/replay_traffic.py
+++ b/tests/e2e/replay_traffic.py
@@ -37,6 +37,7 @@ def rewrite_dst_ip(packets, dst_ip: str):
             pkt = pkt.__class__(bytes(pkt))
         elif pkt.haslayer(IPv6):
             pkt[IPv6].dst = dst_ip
+            pkt = pkt.__class__(bytes(pkt))
         rewritten.append(pkt)
     return rewritten
 

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.0
+scapy>=2.5

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,2 +1,3 @@
 pytest>=7.0
 scapy>=2.5
+# System dependency: tcpreplay must be installed (apt install tcpreplay).


### PR DESCRIPTION
## Summary

Create the E2E test framework scaffolding under `tests/e2e/` with all components specified in #128:

- **`conftest.py`** — session-scoped pytest fixture that assigns RX IP via VPP CLI, TX IP via Linux (local) or SSH (remote), verifies ping connectivity, starts InFMon if needed, and SCPs replay assets in remote mode
- **`helpers.py`** — infmonctl wrappers: `flow_rule_add`, `flow_rule_rm`, `flow_rule_list`, `get_flow_stats`, `clear_all_flow_rules`, `wait_for_stats`
- **`replay_traffic.py`** — standalone script + importable module that reads pcap with scapy, rewrites dst IP, and replays via tcpreplay (local or remote via SSH)
- **`requirements.txt`** — pytest>=7.0, scapy>=2.5
- **`__init__.py`**

All environment variables from the spec are supported with their documented defaults.

Closes #128