### PR TITLE
feat(backend): add VPP plugin shared library target

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -172,9 +172,14 @@ add_test(NAME integration COMMAND test_integration)
 option(ENABLE_VPP_PLUGIN "Build infmon_plugin.so for VPP runtime loading" OFF)
 
 if(ENABLE_VPP_PLUGIN)
+    # Static libraries linked into the MODULE target must be position-independent
+    foreach(_tgt infmon_graph_node infmon_parser infmon_flow_rule
+                 infmon_counter_table infmon_snapshot infmon_stats_segment)
+        set_target_properties(${_tgt} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    endforeach()
+
     # Locate VPP development headers and libraries
     find_path(VPP_INCLUDE_DIR vlib/vlib.h
-        PATHS /usr/include /usr/local/include
         DOC "VPP development headers"
     )
     find_library(VPP_LIB_VLIB NAMES vlib DOC "VPP vlib library")
@@ -211,8 +216,10 @@ if(ENABLE_VPP_PLUGIN)
         infmon_snapshot
         infmon_stats_segment
     )
-    foreach(_lib ${VPP_LIB_VLIB} ${VPP_LIB_VNET} ${VPP_LIB_VLIBMEMORY} ${VPP_LIB_VPPINFRA})
-        target_link_libraries(infmon_plugin PRIVATE ${_lib})
+    foreach(_var VPP_LIB_VLIB VPP_LIB_VNET VPP_LIB_VLIBMEMORY VPP_LIB_VPPINFRA)
+        if(${_var})
+            target_link_libraries(infmon_plugin PRIVATE ${${_var}})
+        endif()
     endforeach()
 
     # Ensure the generated API header is built before the plugin

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -168,6 +168,77 @@ target_link_libraries(test_integration PRIVATE
 target_include_directories(test_integration PRIVATE include)
 add_test(NAME integration COMMAND test_integration)
 
+# --- VPP plugin shared library (.so) ---
+option(ENABLE_VPP_PLUGIN "Build infmon_plugin.so for VPP runtime loading" OFF)
+
+if(ENABLE_VPP_PLUGIN)
+    # Locate VPP development headers and libraries
+    find_path(VPP_INCLUDE_DIR vlib/vlib.h
+        PATHS /usr/include /usr/local/include
+        DOC "VPP development headers"
+    )
+    find_library(VPP_LIB_VLIB NAMES vlib
+        PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
+        DOC "VPP vlib library"
+    )
+    find_library(VPP_LIB_VNET NAMES vnet
+        PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
+        DOC "VPP vnet library"
+    )
+    find_library(VPP_LIB_VLIBMEMORY NAMES vlibmemory
+        PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
+        DOC "VPP vlibmemory library"
+    )
+    find_library(VPP_LIB_VPPINFRA NAMES vppinfra
+        PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
+        DOC "VPP vppinfra library"
+    )
+
+    if(NOT VPP_INCLUDE_DIR)
+        message(FATAL_ERROR "ENABLE_VPP_PLUGIN is ON but VPP dev headers not found. Install vpp-dev.")
+    endif()
+
+    add_library(infmon_plugin MODULE
+        src/vpp/infmon_nodes.c
+    )
+    set_target_properties(infmon_plugin PROPERTIES
+        PREFIX ""                              # produce infmon_plugin.so, not libinfmon_plugin.so
+        OUTPUT_NAME "infmon_plugin"
+        C_VISIBILITY_PRESET default
+    )
+    target_compile_definitions(infmon_plugin PRIVATE INFMON_VPP_BUILD)
+    target_include_directories(infmon_plugin PRIVATE
+        include
+        ${VPP_INCLUDE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}/generated  # for generated API header
+    )
+    target_link_libraries(infmon_plugin PRIVATE
+        infmon_graph_node
+        infmon_parser
+        infmon_flow_rule
+        infmon_counter_table
+        infmon_snapshot
+        infmon_stats_segment
+    )
+    if(VPP_LIB_VLIB)
+        target_link_libraries(infmon_plugin PRIVATE ${VPP_LIB_VLIB})
+    endif()
+    if(VPP_LIB_VNET)
+        target_link_libraries(infmon_plugin PRIVATE ${VPP_LIB_VNET})
+    endif()
+    if(VPP_LIB_VLIBMEMORY)
+        target_link_libraries(infmon_plugin PRIVATE ${VPP_LIB_VLIBMEMORY})
+    endif()
+    if(VPP_LIB_VPPINFRA)
+        target_link_libraries(infmon_plugin PRIVATE ${VPP_LIB_VPPINFRA})
+    endif()
+
+    # Ensure the generated API header is built before the plugin
+    add_dependencies(infmon_plugin infmon_api_generated)
+
+    message(STATUS "VPP plugin target enabled: infmon_plugin.so")
+endif()
+
 if(ENABLE_FUZZER)
     add_executable(fuzz_erspan_parser
         test/fuzz_erspan_parser.cc

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -177,25 +177,16 @@ if(ENABLE_VPP_PLUGIN)
         PATHS /usr/include /usr/local/include
         DOC "VPP development headers"
     )
-    find_library(VPP_LIB_VLIB NAMES vlib
-        PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
-        DOC "VPP vlib library"
-    )
-    find_library(VPP_LIB_VNET NAMES vnet
-        PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
-        DOC "VPP vnet library"
-    )
-    find_library(VPP_LIB_VLIBMEMORY NAMES vlibmemory
-        PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
-        DOC "VPP vlibmemory library"
-    )
-    find_library(VPP_LIB_VPPINFRA NAMES vppinfra
-        PATHS /usr/lib /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu
-        DOC "VPP vppinfra library"
-    )
+    find_library(VPP_LIB_VLIB NAMES vlib DOC "VPP vlib library")
+    find_library(VPP_LIB_VNET NAMES vnet DOC "VPP vnet library")
+    find_library(VPP_LIB_VLIBMEMORY NAMES vlibmemory DOC "VPP vlibmemory library")
+    find_library(VPP_LIB_VPPINFRA NAMES vppinfra DOC "VPP vppinfra library")
 
     if(NOT VPP_INCLUDE_DIR)
         message(FATAL_ERROR "ENABLE_VPP_PLUGIN is ON but VPP dev headers not found. Install vpp-dev.")
+    endif()
+    if(NOT VPP_LIB_VLIB OR NOT VPP_LIB_VNET)
+        message(FATAL_ERROR "ENABLE_VPP_PLUGIN is ON but required VPP libraries (vlib, vnet) not found.")
     endif()
 
     add_library(infmon_plugin MODULE
@@ -220,21 +211,18 @@ if(ENABLE_VPP_PLUGIN)
         infmon_snapshot
         infmon_stats_segment
     )
-    if(VPP_LIB_VLIB)
-        target_link_libraries(infmon_plugin PRIVATE ${VPP_LIB_VLIB})
-    endif()
-    if(VPP_LIB_VNET)
-        target_link_libraries(infmon_plugin PRIVATE ${VPP_LIB_VNET})
-    endif()
-    if(VPP_LIB_VLIBMEMORY)
-        target_link_libraries(infmon_plugin PRIVATE ${VPP_LIB_VLIBMEMORY})
-    endif()
-    if(VPP_LIB_VPPINFRA)
-        target_link_libraries(infmon_plugin PRIVATE ${VPP_LIB_VPPINFRA})
-    endif()
+    foreach(_lib ${VPP_LIB_VLIB} ${VPP_LIB_VNET} ${VPP_LIB_VLIBMEMORY} ${VPP_LIB_VPPINFRA})
+        target_link_libraries(infmon_plugin PRIVATE ${_lib})
+    endforeach()
 
     # Ensure the generated API header is built before the plugin
     add_dependencies(infmon_plugin infmon_api_generated)
+
+    # Install to VPP plugin directory
+    include(GNUInstallDirs)
+    install(TARGETS infmon_plugin
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/vpp_plugins
+    )
 
     message(STATUS "VPP plugin target enabled: infmon_plugin.so")
 endif()


### PR DESCRIPTION
## Summary

Add a CMake `MODULE` library target (`infmon_plugin`) that compiles `infmon_nodes.c` with `-DINFMON_VPP_BUILD` and links against VPP libraries to produce `infmon_plugin.so` for VPP runtime loading.

## Changes

- New CMake option `ENABLE_VPP_PLUGIN` (default `OFF`) in `src/backend/CMakeLists.txt`
- When enabled, locates VPP dev headers (`vlib/vlib.h`) and libraries (`vlib`, `vnet`, `vlibmemory`, `vppinfra`)
- Produces `infmon_plugin.so` (no `lib` prefix) suitable for VPP's plugin directory
- Links against all internal InFMon libraries (parser, flow_rule, counter_table, snapshot, stats_segment, graph_node)
- Depends on generated API header via `infmon_api_generated` target

## Usage

```bash
cmake .. -DENABLE_VPP_PLUGIN=ON
make infmon_plugin
cp infmon_plugin.so /usr/lib/vpp_plugins/
```

## Test Plan

- [x] Default build (without flag) — all 10 tests pass, no regressions
- [x] `-DENABLE_VPP_PLUGIN=ON` — CMake configures successfully, plugin target compiles `infmon_nodes.c` with VPP headers

Closes #138