### PR TITLE
fix(e2e): fix import path and field name so tests run from repo root

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,9 +8,15 @@ import os
 import shutil
 import shlex
 import subprocess
+import sys
 import time
 
 import pytest
+
+# Ensure the e2e directory is on sys.path so bare imports (helpers,
+# replay_traffic) work regardless of the working directory pytest is
+# invoked from (e.g. repo root vs tests/e2e/).
+sys.path.insert(0, os.path.dirname(__file__))
 
 
 def pytest_configure(config):

--- a/tests/e2e/test_packet_replay.py
+++ b/tests/e2e/test_packet_replay.py
@@ -79,7 +79,7 @@ def test_packet_replay(scenario: str, infmon_env: dict) -> None:
         max_keys = config.get("max_keys", 0)
     else:
         # Default: match on standard 5-tuple fields
-        fields = ["src_ip", "dst_ip", "src_port", "dst_port", "protocol"]
+        fields = ["src_ip", "dst_ip", "src_port", "dst_port", "ip_proto"]
         max_keys = 0  # 0 = unlimited keys (sentinel value in InFMon API)
 
     flow_rule_add(name=scenario, fields=fields, max_keys=max_keys)


### PR DESCRIPTION
## Summary

Promote `src_port` and `dst_port` from the v2 future-extension list (spec §9.1) to the v1 field set. The backend ERSPAN parser already extracts these from packets — this PR wires them through the entire stack so they can be used in flow-rule key definitions.

## Changes

### C backend
- `INFMON_FIELD_SRC_PORT` / `INFMON_FIELD_DST_PORT` added to `infmon_field_t` enum
- Field widths: 2 bytes each (network byte order `uint16_t`)
- `infmon_flow_fields_t` gains `src_port` and `dst_port` members
- Key encoder handles the new cases
- `INFMON_FLOW_RULE_FIELDS_MAX` stays at `INFMON_FIELD__COUNT` (now 7)

### VPP API (`infmon.api`)
- `infmon_field_type` enum extended with `SRC_PORT = 5`, `DST_PORT = 6`
- `fields[]` array in messages bumped from `[5]` to `[7]`

### Rust common crate
- `Field::SrcPort` / `Field::DstPort` in config model (width = 2)
- `FieldId::SrcPort` / `FieldId::DstPort` in IPC types
- `FieldValue::Port(u16)` variant for decoded values
- `decode_key` handles 2-byte big-endian port decoding
- `field_to_field_id` mapping updated

### CLI (`infmonctl`)
- `src_port` / `dst_port` accepted in `flow-rule add fields=...`

### OTLP exporter
- `flow.src_port` / `flow.dst_port` attributes emitted

### Spec & tests
- Spec 002 §3: `src_port`/`dst_port` added to field table
- Spec 002 §9.1: removed from future-extension list
- E2E tests updated to use 5-tuple fields

## Test plan
- All 10 C++ tests pass (`ctest`)
- All Rust workspace tests pass (`cargo test --workspace`)
- CLI verified: `infmonctl flow-rule add name=test fields=src_ip,dst_ip,src_port,dst_port,ip_proto` no longer rejects the port fields
