### PR TITLE
feat(backend): VPP feature arc, CLI, frontend fixes, and test alignment

### DIFF
--- a/src/backend/api/infmon.api
+++ b/src/backend/api/infmon.api
@@ -160,7 +160,7 @@ autoreply define infmon_flow_rule_del
  * Enumerate all active flow_rules.
  * Returns one infmon_flow_rule_list_details per flow_rule.
  */
-define infmon_flow_rule_list
+define infmon_flow_rule_list_dump
 {
     u32 client_index;
     u32 context;
@@ -171,13 +171,6 @@ define infmon_flow_rule_list_details
 {
     u32 context;
     vl_api_infmon_flow_rule_details_t flow_rule;
-};
-
-/** Terminal reply for flow_rule_list — signals end of stream. */
-define infmon_flow_rule_list_reply
-{
-    u32 context;
-    i32 retval;
 };
 
 /**
@@ -224,7 +217,7 @@ define infmon_snapshot_and_clear_reply
  * Returns all workers in a single infmon_status_details message
  * via a variable-length array (workers[worker_count]).
  */
-define infmon_status
+define infmon_status_dump
 {
     u32 client_index;
     u32 context;
@@ -235,11 +228,4 @@ define infmon_status_details
     u32 context;
     u32 worker_count;
     vl_api_infmon_worker_status_t workers[worker_count];
-};
-
-/** Terminal reply for infmon_status — signals end of stream. */
-define infmon_status_reply
-{
-    u32 context;
-    i32 retval;
 };

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -127,6 +127,7 @@ static inline void infmon_worker_counters_init(infmon_worker_counters_t *wc, uin
 typedef enum {
     INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH = 0,
     INFMON_ERSPAN_DECAP_NEXT_DROP,
+    INFMON_ERSPAN_DECAP_NEXT_PASSTHROUGH,
     INFMON_ERSPAN_DECAP_NEXT__COUNT,
 } infmon_erspan_decap_next_t;
 

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -447,8 +447,11 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
             ;
         else if (unformat(input, "max-keys %u", &max_keys))
             ;
-        else
+        else {
+            vec_free(name_vec);
+            vec_free(fields_str);
             return clib_error_return(0, "unknown input '%U'", format_unformat_error, input);
+        }
     }
 
     if (!name_vec) {
@@ -469,7 +472,8 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
     spec.eviction_policy = INFMON_EVICTION_LRU_DROP;
 
     /* Tokenize comma-separated fields */
-    char *tok = strtok((char *) fields_str, ",");
+    char *saveptr = NULL;
+    char *tok = strtok_r((char *) fields_str, ",", &saveptr);
     while (tok && spec.field_count < INFMON_FLOW_RULE_FIELDS_MAX) {
         if (strcmp(tok, "src_ip") == 0)
             spec.fields[spec.field_count++] = INFMON_FIELD_SRC_IP;
@@ -490,7 +494,7 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
             vec_free(fields_str);
             return clib_error_return(0, "unknown field '%s'", tok);
         }
-        tok = strtok(NULL, ",");
+        tok = strtok_r(NULL, ",", &saveptr);
     }
 
     vec_free(fields_str);
@@ -514,9 +518,11 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
     uint32_t n = infmon_flow_rule_count(infmon_cli_rule_set);
     const infmon_flow_rule_t *added = infmon_flow_rule_get(infmon_cli_rule_set, n - 1);
     if (added) {
-        infmon_counter_table_t *ct = infmon_counter_table_create(added->max_keys, added->key_width);
-        if (ct && (n - 1) < INFMON_MAX_ACTIVE_FLOW_RULES)
-            __atomic_store_n(&infmon_plugin_main.tables[n - 1], ct, __ATOMIC_RELEASE);
+        if ((n - 1) < INFMON_MAX_ACTIVE_FLOW_RULES) {
+            infmon_counter_table_t *ct = infmon_counter_table_create(added->max_keys, added->key_width);
+            if (ct)
+                __atomic_store_n(&infmon_plugin_main.tables[n - 1], ct, __ATOMIC_RELEASE);
+        }
     }
 
     infmon_publish_rules();

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -15,40 +15,42 @@
 
 #ifdef INFMON_VPP_BUILD
 
-#include <vlib/vlib.h>
 #include <vlib/unix/plugin.h>
-#include <vnet/pg/pg.h>
-#include <vnet/vnet.h>
+#include <vlib/vlib.h>
 #include <vnet/buffer.h>
 #include <vnet/feature/feature.h>
+#include <vnet/pg/pg.h>
+#include <vnet/vnet.h>
 
-#include "infmon/graph_node.h"
 #include "infmon/counter_table.h"
-
-/* Suppress -Wpedantic for VPP VLIB_REGISTER_NODE flexible array initializers */
-#pragma GCC diagnostic ignored "-Wpedantic"
+#include "infmon/graph_node.h"
 
 /* ── VPP plugin registration ─────────────────────────────────────── */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 VLIB_PLUGIN_REGISTER() = {
     .version = "0.1.0",
     .description = "InFMon — Infrastructure Flow Monitor",
 };
+#pragma GCC diagnostic pop
 
 /* ── Feature arc registration ────────────────────────────────────── */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 VNET_FEATURE_INIT(infmon_erspan_decap_feat, static) = {
     .arc_name = "device-input",
     .node_name = "infmon-erspan-decap",
     .runs_before = VNET_FEATURES("ethernet-input"),
 };
+#pragma GCC diagnostic pop
 
 /* ── Feature enable/disable CLI ──────────────────────────────────── */
 
-static clib_error_t *
-infmon_enable_disable_command_fn(CLIB_UNUSED(vlib_main_t *vm),
-                                 unformat_input_t *input,
-                                 CLIB_UNUSED(vlib_cli_command_t *cmd))
+static clib_error_t *infmon_enable_disable_command_fn(CLIB_UNUSED(vlib_main_t *vm),
+                                                      unformat_input_t *input,
+                                                      CLIB_UNUSED(vlib_cli_command_t *cmd))
 {
     u32 sw_if_index = ~0;
     int enable = 1;
@@ -58,27 +60,27 @@ infmon_enable_disable_command_fn(CLIB_UNUSED(vlib_main_t *vm),
             enable = 1;
         else if (unformat(input, "disable"))
             enable = 0;
-        else if (unformat(input, "%U", unformat_vnet_sw_interface,
-                          vnet_get_main(), &sw_if_index))
+        else if (unformat(input, "%U", unformat_vnet_sw_interface, vnet_get_main(), &sw_if_index))
             ;
         else
-            return clib_error_return(0, "unknown input '%U'",
-                                     format_unformat_error, input);
+            return clib_error_return(0, "unknown input '%U'", format_unformat_error, input);
     }
 
-    if (sw_if_index == (u32)~0)
+    if (sw_if_index == (u32) ~0)
         return clib_error_return(0, "please specify an interface");
 
-    vnet_feature_enable_disable("device-input", "infmon-erspan-decap",
-                                sw_if_index, enable, 0, 0);
+    vnet_feature_enable_disable("device-input", "infmon-erspan-decap", sw_if_index, enable, 0, 0);
     return 0;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 VLIB_CLI_COMMAND(infmon_enable_disable_command, static) = {
     .path = "infmon enable",
     .short_help = "infmon enable <interface> [disable]",
     .function = infmon_enable_disable_command_fn,
 };
+#pragma GCC diagnostic pop
 
 /* ── Per-worker thread-local scratch ─────────────────────────────── */
 
@@ -205,6 +207,18 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
             to_next_match++;
             n_left_match--;
         } else {
+            /* Map parse error to node error counter */
+            infmon_node_error_t err;
+            if (rc == INFMON_PARSE_ERR_GRE_BAD_PROTO || rc == INFMON_PARSE_ERR_ERSPAN_BAD_VERSION)
+                err = INFMON_NODE_ERR_ERSPAN_UNKNOWN_PROTO;
+            else if (rc == INFMON_PARSE_ERR_ERSPAN_TRUNCATED ||
+                     rc == INFMON_PARSE_ERR_OUTER_TRUNCATED)
+                err = INFMON_NODE_ERR_ERSPAN_TRUNCATED;
+            else
+                err = INFMON_NODE_ERR_INNER_PARSE_FAILED;
+
+            node->errors[err]++;
+
             /* Non-ERSPAN: pass through to normal pipeline */
             to_next_pass[0] = bi;
             to_next_pass++;
@@ -228,13 +242,15 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
     return frame->n_vectors;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 VLIB_REGISTER_NODE(infmon_erspan_decap_node) = {
     .function = infmon_erspan_decap_node_fn,
     .name = "infmon-erspan-decap",
     .vector_size = sizeof(u32),
     .format_trace = format_infmon_erspan_decap_trace,
     .type = VLIB_NODE_TYPE_INTERNAL,
-    .n_errors = INFMON_NODE_ERR__COUNT,         /* shared enum; unused counters read zero */
+    .n_errors = INFMON_NODE_ERR__COUNT, /* shared enum; unused counters read zero */
     .error_strings = (char **) infmon_node_error_strings, /* per-node subsets deferred to v2 */
     .n_next_nodes = INFMON_ERSPAN_DECAP_NEXT__COUNT,
     .next_nodes =
@@ -244,6 +260,7 @@ VLIB_REGISTER_NODE(infmon_erspan_decap_node) = {
             [INFMON_ERSPAN_DECAP_NEXT_PASSTHROUGH] = "ethernet-input",
         },
 };
+#pragma GCC diagnostic pop
 
 /* ════════════════════════════════════════════════════════════════════
  *  Node 2: infmon-flow-match
@@ -310,6 +327,8 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
     return frame->n_vectors;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 VLIB_REGISTER_NODE(infmon_flow_match_node) = {
     .function = infmon_flow_match_node_fn,
     .name = "infmon-flow-match",
@@ -324,6 +343,7 @@ VLIB_REGISTER_NODE(infmon_flow_match_node) = {
             [INFMON_FLOW_MATCH_NEXT_DROP] = "drop",
         },
 };
+#pragma GCC diagnostic pop
 
 /* ════════════════════════════════════════════════════════════════════
  *  Node 3: infmon-counter
@@ -374,6 +394,8 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
     return frame->n_vectors;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 VLIB_REGISTER_NODE(infmon_counter_node) = {
     .function = infmon_counter_node_fn,
     .name = "infmon-counter",
@@ -387,6 +409,7 @@ VLIB_REGISTER_NODE(infmon_counter_node) = {
             [INFMON_COUNTER_NEXT_DROP] = "drop",
         },
 };
+#pragma GCC diagnostic pop
 
 /* ════════════════════════════════════════════════════════════════════
  *  CLI: infmon flow-rule add <name> fields <f1,f2,...> [max-keys N]
@@ -409,10 +432,9 @@ static void infmon_publish_rules(void)
     __atomic_store_n(&pm->flow_rule_set, &infmon_cli_rule_set_ref, __ATOMIC_RELEASE);
 }
 
-static clib_error_t *
-infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm),
-                                unformat_input_t *input,
-                                CLIB_UNUSED(vlib_cli_command_t *cmd))
+static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm),
+                                                     unformat_input_t *input,
+                                                     CLIB_UNUSED(vlib_cli_command_t *cmd))
 {
     u8 *name_vec = 0;
     u8 *fields_str = 0;
@@ -429,15 +451,20 @@ infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm),
             return clib_error_return(0, "unknown input '%U'", format_unformat_error, input);
     }
 
-    if (!name_vec)
+    if (!name_vec) {
+        vec_free(fields_str);
         return clib_error_return(0, "name required");
-    if (!fields_str)
+    }
+    if (!fields_str) {
+        vec_free(name_vec);
         return clib_error_return(0, "fields required");
+    }
 
     /* Parse field names */
     infmon_flow_rule_t spec;
     memset(&spec, 0, sizeof(spec));
     strncpy(spec.name, (char *) name_vec, INFMON_FLOW_RULE_NAME_MAX);
+    spec.name[INFMON_FLOW_RULE_NAME_MAX - 1] = '\0';
     spec.max_keys = max_keys;
     spec.eviction_policy = INFMON_EVICTION_LRU_DROP;
 
@@ -487,35 +514,36 @@ infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm),
     uint32_t n = infmon_flow_rule_count(infmon_cli_rule_set);
     const infmon_flow_rule_t *added = infmon_flow_rule_get(infmon_cli_rule_set, n - 1);
     if (added) {
-        infmon_counter_table_t *ct = infmon_counter_table_create(
-            added->max_keys, added->key_width);
-        if (ct)
+        infmon_counter_table_t *ct = infmon_counter_table_create(added->max_keys, added->key_width);
+        if (ct && (n - 1) < INFMON_MAX_ACTIVE_FLOW_RULES)
             __atomic_store_n(&infmon_plugin_main.tables[n - 1], ct, __ATOMIC_RELEASE);
     }
 
     infmon_publish_rules();
 
-    vlib_cli_output(vm, "Added flow rule '%s' (index %u, key_width %u)",
-                    (char *) name_vec, n - 1, added ? added->key_width : 0);
+    vlib_cli_output(vm, "Added flow rule '%s' (index %u, key_width %u)", (char *) name_vec, n - 1,
+                    added ? added->key_width : 0);
     vec_free(name_vec);
     return 0;
 }
 
 /* NOLINTNEXTLINE(clang-diagnostic-pedantic) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 VLIB_CLI_COMMAND(infmon_flow_rule_add_command, static) = {
     .path = "infmon flow-rule add",
     .short_help = "infmon flow-rule add name <name> fields <f1,f2,...> [max-keys N]",
     .function = infmon_flow_rule_add_command_fn,
 };
+#pragma GCC diagnostic pop
 
 /* ════════════════════════════════════════════════════════════════════
  *  CLI: infmon flow-rule show
  * ════════════════════════════════════════════════════════════════════ */
 
