### PR TITLE
fix: add tcpreplay prerequisite check for E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ e2e:
 	@[ "$$INFMON_E2E_ENABLED" = "1" ] || { echo "Set INFMON_E2E_ENABLED=1 to run E2E tests (requires BF3 hardware)"; exit 1; }
 	@command -v python3 >/dev/null 2>&1 || { echo "python3 not found"; exit 1; }
 	@python3 -c 'import pytest' 2>/dev/null || { echo "pytest not installed — pip install pytest"; exit 1; }
+	@command -v tcpreplay >/dev/null 2>&1 || { echo "tcpreplay not found — apt install tcpreplay"; exit 1; }
 	@cd tests/e2e && python3 -m pytest -v --tb=short $(PYTEST_ARGS)
 
 build:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,11 +5,23 @@ connectivity, and optionally pushes replay assets to a remote host.
 """
 
 import os
+import shutil
 import shlex
 import subprocess
 import time
 
 import pytest
+
+
+def pytest_configure(config):
+    """Fail early if required external tools are missing."""
+    missing = []
+    if not shutil.which("tcpreplay"):
+        missing.append("tcpreplay (apt install tcpreplay)")
+    if missing:
+        raise pytest.UsageError(
+            f"Missing E2E prerequisites: {', '.join(missing)}"
+        )
 
 # ---------------------------------------------------------------------------
 # Environment defaults


### PR DESCRIPTION
## Summary

Add a runtime check for `tcpreplay` in both the Makefile `e2e` target and `conftest.py` `pytest_configure` hook. This ensures a clear error message is shown early when `tcpreplay` is not installed, rather than failing mid-test with a cryptic subprocess error.

### Changes
- **Makefile**: Added `command -v tcpreplay` check before running E2E tests
- **tests/e2e/conftest.py**: Added `pytest_configure` hook that checks for `tcpreplay` via `shutil.which()` and raises `pytest.UsageError` with install instructions if missing

Closes #141