### PR TITLE
feat: add systemd service unit for infmon-frontend

### DIFF
--- a/deploy/infmon.service
+++ b/deploy/infmon.service
@@ -1,16 +1,34 @@
 [Unit]
 Description=InFMon flow-telemetry frontend
 Documentation=https://github.com/r12f/InFMon
+
+# This unit intentionally does NOT use PartOf=vpp.service or BindsTo=vpp.service.
+# VPP may run under a custom unit name, and infmon-frontend has its own retry loop
+# on the binary-API socket — tying lifecycle to vpp.service would cause unnecessary
+# restarts. If you want co-lifecycle with VPP, add PartOf=vpp.service via a drop-in:
+#   systemctl edit infmon
+#   [Unit]
+#   PartOf=vpp.service
 After=vpp.service network-online.target
 Wants=network-online.target
 
 [Service]
+# Type=notify requires the binary to call sd_notify(READY=1). infmon-frontend
+# implements sd-notify; if startup takes longer than expected, override with:
+#   systemctl edit infmon → TimeoutStartSec=30s
 Type=notify
+
+# Default path assumes Debian/package install. For cargo or manual builds the
+# binary may be in /usr/local/bin or elsewhere — override via:
+#   systemctl edit infmon → ExecStart=/your/path/infmon-frontend ...
 ExecStart=/usr/bin/infmon-frontend --config /etc/infmon/config.yaml
 Restart=on-failure
 RestartSec=2s
 User=infmon
 Group=infmon
+
+# vpp group is needed for access to the binary-API socket and stats segment
+# under /run/vpp.
 SupplementaryGroups=vpp
 RuntimeDirectory=infmon
 RuntimeDirectoryMode=0750
@@ -22,7 +40,19 @@ ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
 NoNewPrivileges=true
+
+# Stats segment is hugepages-backed mmap — this grants read access to
+# /dev/hugepages. Requires kernel hugepage support; if mmap fails, check
+# that hugepages are allocated (see /proc/sys/vm/nr_hugepages).
 ReadOnlyPaths=/dev/hugepages
+
+# Capabilities are locked down by default. If you need to bind to a
+# privileged port (<1024) or encounter stats-segment permission errors,
+# add capabilities back via a drop-in:
+#   systemctl edit infmon
+#   [Service]
+#   CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+#   AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=
 AmbientCapabilities=
 

--- a/deploy/infmon.service
+++ b/deploy/infmon.service
@@ -53,6 +53,9 @@ ReadOnlyPaths=/dev/hugepages
 #   [Service]
 #   CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 #   AmbientCapabilities=CAP_NET_BIND_SERVICE
+# For stats-segment mmap permission errors, add CAP_DAC_READ_SEARCH instead:
+#   CapabilityBoundingSet=CAP_DAC_READ_SEARCH
+#   AmbientCapabilities=CAP_DAC_READ_SEARCH
 CapabilityBoundingSet=
 AmbientCapabilities=
 

--- a/deploy/infmon.service
+++ b/deploy/infmon.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=InFMon flow-telemetry frontend
+Documentation=https://github.com/r12f/InFMon
+After=vpp.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/infmon-frontend --config /etc/infmon/config.yaml
+Restart=on-failure
+RestartSec=2s
+User=infmon
+Group=infmon
+SupplementaryGroups=vpp
+RuntimeDirectory=infmon
+RuntimeDirectoryMode=0750
+StateDirectory=infmon
+StateDirectoryMode=0750
+LogsDirectory=infmon
+LogsDirectoryMode=0750
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+ReadOnlyPaths=/dev/hugepages
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Add `deploy/infmon.service` — a systemd unit file that runs `infmon-frontend` with the default config path (`/etc/infmon/config.yaml`).

The E2E test framework (`tests/e2e/conftest.py`) expects `systemctl is-active infmon` and `systemctl start infmon` to work, but no unit file with the `infmon` service name existed. This adds one under `deploy/` for non-Debian deployments.

The unit is a streamlined version of `packaging/debian/infmon-frontend.service`, keeping the same security hardening (ProtectSystem, NoNewPrivileges, etc.) while using the `infmon` service name the tests expect.

Closes #139