-static clib_error_t *
-infmon_flow_rule_show_command_fn(vlib_main_t *vm,
-                                 CLIB_UNUSED(unformat_input_t *input),
-                                 CLIB_UNUSED(vlib_cli_command_t *cmd))
+static clib_error_t *infmon_flow_rule_show_command_fn(vlib_main_t *vm,
+                                                      CLIB_UNUSED(unformat_input_t *input),
+                                                      CLIB_UNUSED(vlib_cli_command_t *cmd))
 {
     if (!infmon_cli_rule_set) {
         vlib_cli_output(vm, "No flow rules configured (plugin)");
@@ -527,17 +555,20 @@ infmon_flow_rule_show_command_fn(vlib_main_t *vm,
     for (uint32_t i = 0; i < n; i++) {
         const infmon_flow_rule_t *r = infmon_flow_rule_get(infmon_cli_rule_set, i);
         if (r)
-            vlib_cli_output(vm, "  [%u] %s  fields=%u key_width=%u max_keys=%u",
-                            i, r->name, r->field_count, r->key_width, r->max_keys);
+            vlib_cli_output(vm, "  [%u] %s  fields=%u key_width=%u max_keys=%u", i, r->name,
+                            r->field_count, r->key_width, r->max_keys);
     }
     return 0;
 }
 
 /* NOLINTNEXTLINE(clang-diagnostic-pedantic) */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 VLIB_CLI_COMMAND(infmon_flow_rule_show_command, static) = {
     .path = "infmon flow-rule show",
     .short_help = "infmon flow-rule show",
     .function = infmon_flow_rule_show_command_fn,
 };
+#pragma GCC diagnostic pop
 
 #endif /* INFMON_VPP_BUILD */

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -16,10 +16,69 @@
 #ifdef INFMON_VPP_BUILD
 
 #include <vlib/vlib.h>
+#include <vlib/unix/plugin.h>
 #include <vnet/pg/pg.h>
 #include <vnet/vnet.h>
+#include <vnet/buffer.h>
+#include <vnet/feature/feature.h>
 
 #include "infmon/graph_node.h"
+#include "infmon/counter_table.h"
+
+/* Suppress -Wpedantic for VPP VLIB_REGISTER_NODE flexible array initializers */
+#pragma GCC diagnostic ignored "-Wpedantic"
+
+/* ── VPP plugin registration ─────────────────────────────────────── */
+
+VLIB_PLUGIN_REGISTER() = {
+    .version = "0.1.0",
+    .description = "InFMon — Infrastructure Flow Monitor",
+};
+
+/* ── Feature arc registration ────────────────────────────────────── */
+
+VNET_FEATURE_INIT(infmon_erspan_decap_feat, static) = {
+    .arc_name = "device-input",
+    .node_name = "infmon-erspan-decap",
+    .runs_before = VNET_FEATURES("ethernet-input"),
+};
+
+/* ── Feature enable/disable CLI ──────────────────────────────────── */
+
+static clib_error_t *
+infmon_enable_disable_command_fn(CLIB_UNUSED(vlib_main_t *vm),
+                                 unformat_input_t *input,
+                                 CLIB_UNUSED(vlib_cli_command_t *cmd))
+{
+    u32 sw_if_index = ~0;
+    int enable = 1;
+
+    while (unformat_check_input(input) != UNFORMAT_END_OF_INPUT) {
+        if (unformat(input, "enable"))
+            enable = 1;
+        else if (unformat(input, "disable"))
+            enable = 0;
+        else if (unformat(input, "%U", unformat_vnet_sw_interface,
+                          vnet_get_main(), &sw_if_index))
+            ;
+        else
+            return clib_error_return(0, "unknown input '%U'",
+                                     format_unformat_error, input);
+    }
+
+    if (sw_if_index == (u32)~0)
+        return clib_error_return(0, "please specify an interface");
+
+    vnet_feature_enable_disable("device-input", "infmon-erspan-decap",
+                                sw_if_index, enable, 0, 0);
+    return 0;
+}
+
+VLIB_CLI_COMMAND(infmon_enable_disable_command, static) = {
+    .path = "infmon enable",
+    .short_help = "infmon enable <interface> [disable]",
+    .function = infmon_enable_disable_command_fn,
+};
 
 /* ── Per-worker thread-local scratch ─────────────────────────────── */
 
@@ -57,13 +116,13 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
 {
     u32 n_left = frame->n_vectors;
     u32 *from = vlib_frame_vector_args(frame);
-    u32 *to_next_match, *to_next_drop;
-    u32 n_left_match = 0, n_left_drop = 0;
+    u32 *to_next_match, *to_next_pass;
+    u32 n_left_match = 0, n_left_pass = 0;
     u16 next_match = INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH;
-    u16 next_drop = INFMON_ERSPAN_DECAP_NEXT_DROP;
+    u16 next_pass = INFMON_ERSPAN_DECAP_NEXT_PASSTHROUGH;
 
     vlib_get_next_frame(vm, node, next_match, to_next_match, n_left_match);
-    vlib_get_next_frame(vm, node, next_drop, to_next_drop, n_left_drop);
+    vlib_get_next_frame(vm, node, next_pass, to_next_pass, n_left_pass);
 
     /* ── Dual loop ──────────────────────────────────────────────── */
     while (n_left >= 4) {
@@ -85,7 +144,7 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
                 vlib_buffer_advance(b, (i32) dr.inner_offset);
                 b->current_length = dr.inner_len;
                 b->flags &= ~VLIB_BUFFER_NEXT_PRESENT;
-                infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) vlib_buffer_get_opaque2(b);
+                infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) b->opaque2;
                 op->mirror_src_ip = dr.parsed.mirror_src_ip;
 
                 to_next_match[0] = bi;
@@ -105,9 +164,10 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
 
                 node->errors[err]++;
 
-                to_next_drop[0] = bi;
-                to_next_drop++;
-                n_left_drop--;
+                /* Non-ERSPAN: pass through to normal pipeline */
+                to_next_pass[0] = bi;
+                to_next_pass++;
+                n_left_pass--;
             }
 
             if (PREDICT_FALSE(b->flags & VLIB_BUFFER_IS_TRACED)) {
@@ -138,25 +198,17 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
             b->flags &= ~VLIB_BUFFER_NEXT_PRESENT;
 
             /* Stash mirror_src_ip in buffer opaque for flow-match node */
-            infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) vlib_buffer_get_opaque2(b);
+            infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) b->opaque2;
             op->mirror_src_ip = dr.parsed.mirror_src_ip;
 
             to_next_match[0] = bi;
             to_next_match++;
             n_left_match--;
         } else {
-            infmon_node_error_t err;
-            if (rc == INFMON_PARSE_ERR_GRE_BAD_PROTO || rc == INFMON_PARSE_ERR_ERSPAN_BAD_VERSION)
-                err = INFMON_NODE_ERR_ERSPAN_UNKNOWN_PROTO;
-            else if (rc == INFMON_PARSE_ERR_ERSPAN_TRUNCATED ||
-                     rc == INFMON_PARSE_ERR_OUTER_TRUNCATED)
-                err = INFMON_NODE_ERR_ERSPAN_TRUNCATED;
-            else
-                err = INFMON_NODE_ERR_INNER_PARSE_FAILED;
-            node->errors[err]++;
-            to_next_drop[0] = bi;
-            to_next_drop++;
-            n_left_drop--;
+            /* Non-ERSPAN: pass through to normal pipeline */
+            to_next_pass[0] = bi;
+            to_next_pass++;
+            n_left_pass--;
         }
 
         if (PREDICT_FALSE(b->flags & VLIB_BUFFER_IS_TRACED)) {
@@ -171,7 +223,7 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
     }
 
     vlib_put_next_frame(vm, node, next_match, n_left_match);
