### PR TITLE
fix: update helpers.py CLI args to match infmonctl positional syntax

### DIFF
--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -37,6 +37,8 @@ def flow_rule_add(name: str, fields: List[str], max_keys: int = 0) -> None:
         fields: List of match field names (e.g. ["src_ip", "dst_ip"]).
         max_keys: Maximum number of flow keys (0 = unlimited).
     """
+    if not fields:
+        raise ValueError("fields must be non-empty; infmonctl requires at least one match field")
     args = ["flow-rule", "add", f"name={name}", f"fields={','.join(fields)}"]
     if max_keys > 0:
         args.append(f"max_keys={max_keys}")

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -26,25 +26,29 @@ def _parse_json_output(result: subprocess.CompletedProcess) -> Any:
     return json.loads(output)
 
 
-def flow_rule_add(name: str, fields: Dict[str, str], max_keys: int = 0) -> None:
+def flow_rule_add(name: str, fields: List[str], max_keys: int = 0) -> None:
     """Add a flow rule via infmonctl.
+
+    Uses positional key=value syntax expected by infmonctl:
+        infmonctl flow-rule add name=<name> fields=<f1,f2,...> [max_keys=<N>]
 
     Args:
         name: Rule name.
-        fields: Dict of match field name to value.
+        fields: List of match field names (e.g. ["src_ip", "dst_ip"]).
         max_keys: Maximum number of flow keys (0 = unlimited).
     """
-    args = ["flow-rule", "add", "--name", name]
-    for field_name, field_value in fields.items():
-        args.extend(["--field", f"{field_name}={field_value}"])
+    args = ["flow-rule", "add", f"name={name}", f"fields={','.join(fields)}"]
     if max_keys > 0:
-        args.extend(["--max-keys", str(max_keys)])
+        args.append(f"max_keys={max_keys}")
     _run_infmonctl(*args)
 
 
 def flow_rule_rm(name: str) -> None:
-    """Remove a flow rule by name."""
-    _run_infmonctl("flow-rule", "rm", "--name", name)
+    """Remove a flow rule by name.
+
+    Uses positional syntax: infmonctl flow-rule rm <name>
+    """
+    _run_infmonctl("flow-rule", "rm", name)
 
 
 def flow_rule_list() -> List[Dict[str, Any]]:

--- a/tests/e2e/test_packet_replay.py
+++ b/tests/e2e/test_packet_replay.py
@@ -75,11 +75,11 @@ def test_packet_replay(scenario: str, infmon_env: dict) -> None:
     if config_path.exists():
         with open(config_path) as f:
             config = json.load(f)
-        fields = config.get("fields", {})
+        fields = config.get("fields", [])
         max_keys = config.get("max_keys", 0)
     else:
         # Default: match all traffic on the RX interface
-        fields = {}
+        fields = []
         max_keys = 0  # 0 = unlimited keys (sentinel value in InFMon API)
 
     flow_rule_add(name=scenario, fields=fields, max_keys=max_keys)

--- a/tests/e2e/test_packet_replay.py
+++ b/tests/e2e/test_packet_replay.py
@@ -78,8 +78,8 @@ def test_packet_replay(scenario: str, infmon_env: dict) -> None:
         fields = config.get("fields", [])
         max_keys = config.get("max_keys", 0)
     else:
-        # Default: match all traffic on the RX interface
-        fields = []
+        # Default: match on standard 5-tuple fields
+        fields = ["src_ip", "dst_ip", "src_port", "dst_port", "protocol"]
         max_keys = 0  # 0 = unlimited keys (sentinel value in InFMon API)
 
     flow_rule_add(name=scenario, fields=fields, max_keys=max_keys)


### PR DESCRIPTION
## Summary

`flow_rule_add()` in `tests/e2e/helpers.py` was using `--name`/`--field`/`--max-keys` flags, but infmonctl expects positional `key=value` args: `name=X fields=f1,f2 max_keys=N`.

`flow_rule_rm()` was using `--name` flag, but infmonctl expects a positional target argument.

Also updates `test_packet_replay.py` to pass fields as a list of field names instead of a dict, matching the new `flow_rule_add()` signature.

Closes #136