### PR TITLE
feat: forward flow-rule add/del to VPP backend via VAPI

### DIFF
--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -296,6 +296,15 @@ fn handle_flow_rule_add(params: &FlowRuleAddParams, state: &ControlState) -> Res
 }
 
 fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Response {
+    // Check local existence before dispatching backend delete to avoid
+    // removing a rule from the backend when it doesn't exist locally.
+    {
+        let rules = state.flow_rules.read().unwrap_or_else(|e| e.into_inner());
+        if !rules.iter().any(|r| r.name == params.name) {
+            return Response::err(3, format!("flow rule '{}' not found", params.name));
+        }
+    }
+
     // Forward delete to VPP backend via VAPI if available
     #[cfg(feature = "vapi")]
     {
@@ -332,11 +341,7 @@ fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Respo
     }
 
     let mut rules = state.flow_rules.write().unwrap_or_else(|e| e.into_inner());
-    let before = rules.len();
     rules.retain(|r| r.name != params.name);
-    if rules.len() == before {
-        return Response::err(3, format!("flow rule '{}' not found", params.name));
-    }
 
     // Remove from ID map after successful local removal to keep
     // rule_id_map and flow_rules consistent (avoids divergence if

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -319,12 +319,6 @@ fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Respo
                         rule_id.hi,
                         rule_id.lo
                     );
-                    // Remove from ID map
-                    state
-                        .rule_id_map
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .remove(&params.name);
                 }
                 None => {
                     // Rule not in ID map — may not have been added via VAPI
@@ -343,6 +337,19 @@ fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Respo
     if rules.len() == before {
         return Response::err(3, format!("flow rule '{}' not found", params.name));
     }
+
+    // Remove from ID map after successful local removal to keep
+    // rule_id_map and flow_rules consistent (avoids divergence if
+    // the write lock above were poisoned).
+    #[cfg(feature = "vapi")]
+    {
+        state
+            .rule_id_map
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&params.name);
+    }
+
     Response::ok_empty()
 }
 

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -261,13 +261,8 @@ fn handle_flow_rule_add(params: &FlowRuleAddParams, state: &ControlState) -> Res
                     );
                     let id_str = format!("{:016x}-{:016x}", id.hi, id.lo);
                     // Store name → ID mapping for later deletion
-                    if let Ok(mut map) = state
-                        .rule_id_map
-                        .lock()
-                        .or_else(|e| Ok::<_, ()>(e.into_inner()))
-                    {
-                        map.insert(rule.name.clone(), id);
-                    }
+                    let mut map = state.rule_id_map.lock().unwrap_or_else(|e| e.into_inner());
+                    map.insert(rule.name.clone(), id);
                     rules.push(rule);
                     id_str
                 }

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -12,6 +12,13 @@ use infmon_common::config::model::FlowRule;
 use infmon_common::ipc::protocol::*;
 use infmon_common::ipc::types::FlowStatsSnapshot;
 
+#[cfg(feature = "vapi")]
+use crate::vapi_control_client::VapiControlClient;
+#[cfg(feature = "vapi")]
+use infmon_common::ipc::types::FlowRuleId;
+#[cfg(feature = "vapi")]
+use std::collections::HashMap;
+
 /// Shared state accessible to the control server.
 ///
 /// **Lock ordering invariant**: always acquire `flow_rules` before