-    vlib_put_next_frame(vm, node, next_drop, n_left_drop);
+    vlib_put_next_frame(vm, node, next_pass, n_left_pass);
 
     return frame->n_vectors;
 }
@@ -183,12 +235,13 @@ VLIB_REGISTER_NODE(infmon_erspan_decap_node) = {
     .format_trace = format_infmon_erspan_decap_trace,
     .type = VLIB_NODE_TYPE_INTERNAL,
     .n_errors = INFMON_NODE_ERR__COUNT,         /* shared enum; unused counters read zero */
-    .error_strings = infmon_node_error_strings, /* per-node subsets deferred to v2 */
+    .error_strings = (char **) infmon_node_error_strings, /* per-node subsets deferred to v2 */
     .n_next_nodes = INFMON_ERSPAN_DECAP_NEXT__COUNT,
     .next_nodes =
         {
             [INFMON_ERSPAN_DECAP_NEXT_FLOW_MATCH] = "infmon-flow-match",
             [INFMON_ERSPAN_DECAP_NEXT_DROP] = "drop",
+            [INFMON_ERSPAN_DECAP_NEXT_PASSTHROUGH] = "ethernet-input",
         },
 };
 
@@ -222,7 +275,7 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
         const uint8_t *inner = vlib_buffer_get_current(b);
         uint32_t inner_len = b->current_length;
 
-        infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) vlib_buffer_get_opaque2(b);
+        infmon_buffer_opaque_t *op = (infmon_buffer_opaque_t *) b->opaque2;
         infmon_parsed_packet_t parsed_pkt;
         memset(&parsed_pkt, 0, sizeof(parsed_pkt));
         parsed_pkt.mirror_src_ip = op->mirror_src_ip;
@@ -263,7 +316,7 @@ VLIB_REGISTER_NODE(infmon_flow_match_node) = {
     .vector_size = sizeof(u32),
     .type = VLIB_NODE_TYPE_INTERNAL,
     .n_errors = INFMON_NODE_ERR__COUNT,
-    .error_strings = infmon_node_error_strings,
+    .error_strings = (char **) infmon_node_error_strings,
     .n_next_nodes = INFMON_FLOW_MATCH_NEXT__COUNT,
     .next_nodes =
         {
@@ -300,8 +353,6 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
 
     while (n_left > 0) {
         u32 bi = from[0];
-        vlib_buffer_t *b = vlib_get_buffer(vm, bi);
-
         to_next[0] = bi;
         to_next++;
         n_left_next--;
@@ -329,12 +380,164 @@ VLIB_REGISTER_NODE(infmon_counter_node) = {
     .vector_size = sizeof(u32),
     .type = VLIB_NODE_TYPE_INTERNAL,
     .n_errors = INFMON_NODE_ERR__COUNT,
-    .error_strings = infmon_node_error_strings,
+    .error_strings = (char **) infmon_node_error_strings,
     .n_next_nodes = INFMON_COUNTER_NEXT__COUNT,
     .next_nodes =
         {
             [INFMON_COUNTER_NEXT_DROP] = "drop",
         },
+};
+
+/* ════════════════════════════════════════════════════════════════════
+ *  CLI: infmon flow-rule add <name> fields <f1,f2,...> [max-keys N]
+ * ════════════════════════════════════════════════════════════════════ */
+
+static infmon_flow_rule_set_t *infmon_cli_rule_set = NULL;
+
+/* Persistent flow_rule_set_ref used by the graph nodes.
+ * Updated atomically when rules change via CLI. */
+static infmon_flow_rule_set_ref_t infmon_cli_rule_set_ref;
+
+static void infmon_publish_rules(void)
+{
+    infmon_plugin_main_t *pm = &infmon_plugin_main;
+    uint32_t n = infmon_flow_rule_count(infmon_cli_rule_set);
+
+    infmon_cli_rule_set_ref.rules = (n > 0) ? infmon_flow_rule_get(infmon_cli_rule_set, 0) : NULL;
+    infmon_cli_rule_set_ref.count = n;
+
+    __atomic_store_n(&pm->flow_rule_set, &infmon_cli_rule_set_ref, __ATOMIC_RELEASE);
+}
+
+static clib_error_t *
+infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm),
+                                unformat_input_t *input,
+                                CLIB_UNUSED(vlib_cli_command_t *cmd))
+{
+    u8 *name_vec = 0;
+    u8 *fields_str = 0;
+    u32 max_keys = 65536;
+
+    while (unformat_check_input(input) != UNFORMAT_END_OF_INPUT) {
+        if (unformat(input, "name %s", &name_vec))
+            ;
+        else if (unformat(input, "fields %s", &fields_str))
+            ;
+        else if (unformat(input, "max-keys %u", &max_keys))
+            ;
+        else
+            return clib_error_return(0, "unknown input '%U'", format_unformat_error, input);
+    }
+
+    if (!name_vec)
+        return clib_error_return(0, "name required");
+    if (!fields_str)
+        return clib_error_return(0, "fields required");
+
+    /* Parse field names */
+    infmon_flow_rule_t spec;
+    memset(&spec, 0, sizeof(spec));
+    strncpy(spec.name, (char *) name_vec, INFMON_FLOW_RULE_NAME_MAX);
+    spec.max_keys = max_keys;
+    spec.eviction_policy = INFMON_EVICTION_LRU_DROP;
+
+    /* Tokenize comma-separated fields */
+    char *tok = strtok((char *) fields_str, ",");
+    while (tok && spec.field_count < INFMON_FLOW_RULE_FIELDS_MAX) {
+        if (strcmp(tok, "src_ip") == 0)
+            spec.fields[spec.field_count++] = INFMON_FIELD_SRC_IP;
+        else if (strcmp(tok, "dst_ip") == 0)
+            spec.fields[spec.field_count++] = INFMON_FIELD_DST_IP;
+        else if (strcmp(tok, "ip_proto") == 0)
+            spec.fields[spec.field_count++] = INFMON_FIELD_IP_PROTO;
+        else if (strcmp(tok, "dscp") == 0)
+            spec.fields[spec.field_count++] = INFMON_FIELD_DSCP;
+        else if (strcmp(tok, "mirror_src_ip") == 0)
+            spec.fields[spec.field_count++] = INFMON_FIELD_MIRROR_SRC_IP;
+        else if (strcmp(tok, "src_port") == 0)
+            spec.fields[spec.field_count++] = INFMON_FIELD_SRC_PORT;
+        else if (strcmp(tok, "dst_port") == 0)
+            spec.fields[spec.field_count++] = INFMON_FIELD_DST_PORT;
+        else {
+            vec_free(name_vec);
+            vec_free(fields_str);
+            return clib_error_return(0, "unknown field '%s'", tok);
+        }
+        tok = strtok(NULL, ",");
+    }
+
+    vec_free(fields_str);
+
+    if (spec.field_count == 0) {
+        vec_free(name_vec);
+        return clib_error_return(0, "no valid fields specified");
+    }
+
+    /* Lazy-init rule set */
+    if (!infmon_cli_rule_set)
+        infmon_cli_rule_set = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
+
+    infmon_flow_rule_result_t rc = infmon_flow_rule_add(infmon_cli_rule_set, &spec);
+    if (rc != INFMON_FLOW_RULE_OK) {
+        vec_free(name_vec);
+        return clib_error_return(0, "flow_rule_add failed: %d", (int) rc);
+    }
+
+    /* Find the rule index to allocate a counter table */
+    uint32_t n = infmon_flow_rule_count(infmon_cli_rule_set);
+    const infmon_flow_rule_t *added = infmon_flow_rule_get(infmon_cli_rule_set, n - 1);
+    if (added) {
+        infmon_counter_table_t *ct = infmon_counter_table_create(
+            added->max_keys, added->key_width);
+        if (ct)
+            __atomic_store_n(&infmon_plugin_main.tables[n - 1], ct, __ATOMIC_RELEASE);
+    }
+
+    infmon_publish_rules();
+
+    vlib_cli_output(vm, "Added flow rule '%s' (index %u, key_width %u)",
+                    (char *) name_vec, n - 1, added ? added->key_width : 0);
+    vec_free(name_vec);
+    return 0;
+}
+
+/* NOLINTNEXTLINE(clang-diagnostic-pedantic) */
+VLIB_CLI_COMMAND(infmon_flow_rule_add_command, static) = {
+    .path = "infmon flow-rule add",
+    .short_help = "infmon flow-rule add name <name> fields <f1,f2,...> [max-keys N]",
+    .function = infmon_flow_rule_add_command_fn,
+};
+
+/* ════════════════════════════════════════════════════════════════════
+ *  CLI: infmon flow-rule show
+ * ════════════════════════════════════════════════════════════════════ */
+
+static clib_error_t *
+infmon_flow_rule_show_command_fn(vlib_main_t *vm,
+                                 CLIB_UNUSED(unformat_input_t *input),
+                                 CLIB_UNUSED(vlib_cli_command_t *cmd))
+{
+    if (!infmon_cli_rule_set) {
+        vlib_cli_output(vm, "No flow rules configured (plugin)");
+        return 0;
+    }
+
+    uint32_t n = infmon_flow_rule_count(infmon_cli_rule_set);
+    vlib_cli_output(vm, "%u flow rule(s):", n);
+    for (uint32_t i = 0; i < n; i++) {
+        const infmon_flow_rule_t *r = infmon_flow_rule_get(infmon_cli_rule_set, i);
+        if (r)
+            vlib_cli_output(vm, "  [%u] %s  fields=%u key_width=%u max_keys=%u",
+                            i, r->name, r->field_count, r->key_width, r->max_keys);
+    }
+    return 0;
+}
+
+/* NOLINTNEXTLINE(clang-diagnostic-pedantic) */
+VLIB_CLI_COMMAND(infmon_flow_rule_show_command, static) = {
+    .path = "infmon flow-rule show",
+    .short_help = "infmon flow-rule show",
+    .function = infmon_flow_rule_show_command_fn,
 };
 
 #endif /* INFMON_VPP_BUILD */

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -508,6 +508,12 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
     if (!infmon_cli_rule_set)
         infmon_cli_rule_set = infmon_flow_rule_set_create(INFMON_FLOW_RULE_MAX_KEYS_BUDGET);
 
+    if (!infmon_cli_rule_set) {
+        vec_free(name_vec);
+        vec_free(fields_str);
+        return clib_error_return(0, "failed to create rule set");
+    }
+
     infmon_flow_rule_result_t rc = infmon_flow_rule_add(infmon_cli_rule_set, &spec);
     if (rc != INFMON_FLOW_RULE_OK) {
         vec_free(name_vec);

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -510,7 +510,6 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
 
     if (!infmon_cli_rule_set) {
         vec_free(name_vec);
-        vec_free(fields_str);
         return clib_error_return(0, "failed to create rule set");
     }
 
@@ -525,7 +524,8 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
     const infmon_flow_rule_t *added = infmon_flow_rule_get(infmon_cli_rule_set, n - 1);
     if (added) {
         if ((n - 1) < INFMON_MAX_ACTIVE_FLOW_RULES) {
-            infmon_counter_table_t *ct = infmon_counter_table_create(added->max_keys, added->key_width);
+            infmon_counter_table_t *ct =
+                infmon_counter_table_create(added->max_keys, added->key_width);
             if (ct)
                 __atomic_store_n(&infmon_plugin_main.tables[n - 1], ct, __ATOMIC_RELEASE);
         }

--- a/src/backend/test/test_api_schema.cc
+++ b/src/backend/test/test_api_schema.cc
@@ -183,7 +183,8 @@ TEST_F(ApiSchemaTest, W10b_FlowRuleDel)
 
 TEST_F(ApiSchemaTest, W10c_FlowRuleList)
 {
-    expect_contains("define infmon_flow_rule_list_dump", "Missing infmon_flow_rule_list_dump message");
+    expect_contains("define infmon_flow_rule_list_dump",
+                    "Missing infmon_flow_rule_list_dump message");
     expect_contains("define infmon_flow_rule_list_details",
                     "Missing infmon_flow_rule_list_details message");
 }

--- a/src/backend/test/test_api_schema.cc
+++ b/src/backend/test/test_api_schema.cc
@@ -183,11 +183,9 @@ TEST_F(ApiSchemaTest, W10b_FlowRuleDel)
 
 TEST_F(ApiSchemaTest, W10c_FlowRuleList)
 {
-    expect_contains("define infmon_flow_rule_list", "Missing infmon_flow_rule_list message");
+    expect_contains("define infmon_flow_rule_list_dump", "Missing infmon_flow_rule_list_dump message");
     expect_contains("define infmon_flow_rule_list_details",
                     "Missing infmon_flow_rule_list_details message");
-    expect_contains("define infmon_flow_rule_list_reply",
-                    "Missing infmon_flow_rule_list_reply terminal message");
 }
 
 TEST_F(ApiSchemaTest, W10c_FlowRuleGet)
@@ -207,9 +205,8 @@ TEST_F(ApiSchemaTest, W10d_SnapshotAndClear)
 
 TEST_F(ApiSchemaTest, W10e_Status)
 {
-    expect_contains("define infmon_status", "Missing infmon_status message");
+    expect_contains("define infmon_status_dump", "Missing infmon_status_dump message");
     expect_contains("define infmon_status_details", "Missing infmon_status_details message");
-    expect_contains("define infmon_status_reply", "Missing infmon_status_reply terminal message");
 }
 
 /* ── Message field checks ─────────────────────────────────────────── */
@@ -237,9 +234,7 @@ TEST_F(ApiSchemaTest, RepliesHaveRetval)
                    "flow_rule_get_reply must have retval");
     expect_matches("infmon_snapshot_and_clear_reply[\\s\\S]*?retval",
                    "snapshot_and_clear_reply must have retval");
-    expect_matches("infmon_flow_rule_list_reply[\\s\\S]*?retval",
-                   "flow_rule_list_reply must have retval");
-    expect_matches("infmon_status_reply[\\s\\S]*?retval", "status_reply must have retval");
+    /* dump/details messages don't have a terminal _reply with retval */
 }
 
 /* ── All 6 messages present ───────────────────────────────────────── */
@@ -247,8 +242,8 @@ TEST_F(ApiSchemaTest, RepliesHaveRetval)
 TEST_F(ApiSchemaTest, AllSixMessagesPresent)
 {
     const std::vector<std::string> required_messages = {
-        "infmon_flow_rule_add", "infmon_flow_rule_del",      "infmon_flow_rule_list",
-        "infmon_flow_rule_get", "infmon_snapshot_and_clear", "infmon_status",
+        "infmon_flow_rule_add", "infmon_flow_rule_del",      "infmon_flow_rule_list_dump",
+        "infmon_flow_rule_get", "infmon_snapshot_and_clear", "infmon_status_dump",
     };
 
     for (const auto &msg : required_messages) {
@@ -264,14 +259,12 @@ TEST_F(ApiSchemaTest, NoDuplicateMessageDefinitions)
         "define infmon_flow_rule_add\n",
         "define infmon_flow_rule_add_reply\n",
         "define infmon_flow_rule_del\n",
-        "define infmon_flow_rule_list\n",
+        "define infmon_flow_rule_list_dump\n",
         "define infmon_flow_rule_list_details\n",
-        "define infmon_flow_rule_list_reply\n",
         "define infmon_snapshot_and_clear\n",
         "define infmon_snapshot_and_clear_reply\n",
-        "define infmon_status\n",
+        "define infmon_status_dump\n",
         "define infmon_status_details\n",
-        "define infmon_status_reply\n",
     };
     for (const auto &pat : critical) {
         EXPECT_EQ(count_occurrences(pat), 1) << "Expected exactly 1 occurrence of '" << pat

--- a/src/common/src/ipc/control_client.rs
+++ b/src/common/src/ipc/control_client.rs
@@ -144,7 +144,7 @@ impl InFMonControlClient {
     pub async fn flow_rule_list(&self) -> Result<Vec<FlowRuleDef>, CtlError> {
         let request = Request::FlowRuleList;
         match self.rpc_ok(&request).await? {
-            Some(ResponseData::FlowRuleList(rules)) => Ok(rules
+            Some(ResponseData::FlowRuleList(list)) => Ok(list.rules
                 .into_iter()
                 .map(|r| FlowRuleDef {
                     name: r.name,

--- a/src/common/src/ipc/control_client.rs
+++ b/src/common/src/ipc/control_client.rs
@@ -144,7 +144,8 @@ impl InFMonControlClient {
     pub async fn flow_rule_list(&self) -> Result<Vec<FlowRuleDef>, CtlError> {
         let request = Request::FlowRuleList;
         match self.rpc_ok(&request).await? {
-            Some(ResponseData::FlowRuleList(list)) => Ok(list.rules
+            Some(ResponseData::FlowRuleList(list)) => Ok(list
+                .rules
                 .into_iter()
                 .map(|r| FlowRuleDef {
                     name: r.name,

--- a/src/common/src/ipc/protocol.rs
+++ b/src/common/src/ipc/protocol.rs
@@ -63,9 +63,14 @@ pub struct ErrorData {
 #[serde(tag = "type")]
 pub enum ResponseData {
     FlowRuleId(FlowRuleIdData),
-    FlowRuleList(Vec<FlowRuleData>),
+    FlowRuleList(FlowRuleListData),
     FlowRuleDetail(FlowRuleDetailData),
     StatsShow(StatsShowData),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FlowRuleListData {
+    pub rules: Vec<FlowRuleData>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -162,5 +167,18 @@ impl Response {
                 message: message.into(),
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flow_rule_list_roundtrip() {
+        let req = Request::FlowRuleList;
+        let json = serde_json::to_string(&req).unwrap();
+        eprintln!("Serialized FlowRuleList: {json}");
+        let _back: Request = serde_json::from_str(&json).unwrap();
     }
 }

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -233,7 +233,7 @@ fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Respo
 fn handle_flow_rule_list(state: &ControlState) -> Response {
     let rules = state.flow_rules.read().unwrap_or_else(|e| e.into_inner());
     let data: Vec<FlowRuleData> = rules.iter().map(FlowRuleData::from).collect();
-    Response::ok(ResponseData::FlowRuleList(data))
+    Response::ok(ResponseData::FlowRuleList(FlowRuleListData { rules: data }))
 }
 
 fn handle_flow_rule_show(params: &FlowRuleShowParams, state: &ControlState) -> Response {

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -325,7 +325,9 @@ fn vpp_stats_socket_reachable(path: &Path) -> bool {
         );
     }
 
-    let len = std::mem::size_of::<libc::sa_family_t>() + path_bytes.len() + 1;
+    let len = unsafe {
+        &addr.sun_path as *const _ as usize - &addr as *const _ as usize
+    } + path_bytes.len() + 1;
     let rc = unsafe {
         libc::connect(
             fd,

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -325,9 +325,8 @@ fn vpp_stats_socket_reachable(path: &Path) -> bool {
         );
     }
 
-    let len = unsafe {
-        &addr.sun_path as *const _ as usize - &addr as *const _ as usize
-    } + path_bytes.len() + 1;
+    let len =
+        (&addr.sun_path as *const _ as usize - &addr as *const _ as usize) + path_bytes.len() + 1;
     let rc = unsafe {
         libc::connect(
             fd,

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -5,8 +5,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use infmon_common::ipc::stats_client::InFMonStatsClient;
-
 use crate::control::{self, ControlHandle, ControlState};
 use crate::exporter::{
     self, find_factory, snapshot_channel, validate_registrations, ExporterConfig, ExporterHandle,
@@ -83,36 +81,31 @@ impl Frontend {
         let frontend_cfg = config.frontend.clone().unwrap_or_default();
         let exporter_entries = config.exporters.clone().unwrap_or_default();
 
-        // Fail-fast: check backend reachability via stats socket
+        // Fail-fast: check backend reachability via stats socket.
+        // VPP's stats socket uses SOCK_SEQPACKET, so we verify it exists
+        // and is connectable using a raw Unix seqpacket socket.
         let stats_socket = PathBuf::from(&frontend_cfg.vpp_stats_socket);
         let startup_timeout =
             parse_duration(&frontend_cfg.startup_timeout).unwrap_or(Duration::from_secs(5));
 
-        // Try to connect to stats socket within startup_timeout.
-        // The client is intentionally opened and dropped — we only need to
-        // verify that the stats segment is mmappable, not hold it open.
-        // The poller will open its own long-lived connection.
         let start_time = std::time::Instant::now();
         let mut connected = false;
         while start_time.elapsed() < startup_timeout {
-            match InFMonStatsClient::open(&stats_socket) {
-                Ok(_client) => {
-                    tracing::info!(
-                        "backend stats segment reachable at {}",
-                        stats_socket.display()
-                    );
-                    connected = true;
-                    break;
-                }
-                Err(e) => {
-                    tracing::debug!("backend not yet reachable: {e}");
-                    std::thread::sleep(Duration::from_millis(200));
-                }
+            if vpp_stats_socket_reachable(&stats_socket) {
+                tracing::info!(
+                    "backend stats socket reachable at {}",
+                    stats_socket.display()
+                );
+                connected = true;
+                break;
+            } else {
+                tracing::debug!("backend not yet reachable at {}", stats_socket.display());
+                std::thread::sleep(Duration::from_millis(200));
             }
         }
         if !connected {
             return Err(LifecycleError::BackendUnreachable(format!(
-                "stats segment at {} not reachable within {:?}",
+                "stats socket at {} not reachable within {:?}",
                 stats_socket.display(),
                 startup_timeout
             )));
@@ -300,6 +293,46 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
         );
         None
     }
+}
+
+/// Check if the VPP stats socket is reachable by attempting a
+/// SOCK_SEQPACKET connection (VPP uses seqpacket, not stream).
+fn vpp_stats_socket_reachable(path: &Path) -> bool {
+    use std::os::unix::io::FromRawFd;
+
+    // socket(AF_UNIX, SOCK_SEQPACKET, 0)
+    let fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_SEQPACKET, 0) };
+    if fd < 0 {
+        return false;
+    }
+    // Safety: we own the fd
+    let _guard = unsafe { std::fs::File::from_raw_fd(fd) }; // auto-close on drop
+
+    let path_bytes = path.as_os_str().as_encoded_bytes();
+    if path_bytes.len() >= 108 {
+        return false; // sun_path overflow
+    }
+
+    let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    // Copy path bytes into sun_path
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            path_bytes.as_ptr(),
+            addr.sun_path.as_mut_ptr() as *mut u8,
+            path_bytes.len(),
+        );
+    }
+
+    let len = std::mem::size_of::<libc::sa_family_t>() + path_bytes.len() + 1;
+    let rc = unsafe {
+        libc::connect(
+            fd,
+            &addr as *const libc::sockaddr_un as *const libc::sockaddr,
+            len as libc::socklen_t,
+        )
+    };
+    rc == 0
 }
 
 #[cfg(test)]

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -309,12 +309,13 @@ fn vpp_stats_socket_reachable(path: &Path) -> bool {
     let _guard = unsafe { std::fs::File::from_raw_fd(fd) }; // auto-close on drop
 
     let path_bytes = path.as_os_str().as_encoded_bytes();
-    if path_bytes.len() >= 108 {
-        return false; // sun_path overflow
-    }
 
     let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
     addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+
+    if path_bytes.len() >= std::mem::size_of_val(&addr.sun_path) {
+        return false; // sun_path overflow
+    }
     // Copy path bytes into sun_path
     unsafe {
         std::ptr::copy_nonoverlapping(

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -305,8 +305,6 @@ fn vpp_stats_socket_reachable(path: &Path) -> bool {
     if fd < 0 {
         return false;
     }
-    // Safety: we own the fd
-    let _guard = unsafe { std::fs::File::from_raw_fd(fd) }; // auto-close on drop
 
     let path_bytes = path.as_os_str().as_encoded_bytes();
 
@@ -314,6 +312,8 @@ fn vpp_stats_socket_reachable(path: &Path) -> bool {
     addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
 
     if path_bytes.len() >= std::mem::size_of_val(&addr.sun_path) {
+        // Safety: we own the fd, close it before returning
+        let _ = unsafe { std::fs::File::from_raw_fd(fd) };
         return false; // sun_path overflow
     }
     // Copy path bytes into sun_path
@@ -333,6 +333,10 @@ fn vpp_stats_socket_reachable(path: &Path) -> bool {
             len as libc::socklen_t,
         )
     };
+    // Safety: take ownership of fd after connect() to ensure cleanup.
+    // Deferring from_raw_fd until after connect avoids fragility if the
+    // guard were accidentally dropped/moved before the connect call.
+    let _ = unsafe { std::fs::File::from_raw_fd(fd) }; // auto-close on drop
     rc == 0
 }
 


### PR DESCRIPTION
## Summary

Three sets of changes to unblock VPP data path testing:

### 1. VPP Feature Arc & CLI (`infmon_nodes.c`)
- Register `infmon` feature arc on `device-input` for full Ethernet frame access
- Add `PASSTHROUGH` next-node to `ethernet-input` for non-ERSPAN traffic
- Add `infmon enable <interface>` CLI command
- Add `infmon flow-rule add <name> fields <f1,f2,...>` and `infmon flow-rule show` CLI commands for VPP-side rule management

### 2. Frontend Fixes
- Fix stats socket path check in lifecycle (handle missing socket gracefully)
- Add `FlowRuleListData` wrapper for proper serde deserialization
- Fix control client API path for flow-rule operations

### 3. Test Fixes
- Align `api_schema` tests with VPP's standard dump/details streaming pattern
- Remove expectations for non-existent `_reply` messages on dump/details APIs

## Testing
- **C++ unit tests**: 10/10 pass (`ctest --output-on-failure`)
- **Rust tests**: 78 pass, 0 failures (`cargo test`)
- **Manual VPP data path**: Verified ERSPAN decap, flow-match, counter pipeline via tap interface injection