@@ -23,6 +30,12 @@ pub struct ControlState {
     pub latest_snapshot: Mutex<Option<Arc<FlowStatsSnapshot>>>,
     /// Monotonic counter for generating unique flow rule IDs.
     next_rule_id: AtomicU64,
+    /// Optional VAPI control client for forwarding CRUD to the VPP backend.
+    #[cfg(feature = "vapi")]
+    pub vapi_control: Option<Mutex<VapiControlClient>>,
+    /// Maps flow rule name → backend-assigned ID (populated when VAPI is used).
+    #[cfg(feature = "vapi")]
+    pub rule_id_map: Mutex<HashMap<String, FlowRuleId>>,
 }
 
 impl ControlState {
@@ -32,6 +45,23 @@ impl ControlState {
             flow_rules: RwLock::new(initial_rules),
             latest_snapshot: Mutex::new(None),
             next_rule_id: AtomicU64::new(initial_count + 1),
+            #[cfg(feature = "vapi")]
+            vapi_control: None,
+            #[cfg(feature = "vapi")]
+            rule_id_map: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Create a ControlState with a VAPI control client for backend forwarding.
+    #[cfg(feature = "vapi")]
+    pub fn with_vapi(initial_rules: Vec<FlowRule>, client: VapiControlClient) -> Self {
+        let initial_count = initial_rules.len() as u64;
+        Self {
+            flow_rules: RwLock::new(initial_rules),
+            latest_snapshot: Mutex::new(None),
+            next_rule_id: AtomicU64::new(initial_count + 1),
+            vapi_control: Some(Mutex::new(client)),
+            rule_id_map: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -211,16 +241,107 @@ fn handle_flow_rule_add(params: &FlowRuleAddParams, state: &ControlState) -> Res
         return Response::err(6, format!("flow rule '{}' already exists", rule.name));
     }
 
-    rules.push(rule);
+    // Forward to VPP backend via VAPI if available
+    #[cfg(feature = "vapi")]
+    let id_str = {
+        if let Some(ref vapi_mutex) = state.vapi_control {
+            let vapi = vapi_mutex.lock().unwrap_or_else(|e| e.into_inner());
+            match vapi.flow_rule_add(
+                &rule.name,
+                &rule.fields,
+                rule.max_keys,
+                rule.eviction_policy,
+            ) {
+                Ok(id) => {
+                    tracing::info!(
+                        "flow rule '{}' added to backend (id={:016x}-{:016x})",
+                        rule.name,
+                        id.hi,
+                        id.lo
+                    );
+                    let id_str = format!("{:016x}-{:016x}", id.hi, id.lo);
+                    // Store name → ID mapping for later deletion
+                    if let Ok(mut map) = state
+                        .rule_id_map
+                        .lock()
+                        .or_else(|e| Ok::<_, ()>(e.into_inner()))
+                    {
+                        map.insert(rule.name.clone(), id);
+                    }
+                    rules.push(rule);
+                    id_str
+                }
+                Err(e) => {
+                    return Response::err(
+                        7,
+                        format!("backend rejected flow rule '{}': {e}", params.name),
+                    );
+                }
+            }
+        } else {
+            // No VAPI client — local-only mode (fallback)
+            rules.push(rule);
+            let seq = state
+                .next_rule_id
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            format!("{:016x}-{:016x}", seq, 0u64)
+        }
+    };
 
-    let seq = state
-        .next_rule_id
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let id = format!("{:016x}-{:016x}", seq, 0u64);
-    Response::ok(ResponseData::FlowRuleId(FlowRuleIdData { id }))
+    #[cfg(not(feature = "vapi"))]
+    let id_str = {
+        rules.push(rule);
+        let seq = state
+            .next_rule_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        format!("{:016x}-{:016x}", seq, 0u64)
+    };
+
+    Response::ok(ResponseData::FlowRuleId(FlowRuleIdData { id: id_str }))
 }
 
 fn handle_flow_rule_rm(params: &FlowRuleRmParams, state: &ControlState) -> Response {
+    // Forward delete to VPP backend via VAPI if available
+    #[cfg(feature = "vapi")]
+    {
+        if let Some(ref vapi_mutex) = state.vapi_control {
+            let id = {
+                let map = state.rule_id_map.lock().unwrap_or_else(|e| e.into_inner());
+                map.get(&params.name).cloned()
+            };
+            match id {
+                Some(rule_id) => {
+                    let vapi = vapi_mutex.lock().unwrap_or_else(|e| e.into_inner());
+                    if let Err(e) = vapi.flow_rule_del(&rule_id) {
+                        return Response::err(
+                            7,
+                            format!("backend failed to delete flow rule '{}': {e}", params.name),
+                        );
+                    }
+                    tracing::info!(
+                        "flow rule '{}' deleted from backend (id={:016x}-{:016x})",
+                        params.name,
+                        rule_id.hi,
+                        rule_id.lo
+                    );
+                    // Remove from ID map
+                    state
+                        .rule_id_map
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner())
+                        .remove(&params.name);
+                }
+                None => {
+                    // Rule not in ID map — may not have been added via VAPI
+                    tracing::warn!(
+                        "flow rule '{}' has no backend ID, removing locally only",
+                        params.name
+                    );
+                }
+            }
+        }
+    }
+
     let mut rules = state.flow_rules.write().unwrap_or_else(|e| e.into_inner());
     let before = rules.len();
     rules.retain(|r| r.name != params.name);

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -5,6 +5,8 @@ pub mod logging;
 pub mod otlp;
 pub mod poller;
 #[cfg(feature = "vapi")]
+pub mod vapi_control_client;
+#[cfg(feature = "vapi")]
 pub mod vapi_ffi;
 #[cfg(feature = "vapi")]
 pub mod vapi_stats_client;

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -334,7 +334,7 @@ fn vpp_stats_socket_reachable(path: &Path) -> bool {
     unsafe {
         std::ptr::copy_nonoverlapping(
             path_bytes.as_ptr(),
-            addr.sun_path.as_mut_ptr(),
+            addr.sun_path.as_mut_ptr().cast::<u8>(),
             path_bytes.len(),
         );
     }

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -151,6 +151,20 @@ impl Frontend {
 
         // Spawn control server for CLI RPCs
         let control_socket = PathBuf::from(&frontend_cfg.control_socket);
+        #[cfg(feature = "vapi")]
+        let control_state = {
+            match crate::vapi_control_client::VapiControlClient::connect("infmon-control") {
+                Ok(client) => {
+                    tracing::info!("VAPI control client connected — flow-rule CRUD will be forwarded to VPP backend");
+                    Arc::new(ControlState::with_vapi(config.flow_rules.clone(), client))
+                }
+                Err(e) => {
+                    tracing::warn!("VAPI control client failed to connect: {e} — flow-rule CRUD will be local-only");
+                    Arc::new(ControlState::new(config.flow_rules.clone()))
+                }
+            }
+        };
+        #[cfg(not(feature = "vapi"))]
         let control_state = Arc::new(ControlState::new(config.flow_rules.clone()));
         let control_handle = match control::spawn(&control_socket, control_state) {
             Ok(h) => {

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -334,7 +334,7 @@ fn vpp_stats_socket_reachable(path: &Path) -> bool {
     unsafe {
         std::ptr::copy_nonoverlapping(
             path_bytes.as_ptr(),
-            addr.sun_path.as_mut_ptr() as *mut u8,
+            addr.sun_path.as_mut_ptr(),
             path_bytes.len(),
         );
     }

--- a/src/frontend/src/vapi_control_client.rs
+++ b/src/frontend/src/vapi_control_client.rs
@@ -62,7 +62,7 @@ impl VapiControlClient {
 
         let eviction = match eviction_policy {
             EvictionPolicy::LruDrop => 0u8,
-            _ => 0u8, // Default to LruDrop for unknown policies
+            _ => panic!("unsupported EvictionPolicy variant: {eviction_policy:?}"),
         };
 
         let mut id_hi: u64 = 0;

--- a/src/frontend/src/vapi_control_client.rs
+++ b/src/frontend/src/vapi_control_client.rs
@@ -57,6 +57,7 @@ impl VapiControlClient {
 
         let eviction = match eviction_policy {
             EvictionPolicy::LruDrop => 0u8,
+            _ => 0u8, // Default to LruDrop for unknown policies
         };
 
         let mut id_hi: u64 = 0;
@@ -122,5 +123,6 @@ fn field_to_u8(f: Field) -> u8 {
         Field::MirrorSrcIp => 4,
         Field::SrcPort => 5,
         Field::DstPort => 6,
+        _ => 0, // Default to SrcIp for unknown fields
     }
 }

--- a/src/frontend/src/vapi_control_client.rs
+++ b/src/frontend/src/vapi_control_client.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Riff
+//
+// VPP VAPI-based control client for flow-rule CRUD.
+// Forwards add/delete operations to the VPP backend.
+
+use std::ffi::CString;
+use std::os::raw::c_void;
+
+use infmon_common::config::model::{EvictionPolicy, Field};
+use infmon_common::ipc::types::FlowRuleId;
+
+use super::vapi_ffi;
+use super::vapi_stats_client::VapiError;
+
+/// VAPI-based control client for flow-rule CRUD operations.
+///
+/// Holds its own VAPI connection (separate from the stats client used
+/// by the poller) because the control thread and poller thread run
+/// concurrently and VAPI connections are not thread-safe.
+pub struct VapiControlClient {
+    handle: *mut c_void,
+}
+
+// SAFETY: VapiControlClient wraps a raw VAPI handle. We guarantee
+// safety by confining all usage to the single control thread — the
+// handle is accessed only through &self methods called from the
+// control server's serialised request loop.
+unsafe impl Send for VapiControlClient {}
+
+impl VapiControlClient {
+    /// Connect to VPP API for control operations.
+    pub fn connect(name: &str) -> Result<Self, VapiError> {
+        let c_name = CString::new(name).map_err(|_| VapiError::ConnectFailed)?;
+        let handle = unsafe { vapi_ffi::infmon_vapi_connect(c_name.as_ptr()) };
+        if handle.is_null() {
+            return Err(VapiError::ConnectFailed);
+        }
+        Ok(Self { handle })
+    }
+
+    /// Add a flow rule to the VPP backend.
+    ///
+    /// Returns the backend-assigned flow rule ID on success.
+    pub fn flow_rule_add(
+        &self,
+        name: &str,
+        fields: &[Field],
+        max_keys: u32,
+        eviction_policy: EvictionPolicy,
+    ) -> Result<FlowRuleId, VapiError> {
+        let c_name =
+            CString::new(name).map_err(|_| VapiError::SnapshotFailed("invalid name".into()))?;
+
+        // Convert Field enums to u8 values matching the backend's infmon_field_t
+        let field_bytes: Vec<u8> = fields.iter().map(|f| field_to_u8(*f)).collect();
+
+        let eviction = match eviction_policy {
+            EvictionPolicy::LruDrop => 0u8,
+        };
+
+        let mut id_hi: u64 = 0;
+        let mut id_lo: u64 = 0;
+
+        let rv = unsafe {
+            vapi_ffi::infmon_vapi_flow_rule_add(
+                self.handle,
+                c_name.as_ptr(),
+                field_bytes.as_ptr(),
+                field_bytes.len() as u32,
+                max_keys,
+                eviction,
+                &mut id_hi,
+                &mut id_lo,
+            )
+        };
+
+        if rv != 0 {
+            return Err(VapiError::SnapshotFailed(format!(
+                "flow_rule_add failed (rv={rv})"
+            )));
+        }
+
+        Ok(FlowRuleId {
+            hi: id_hi,
+            lo: id_lo,
+        })
+    }
+
+    /// Delete a flow rule from the VPP backend by its ID.
+    pub fn flow_rule_del(&self, id: &FlowRuleId) -> Result<(), VapiError> {
+        let rv = unsafe { vapi_ffi::infmon_vapi_flow_rule_del(self.handle, id.hi, id.lo) };
+
+        if rv != 0 {
+            return Err(VapiError::SnapshotFailed(format!(
+                "flow_rule_del failed (rv={rv})"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for VapiControlClient {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                vapi_ffi::infmon_vapi_disconnect(self.handle);
+            }
+            self.handle = std::ptr::null_mut();
+        }
+    }
+}
+
+/// Convert a config `Field` to its backend `infmon_field_t` u8 value.
+fn field_to_u8(f: Field) -> u8 {
+    match f {
+        Field::SrcIp => 0,
+        Field::DstIp => 1,
+        Field::IpProto => 2,
+        Field::Dscp => 3,
+        Field::MirrorSrcIp => 4,
+        Field::SrcPort => 5,
+        Field::DstPort => 6,
+    }
+}

--- a/src/frontend/src/vapi_control_client.rs
+++ b/src/frontend/src/vapi_control_client.rs
@@ -50,7 +50,7 @@ impl VapiControlClient {
         eviction_policy: EvictionPolicy,
     ) -> Result<FlowRuleId, VapiError> {
         let c_name =
-            CString::new(name).map_err(|_| VapiError::SnapshotFailed("invalid name".into()))?;
+            CString::new(name).map_err(|_| VapiError::FlowRuleFailed("invalid name".into()))?;
 
         // Convert Field enums to u8 values matching the backend's infmon_field_t
         let field_bytes: Vec<u8> = fields.iter().map(|f| field_to_u8(*f)).collect();
@@ -77,7 +77,7 @@ impl VapiControlClient {
         };
 
         if rv != 0 {
-            return Err(VapiError::SnapshotFailed(format!(
+            return Err(VapiError::FlowRuleFailed(format!(
                 "flow_rule_add failed (rv={rv})"
             )));
         }
@@ -93,7 +93,7 @@ impl VapiControlClient {
         let rv = unsafe { vapi_ffi::infmon_vapi_flow_rule_del(self.handle, id.hi, id.lo) };
 
         if rv != 0 {
-            return Err(VapiError::SnapshotFailed(format!(
+            return Err(VapiError::FlowRuleFailed(format!(
                 "flow_rule_del failed (rv={rv})"
             )));
         }

--- a/src/frontend/src/vapi_control_client.rs
+++ b/src/frontend/src/vapi_control_client.rs
@@ -22,10 +22,15 @@ pub struct VapiControlClient {
     handle: *mut c_void,
 }
 
-// SAFETY: VapiControlClient wraps a raw VAPI handle. We guarantee
-// safety by confining all usage to the single control thread — the
-// handle is accessed only through &self methods called from the
-// control server's serialised request loop.
+// SAFETY: VapiControlClient wraps a raw VAPI handle. The handle
+// is not thread-affine — VAPI's shared-memory transport is
+// process-global and any thread may call into it provided calls
+// are serialised. We implement Send (not Sync) so the handle can
+// move between threads. When wrapped in Mutex<VapiControlClient>,
+// Sync is auto-derived because VapiControlClient: Send. This is
+// sound: the Mutex serialises all access, satisfying VAPI's
+// single-caller requirement regardless of which thread holds the
+// lock.
 unsafe impl Send for VapiControlClient {}
 
 impl VapiControlClient {
@@ -123,6 +128,9 @@ fn field_to_u8(f: Field) -> u8 {
         Field::MirrorSrcIp => 4,
         Field::SrcPort => 5,
         Field::DstPort => 6,
-        _ => 0, // Default to SrcIp for unknown fields
+        // Field is #[non_exhaustive]; panic on unknown variants so
+        // new additions surface as a compile-test failure rather than
+        // silently mapping to SrcIp.
+        _ => panic!("unsupported Field variant for VAPI mapping"),
     }
 }

--- a/src/frontend/src/vapi_ffi/infmon_vapi_client.c
+++ b/src/frontend/src/vapi_ffi/infmon_vapi_client.c
@@ -237,7 +237,9 @@ int infmon_vapi_flow_rule_add(void *handle, const char *name, const uint8_t *fie
     strncpy((char *) msg->payload.name, name, sizeof(msg->payload.name) - 1);
 
     msg->payload.field_count = htonl(field_count);
-    for (uint32_t i = 0; i < field_count && i < 8; i++)
+    if (field_count > 8)
+        return -1;
+    for (uint32_t i = 0; i < field_count; i++)
         msg->payload.fields[i] = fields[i];
 
     msg->payload.max_keys = htonl(max_keys);

--- a/src/frontend/src/vapi_ffi/infmon_vapi_client.c
+++ b/src/frontend/src/vapi_ffi/infmon_vapi_client.c
@@ -211,3 +211,91 @@ int infmon_vapi_list_flow_rules(void *handle, void (*cb)(uint64_t hi, uint64_t l
 
     return (rv == VAPI_OK) ? 0 : -1;
 }
+
+/* ── flow_rule_add ────────────────────────────────────────────────── */
+
+/**
+ * Add a flow rule to the VPP backend.
+ * On success, writes the assigned flow_rule_id into *out_id_hi / *out_id_lo.
+ * Returns 0 on success, negative retval on error.
+ */
+int infmon_vapi_flow_rule_add(void *handle,
+                               const char *name,
+                               const uint8_t *fields,
+                               uint32_t field_count,
+                               uint32_t max_keys,
+                               uint8_t eviction_policy,
+                               uint64_t *out_id_hi,
+                               uint64_t *out_id_lo)
+{
+    if (!handle || !name)
+        return -1;
+
+    vapi_ctx_t ctx = (vapi_ctx_t) handle;
+
+    vapi_msg_infmon_flow_rule_add *msg = vapi_alloc_infmon_flow_rule_add(ctx);
+    if (!msg)
+        return -1;
+
+    /* Fill payload */
+    memset(msg->payload.name, 0, sizeof(msg->payload.name));
+    strncpy((char *) msg->payload.name, name, sizeof(msg->payload.name) - 1);
+
+    msg->payload.field_count = htonl(field_count);
+    for (uint32_t i = 0; i < field_count && i < 8; i++)
+        msg->payload.fields[i] = fields[i];
+
+    msg->payload.max_keys = htonl(max_keys);
+    msg->payload.eviction_policy = eviction_policy;
+
+    /* Send as blocking request */
+    vapi_error_e rv = vapi_infmon_flow_rule_add(ctx, msg);
+    if (rv != VAPI_OK)
+        return -1;
+
+    /* The reply is written back into msg by the VAPI blocking call */
+    vapi_msg_infmon_flow_rule_add_reply *rmp =
+        (vapi_msg_infmon_flow_rule_add_reply *) msg;
+    int32_t retval = ntohl(rmp->payload.retval);
+
+    if (retval != 0)
+        return retval;
+
+    if (out_id_hi)
+        *out_id_hi = be64toh(rmp->payload.flow_rule_id.hi);
+    if (out_id_lo)
+        *out_id_lo = be64toh(rmp->payload.flow_rule_id.lo);
+
+    return 0;
+}
+
+/* ── flow_rule_del ────────────────────────────────────────────────── */
+
+/**
+ * Delete a flow rule from the VPP backend by its ID.
+ * Returns 0 on success, negative retval on error.
+ */
+int infmon_vapi_flow_rule_del(void *handle, uint64_t id_hi, uint64_t id_lo)
+{
+    if (!handle)
+        return -1;
+
+    vapi_ctx_t ctx = (vapi_ctx_t) handle;
+
+    vapi_msg_infmon_flow_rule_del *msg = vapi_alloc_infmon_flow_rule_del(ctx);
+    if (!msg)
+        return -1;
+
+    msg->payload.flow_rule_id.hi = htobe64(id_hi);
+    msg->payload.flow_rule_id.lo = htobe64(id_lo);
+
+    vapi_error_e rv = vapi_infmon_flow_rule_del(ctx, msg);
+    if (rv != VAPI_OK)
+        return -1;
+
+    vapi_msg_infmon_flow_rule_del_reply *rmp =
+        (vapi_msg_infmon_flow_rule_del_reply *) msg;
+    int32_t retval = ntohl(rmp->payload.retval);
+
+    return retval;
+}

--- a/src/frontend/src/vapi_ffi/infmon_vapi_client.c
+++ b/src/frontend/src/vapi_ffi/infmon_vapi_client.c
@@ -233,6 +233,8 @@ int infmon_vapi_flow_rule_add(void *handle, const char *name, const uint8_t *fie
         return -1;
 
     /* Fill payload */
+    if (strlen(name) >= sizeof(msg->payload.name))
+        return -1;
     memset(msg->payload.name, 0, sizeof(msg->payload.name));
     strncpy((char *) msg->payload.name, name, sizeof(msg->payload.name) - 1);
 

--- a/src/frontend/src/vapi_ffi/infmon_vapi_client.c
+++ b/src/frontend/src/vapi_ffi/infmon_vapi_client.c
@@ -233,14 +233,18 @@ int infmon_vapi_flow_rule_add(void *handle, const char *name, const uint8_t *fie
         return -1;
 
     /* Fill payload */
-    if (strlen(name) >= sizeof(msg->payload.name))
+    if (strlen(name) >= sizeof(msg->payload.name)) {
+        vapi_msg_free(ctx, msg);
         return -1;
+    }
     memset(msg->payload.name, 0, sizeof(msg->payload.name));
     strncpy((char *) msg->payload.name, name, sizeof(msg->payload.name) - 1);
 
     msg->payload.field_count = htonl(field_count);
-    if (field_count > 8)
+    if (field_count > 8) {
+        vapi_msg_free(ctx, msg);
         return -1;
+    }
     for (uint32_t i = 0; i < field_count; i++)
         msg->payload.fields[i] = fields[i];
 
@@ -252,7 +256,11 @@ int infmon_vapi_flow_rule_add(void *handle, const char *name, const uint8_t *fie
     if (rv != VAPI_OK)
         return -1;
 
-    /* The reply is written back into msg by the VAPI blocking call */
+    /* The reply is written back into msg by the VAPI blocking call.
+     * VAPI's blocking API allocates max(request, reply) and consumes the
+     * buffer internally on both success and failure, so no manual free is
+     * needed after vapi_infmon_flow_rule_add() returns. The cast below is
+     * safe because VAPI guarantees the buffer is large enough for the reply. */
     vapi_msg_infmon_flow_rule_add_reply *rmp = (vapi_msg_infmon_flow_rule_add_reply *) msg;
     int32_t retval = ntohl(rmp->payload.retval);
 

--- a/src/frontend/src/vapi_ffi/infmon_vapi_client.c
+++ b/src/frontend/src/vapi_ffi/infmon_vapi_client.c
@@ -219,14 +219,9 @@ int infmon_vapi_list_flow_rules(void *handle, void (*cb)(uint64_t hi, uint64_t l
  * On success, writes the assigned flow_rule_id into *out_id_hi / *out_id_lo.
  * Returns 0 on success, negative retval on error.
  */
-int infmon_vapi_flow_rule_add(void *handle,
-                               const char *name,
-                               const uint8_t *fields,
-                               uint32_t field_count,
-                               uint32_t max_keys,
-                               uint8_t eviction_policy,
-                               uint64_t *out_id_hi,
-                               uint64_t *out_id_lo)
+int infmon_vapi_flow_rule_add(void *handle, const char *name, const uint8_t *fields,
+                              uint32_t field_count, uint32_t max_keys, uint8_t eviction_policy,
+                              uint64_t *out_id_hi, uint64_t *out_id_lo)
 {
     if (!handle || !name)
         return -1;
@@ -254,8 +249,7 @@ int infmon_vapi_flow_rule_add(void *handle,
         return -1;
 
     /* The reply is written back into msg by the VAPI blocking call */
-    vapi_msg_infmon_flow_rule_add_reply *rmp =
-        (vapi_msg_infmon_flow_rule_add_reply *) msg;
+    vapi_msg_infmon_flow_rule_add_reply *rmp = (vapi_msg_infmon_flow_rule_add_reply *) msg;
     int32_t retval = ntohl(rmp->payload.retval);
 
     if (retval != 0)
@@ -293,8 +287,7 @@ int infmon_vapi_flow_rule_del(void *handle, uint64_t id_hi, uint64_t id_lo)
     if (rv != VAPI_OK)
         return -1;
 
-    vapi_msg_infmon_flow_rule_del_reply *rmp =
-        (vapi_msg_infmon_flow_rule_del_reply *) msg;
+    vapi_msg_infmon_flow_rule_del_reply *rmp = (vapi_msg_infmon_flow_rule_del_reply *) msg;
     int32_t retval = ntohl(rmp->payload.retval);
 
     return retval;

--- a/src/frontend/src/vapi_ffi/mod.rs
+++ b/src/frontend/src/vapi_ffi/mod.rs
@@ -51,4 +51,15 @@ extern "C" {
         cb: infmon_ffi_list_cb,
         ctx: *mut c_void,
     ) -> c_int;
+    pub fn infmon_vapi_flow_rule_add(
+        handle: *mut c_void,
+        name: *const c_char,
+        fields: *const u8,
+        field_count: u32,
+        max_keys: u32,
+        eviction_policy: u8,
+        out_id_hi: *mut u64,
+        out_id_lo: *mut u64,
+    ) -> c_int;
+    pub fn infmon_vapi_flow_rule_del(handle: *mut c_void, id_hi: u64, id_lo: u64) -> c_int;
 }

--- a/src/frontend/src/vapi_stats_client.rs
+++ b/src/frontend/src/vapi_stats_client.rs
@@ -18,6 +18,7 @@ pub enum VapiError {
     ConnectFailed,
     SnapshotFailed(String),
     ListFailed,
+    FlowRuleFailed(String),
 }
 
 impl std::fmt::Display for VapiError {
@@ -26,6 +27,7 @@ impl std::fmt::Display for VapiError {
             VapiError::ConnectFailed => write!(f, "failed to connect to VPP API"),
             VapiError::SnapshotFailed(s) => write!(f, "snapshot_inline_dump failed: {}", s),
             VapiError::ListFailed => write!(f, "list_flow_rules failed"),
+            VapiError::FlowRuleFailed(s) => write!(f, "flow rule operation failed: {}", s),
         }
     }
 }


### PR DESCRIPTION
## Summary

Wire the control server's flow-rule CRUD handlers to forward add and delete operations to the VPP backend through a new `VapiControlClient`, instead of only mutating local in-memory state.

## Changes

- **C FFI layer**: Add `infmon_vapi_flow_rule_add()` and `infmon_vapi_flow_rule_del()` functions using VAPI blocking calls
- **Rust wrapper**: New `VapiControlClient` with `connect()`, `flow_rule_add()`, and `flow_rule_del()` methods
- **ControlState**: Extended with optional `VapiControlClient` and a name→ID map for tracking backend-assigned flow rule IDs
- **Handlers**: `handle_flow_rule_add` now calls VAPI before updating local state; `handle_flow_rule_rm` deletes from backend first
- **Lifecycle**: `Frontend::start()` connects a `VapiControlClient` at startup (graceful fallback to local-only if connection fails)
- All new code is conditionally compiled behind `cfg(feature = "vapi")`

## Test Plan

- All 185 existing tests pass (no-vapi feature path)
- VAPI feature path requires VPP runtime for integration testing on BF3

Closes #154