### PR TITLE
feat: per-worker counter tables to eliminate cross-worker contention

### DIFF
--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -46,7 +46,7 @@ typedef struct {
     infmon_snapshot_mgr_t *snap_mgr; /**< Optional; required for snapshot_and_clear. */
     /* private: Per-rule counter tables, indexed by rule position in the set.
      * Managed internally by add/del; caller must not touch. */
-    infmon_counter_table_t *tables[INFMON_FLOW_RULE_SET_MAX];
+    infmon_counter_table_t *tables[INFMON_MAX_WORKERS][INFMON_FLOW_RULE_SET_MAX];
     /* Per-rule UUID, indexed in parallel with tables[]. */
     infmon_flow_rule_id_t flow_rule_ids[INFMON_FLOW_RULE_SET_MAX];
     /* Per-worker status counters (set by caller, read by infmon_api_status). */
@@ -64,7 +64,8 @@ typedef struct {
     infmon_api_result_t result;
     infmon_stats_descriptor_t descriptor; /**< Populated on success. */
     infmon_counter_table_t
-        *retired_table; /**< Direct pointer to the retired table (VPP-internal). */
+        *retired_tables[INFMON_MAX_WORKERS]; /**< Per-worker retired tables. */
+    uint32_t num_retired;                    /**< Number of retired tables. */
 } infmon_api_snap_reply_t;
 
 /* ── Lifecycle ───────────────────────────────────────────────────── */

--- a/src/backend/include/infmon/api_handler.h
+++ b/src/backend/include/infmon/api_handler.h
@@ -62,10 +62,9 @@ typedef struct {
  */
 typedef struct {
     infmon_api_result_t result;
-    infmon_stats_descriptor_t descriptor; /**< Populated on success. */
-    infmon_counter_table_t
-        *retired_tables[INFMON_MAX_WORKERS]; /**< Per-worker retired tables. */
-    uint32_t num_retired;                    /**< Number of retired tables. */
+    infmon_stats_descriptor_t descriptor;                       /**< Populated on success. */
+    infmon_counter_table_t *retired_tables[INFMON_MAX_WORKERS]; /**< Per-worker retired tables. */
+    uint32_t num_retired;                                       /**< Number of retired tables. */
 } infmon_api_snap_reply_t;
 
 /* ── Lifecycle ───────────────────────────────────────────────────── */

--- a/src/backend/include/infmon/graph_node.h
+++ b/src/backend/include/infmon/graph_node.h
@@ -25,6 +25,7 @@
 #include "infmon/counter_table.h"
 #include "infmon/erspan_parser.h"
 #include "infmon/flow_rule.h"
+#include "infmon/snapshot.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -178,8 +179,9 @@ typedef struct {
 
 typedef struct {
     const infmon_flow_rule_set_ref_t *flow_rule_set;
-    infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES];
+    infmon_counter_table_t *tables[INFMON_MAX_WORKERS][INFMON_MAX_ACTIVE_FLOW_RULES];
     uint64_t tick;
+    uint32_t num_workers; /* number of active workers */
 } infmon_plugin_main_t;
 
 /* ── Key encoding buffer (per-worker, reused across packets) ─────── */

--- a/src/backend/include/infmon/snapshot.h
+++ b/src/backend/include/infmon/snapshot.h
@@ -46,7 +46,8 @@ typedef struct {
 /* ── Retired table descriptor ────────────────────────────────────── */
 
 typedef struct {
-    infmon_counter_table_t *table; /**< The retired table. */
+    infmon_counter_table_t *tables[INFMON_MAX_WORKERS]; /**< Retired tables, one per worker. */
+    uint32_t num_tables;           /**< Number of workers that had tables. */
     uint64_t swap_epoch;           /**< Global epoch at time of swap. */
     uint64_t swap_timestamp_ns;    /**< Wall-clock timestamp of swap. */
     uint32_t flow_rule_index;      /**< Which flow_rule this belonged to. */
@@ -96,8 +97,9 @@ typedef enum {
 
 typedef struct {
     infmon_snap_result_t result;
-    infmon_counter_table_t *retired_table; /**< The old table (generation G). */
-    uint64_t retired_generation;           /**< Generation of the retired table. */
+    infmon_counter_table_t *retired_tables[INFMON_MAX_WORKERS]; /**< Per-worker retired tables. */
+    uint32_t num_retired;              /**< Number of retired tables (= num_workers). */
+    uint64_t retired_generation;       /**< Generation of the retired tables. */
 } infmon_snap_reply_t;
 
 /* ── Lifecycle ───────────────────────────────────────────────────── */
@@ -153,13 +155,16 @@ static inline uint64_t infmon_worker_epoch_read(const infmon_snapshot_mgr_t *mgr
  * 4. Enqueues the old table for RCU retirement.
  *
  * @param mgr              Snapshot manager.
- * @param tables           Pointer to the tables array (e.g. pm->tables).
+ * @param tables_flat      Pointer to first element of 2D tables array.
+ * @param tables_stride    Number of flow rule slots per worker row.
+ * @param num_workers      Number of workers (rows in tables).
  * @param flow_rule_index  Index of the flow_rule to snapshot.
  * @param max_flow_rules   Size of the tables array.
  * @param max_key_width    Key width for the new table (same as old).
  * @param reply            Output: result + retired table info.
  */
-void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_t **tables,
+void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_t **tables_flat,
+                               uint32_t tables_stride, uint32_t num_workers,
                                uint32_t flow_rule_index, uint32_t max_flow_rules,
                                uint32_t max_key_width, infmon_snap_reply_t *reply);
 

--- a/src/backend/include/infmon/snapshot.h
+++ b/src/backend/include/infmon/snapshot.h
@@ -47,11 +47,11 @@ typedef struct {
 
 typedef struct {
     infmon_counter_table_t *tables[INFMON_MAX_WORKERS]; /**< Retired tables, one per worker. */
-    uint32_t num_tables;           /**< Number of workers that had tables. */
-    uint64_t swap_epoch;           /**< Global epoch at time of swap. */
-    uint64_t swap_timestamp_ns;    /**< Wall-clock timestamp of swap. */
-    uint32_t flow_rule_index;      /**< Which flow_rule this belonged to. */
-    bool pending;                  /**< true if still awaiting retirement. */
+    uint32_t num_tables;                                /**< Number of workers that had tables. */
+    uint64_t swap_epoch;                                /**< Global epoch at time of swap. */
+    uint64_t swap_timestamp_ns;                         /**< Wall-clock timestamp of swap. */
+    uint32_t flow_rule_index;                           /**< Which flow_rule this belonged to. */
+    bool pending;                                       /**< true if still awaiting retirement. */
 } infmon_retired_table_t;
 
 /* ── Snapshot manager ────────────────────────────────────────────── */
@@ -98,8 +98,8 @@ typedef enum {
 typedef struct {
     infmon_snap_result_t result;
     infmon_counter_table_t *retired_tables[INFMON_MAX_WORKERS]; /**< Per-worker retired tables. */
-    uint32_t num_retired;              /**< Number of retired tables (= num_workers). */
-    uint64_t retired_generation;       /**< Generation of the retired tables. */
+    uint32_t num_retired;        /**< Number of retired tables (= num_workers). */
+    uint64_t retired_generation; /**< Generation of the retired tables. */
 } infmon_snap_reply_t;
 
 /* ── Lifecycle ───────────────────────────────────────────────────── */

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -96,10 +96,12 @@ void infmon_api_ctx_destroy(infmon_api_ctx_t *ctx)
 {
     if (!ctx)
         return;
-    for (uint32_t i = 0; i < INFMON_FLOW_RULE_SET_MAX; i++) {
-        if (ctx->tables[i]) {
-            infmon_counter_table_destroy(ctx->tables[i]);
-            ctx->tables[i] = NULL;
+    for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++) {
+        for (uint32_t i = 0; i < INFMON_FLOW_RULE_SET_MAX; i++) {
+            if (ctx->tables[w][i]) {
+                infmon_counter_table_destroy(ctx->tables[w][i]);
+                ctx->tables[w][i] = NULL;
+            }
         }
     }
     memset(ctx, 0, sizeof(*ctx));
@@ -137,14 +139,21 @@ static infmon_api_result_t flow_rule_add_internal(infmon_api_ctx_t *ctx,
         return INFMON_API_ERR_INTERNAL;
     }
 
-    /* 4. Create a counter table. */
-    infmon_counter_table_t *ct =
-        infmon_counter_table_create(inserted->max_keys, inserted->key_width);
-    if (!ct) {
-        infmon_flow_rule_rm(ctx->rule_set, rule->name);
-        return INFMON_API_ERR_INTERNAL;
+    /* 4. Create counter tables for each worker. */
+    uint32_t nw = ctx->worker_count > 0 ? ctx->worker_count : 1;
+    for (uint32_t w = 0; w < nw; w++) {
+        infmon_counter_table_t *ct =
+            infmon_counter_table_create(inserted->max_keys, inserted->key_width);
+        if (!ct) {
+            for (uint32_t cw = 0; cw < w; cw++) {
+                infmon_counter_table_destroy(ctx->tables[cw][idx]);
+                ctx->tables[cw][idx] = NULL;
+            }
+            infmon_flow_rule_rm(ctx->rule_set, rule->name);
+            return INFMON_API_ERR_INTERNAL;
+        }
+        ctx->tables[w][idx] = ct;
     }
-    ctx->tables[idx] = ct;
 
     /* 5. Record the flow_rule_id if provided, otherwise zero out the slot
      *    to avoid stale IDs from a previous occupant of this index. */
@@ -184,19 +193,24 @@ infmon_api_result_t infmon_api_flow_rule_del(infmon_api_ctx_t *ctx, const char *
     if (rr != INFMON_FLOW_RULE_OK)
         return map_rule_result(rr);
 
-    /* 3. Destroy the counter table (rule is already gone, safe to free). */
-    if (ctx->tables[idx]) {
-        infmon_counter_table_destroy(ctx->tables[idx]);
-        ctx->tables[idx] = NULL;
+    /* 3. Destroy the counter tables for all workers. */
+    uint32_t nw = ctx->worker_count > 0 ? ctx->worker_count : 1;
+    for (uint32_t w = 0; w < nw; w++) {
+        if (ctx->tables[w][idx]) {
+            infmon_counter_table_destroy(ctx->tables[w][idx]);
+            ctx->tables[w][idx] = NULL;
+        }
     }
 
     /* 4. Compact the tables and flow_rule_ids arrays (rm shifts entries in the set). */
     uint32_t count = infmon_flow_rule_count(ctx->rule_set);
     for (uint32_t i = idx; i < count; i++) {
-        ctx->tables[i] = ctx->tables[i + 1];
+        for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++)
+            ctx->tables[w][i] = ctx->tables[w][i + 1];
         ctx->flow_rule_ids[i] = ctx->flow_rule_ids[i + 1];
     }
-    ctx->tables[count] = NULL;
+    for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++)
+        ctx->tables[w][count] = NULL;
     memset(&ctx->flow_rule_ids[count], 0, sizeof(ctx->flow_rule_ids[0]));
 
     return INFMON_API_OK;
@@ -295,7 +309,9 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
         reply->result = INFMON_API_ERR_INTERNAL;
         return INFMON_API_ERR_INTERNAL;
     }
-    infmon_snapshot_and_clear(ctx->snap_mgr, ctx->tables, idx, INFMON_FLOW_RULE_SET_MAX,
+    infmon_snapshot_and_clear(ctx->snap_mgr, &ctx->tables[0][0], INFMON_FLOW_RULE_SET_MAX,
+                              ctx->worker_count > 0 ? ctx->worker_count : 1,
+                              idx, INFMON_FLOW_RULE_SET_MAX,
                               rule->key_width, &snap_reply);
 
     reply->result = map_snap_result(snap_reply.result);
@@ -303,8 +319,8 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
     if (snap_reply.result != INFMON_SNAP_OK)
         return reply->result;
 
-    /* Build the descriptor from the retired table. */
-    infmon_counter_table_t *retired = snap_reply.retired_table;
+    /* Build the descriptor from the first retired table. */
+    infmon_counter_table_t *retired = snap_reply.retired_tables[0];
     infmon_stats_descriptor_t *desc = &reply->descriptor;
 
     desc->flow_rule_id = flow_rule_id;
@@ -323,8 +339,10 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
     desc->table_full = retired->table_full;
     desc->active = 1;
 
-    /* Expose the retired table pointer for inline callers. */
-    reply->retired_table = retired;
+    /* Expose the retired tables for inline callers. */
+    for (uint32_t w = 0; w < snap_reply.num_retired; w++)
+        reply->retired_tables[w] = snap_reply.retired_tables[w];
+    reply->num_retired = snap_reply.num_retired;
 
     return INFMON_API_OK;
 }

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -304,6 +304,7 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
 
     /* Delegate to the snapshot manager. */
     infmon_snap_reply_t snap_reply;
+    memset(&snap_reply, 0, sizeof(snap_reply));
     const infmon_flow_rule_t *rule = infmon_flow_rule_get(ctx->rule_set, idx);
     if (!rule) {
         reply->result = INFMON_API_ERR_INTERNAL;

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -310,9 +310,8 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
         return INFMON_API_ERR_INTERNAL;
     }
     infmon_snapshot_and_clear(ctx->snap_mgr, &ctx->tables[0][0], INFMON_FLOW_RULE_SET_MAX,
-                              ctx->worker_count > 0 ? ctx->worker_count : 1,
-                              idx, INFMON_FLOW_RULE_SET_MAX,
-                              rule->key_width, &snap_reply);
+                              ctx->worker_count > 0 ? ctx->worker_count : 1, idx,
+                              INFMON_FLOW_RULE_SET_MAX, rule->key_width, &snap_reply);
 
     reply->result = map_snap_result(snap_reply.result);
 

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -205,11 +205,11 @@ infmon_api_result_t infmon_api_flow_rule_del(infmon_api_ctx_t *ctx, const char *
     /* 4. Compact the tables and flow_rule_ids arrays (rm shifts entries in the set). */
     uint32_t count = infmon_flow_rule_count(ctx->rule_set);
     for (uint32_t i = idx; i < count; i++) {
-        for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++)
+        for (uint32_t w = 0; w < nw; w++)
             ctx->tables[w][i] = ctx->tables[w][i + 1];
         ctx->flow_rule_ids[i] = ctx->flow_rule_ids[i + 1];
     }
-    for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++)
+    for (uint32_t w = 0; w < nw; w++)
         ctx->tables[w][count] = NULL;
     memset(&ctx->flow_rule_ids[count], 0, sizeof(ctx->flow_rule_ids[0]));
 

--- a/src/backend/src/api_handler.c
+++ b/src/backend/src/api_handler.c
@@ -318,7 +318,7 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
     if (snap_reply.result != INFMON_SNAP_OK)
         return reply->result;
 
-    /* Build the descriptor from the first retired table. */
+    /* Build the descriptor by aggregating across all retired worker tables. */
     infmon_counter_table_t *retired = snap_reply.retired_tables[0];
     infmon_stats_descriptor_t *desc = &reply->descriptor;
 
@@ -334,8 +334,18 @@ infmon_api_result_t infmon_api_snapshot_and_clear(infmon_api_ctx_t *ctx,
     desc->key_arena_offset = infmon_stats_offset_of(seg_base, retired->key_arena);
     desc->key_arena_capacity = retired->key_arena_capacity;
     desc->key_arena_used = retired->key_arena_used;
-    desc->insert_failed = retired->insert_failed;
-    desc->table_full = retired->table_full;
+
+    /* Aggregate insert_failed and table_full across all workers. */
+    uint64_t total_insert_failed = 0;
+    uint64_t total_table_full = 0;
+    for (uint32_t w = 0; w < snap_reply.num_retired; w++) {
+        if (snap_reply.retired_tables[w]) {
+            total_insert_failed += snap_reply.retired_tables[w]->insert_failed;
+            total_table_full |= snap_reply.retired_tables[w]->table_full;
+        }
+    }
+    desc->insert_failed = total_insert_failed;
+    desc->table_full = total_table_full;
     desc->active = 1;
 
     /* Expose the retired tables for inline callers. */

--- a/src/backend/src/snapshot.c
+++ b/src/backend/src/snapshot.c
@@ -130,6 +130,7 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
 
     /* Swap each worker's table (reusing old pointers from allocation pass) */
     uint64_t gen = 0;
+    bool gen_set = false;
     for (uint32_t w = 0; w < nw; w++) {
         if (!old_tables[w] || !new_tables[w])
             continue;
@@ -137,8 +138,10 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
         uint64_t new_gen = old_tables[w]->generation + 1;
         new_tables[w]->generation = new_gen;
         new_tables[w]->epoch_ns = now;
-        if (w == 0)
+        if (!gen_set) {
             gen = old_tables[w]->generation;
+            gen_set = true;
+        }
 
         __atomic_store_n(&tables_flat[w * tables_stride + flow_rule_index], new_tables[w],
                          __ATOMIC_RELEASE);

--- a/src/backend/src/snapshot.c
+++ b/src/backend/src/snapshot.c
@@ -86,7 +86,8 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
     uint32_t nw = num_workers > 0 ? num_workers : 1;
 
     /* Get the current table from worker 0 to check existence */
-    infmon_counter_table_t *old_table0 = __atomic_load_n(&tables_flat[0 * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
+    infmon_counter_table_t *old_table0 =
+        __atomic_load_n(&tables_flat[0 * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
 
     if (!old_table0) {
         reply->result = INFMON_SNAP_NULL_TABLE;
@@ -102,8 +103,10 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
     /* Allocate new tables for all workers */
     infmon_counter_table_t *new_tables[INFMON_MAX_WORKERS] = {0};
     for (uint32_t w = 0; w < nw; w++) {
-        infmon_counter_table_t *old_w = __atomic_load_n(&tables_flat[w * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
-        if (!old_w) continue;
+        infmon_counter_table_t *old_w =
+            __atomic_load_n(&tables_flat[w * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
+        if (!old_w)
+            continue;
         new_tables[w] = infmon_counter_table_create(old_w->num_slots, max_key_width);
         if (!new_tables[w]) {
             /* Cleanup already allocated */
@@ -127,15 +130,19 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
     infmon_counter_table_t *old_tables[INFMON_MAX_WORKERS] = {0};
     uint64_t gen = 0;
     for (uint32_t w = 0; w < nw; w++) {
-        infmon_counter_table_t *old_w = __atomic_load_n(&tables_flat[w * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
-        if (!old_w || !new_tables[w]) continue;
+        infmon_counter_table_t *old_w =
+            __atomic_load_n(&tables_flat[w * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
+        if (!old_w || !new_tables[w])
+            continue;
 
         uint64_t new_gen = old_w->generation + 1;
         new_tables[w]->generation = new_gen;
         new_tables[w]->epoch_ns = now;
-        if (w == 0) gen = old_w->generation;
+        if (w == 0)
+            gen = old_w->generation;
 
-        __atomic_store_n(&tables_flat[w * tables_stride + flow_rule_index], new_tables[w], __ATOMIC_RELEASE);
+        __atomic_store_n(&tables_flat[w * tables_stride + flow_rule_index], new_tables[w],
+                         __ATOMIC_RELEASE);
         old_tables[w] = old_w;
     }
 

--- a/src/backend/src/snapshot.c
+++ b/src/backend/src/snapshot.c
@@ -100,11 +100,13 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
         return;
     }
 
-    /* Allocate new tables for all workers */
+    /* Allocate new tables for all workers, saving old pointers to avoid TOCTOU */
     infmon_counter_table_t *new_tables[INFMON_MAX_WORKERS] = {0};
+    infmon_counter_table_t *old_tables[INFMON_MAX_WORKERS] = {0};
     for (uint32_t w = 0; w < nw; w++) {
         infmon_counter_table_t *old_w =
             __atomic_load_n(&tables_flat[w * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
+        old_tables[w] = old_w;
         if (!old_w)
             continue;
         new_tables[w] = infmon_counter_table_create(old_w->num_slots, max_key_width);
@@ -126,24 +128,20 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
     /* Bump global epoch for this swap */
     uint64_t swap_epoch = ++mgr->global_epoch;
 
-    /* Swap each worker's table */
-    infmon_counter_table_t *old_tables[INFMON_MAX_WORKERS] = {0};
+    /* Swap each worker's table (reusing old pointers from allocation pass) */
     uint64_t gen = 0;
     for (uint32_t w = 0; w < nw; w++) {
-        infmon_counter_table_t *old_w =
-            __atomic_load_n(&tables_flat[w * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
-        if (!old_w || !new_tables[w])
+        if (!old_tables[w] || !new_tables[w])
             continue;
 
-        uint64_t new_gen = old_w->generation + 1;
+        uint64_t new_gen = old_tables[w]->generation + 1;
         new_tables[w]->generation = new_gen;
         new_tables[w]->epoch_ns = now;
         if (w == 0)
-            gen = old_w->generation;
+            gen = old_tables[w]->generation;
 
         __atomic_store_n(&tables_flat[w * tables_stride + flow_rule_index], new_tables[w],
                          __ATOMIC_RELEASE);
-        old_tables[w] = old_w;
     }
 
     /* Enqueue one retired entry with all per-worker tables */

--- a/src/backend/src/snapshot.c
+++ b/src/backend/src/snapshot.c
@@ -44,9 +44,13 @@ void infmon_snapshot_mgr_destroy(infmon_snapshot_mgr_t *mgr)
 
     /* Free any retired tables still pending */
     for (uint32_t i = 0; i < INFMON_MAX_RETIRED; i++) {
-        if (mgr->retired[i].pending && mgr->retired[i].table) {
-            infmon_counter_table_destroy(mgr->retired[i].table);
-            mgr->retired[i].table = NULL;
+        if (mgr->retired[i].pending) {
+            for (uint32_t w = 0; w < mgr->retired[i].num_tables; w++) {
+                if (mgr->retired[i].tables[w]) {
+                    infmon_counter_table_destroy(mgr->retired[i].tables[w]);
+                    mgr->retired[i].tables[w] = NULL;
+                }
+            }
             mgr->retired[i].pending = false;
         }
     }
@@ -66,7 +70,8 @@ bool infmon_all_workers_past(const infmon_snapshot_mgr_t *mgr, uint64_t epoch)
 
 /* ── Snapshot and clear ──────────────────────────────────────────── */
 
-void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_t **tables,
+void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_t **tables_flat,
+                               uint32_t tables_stride, uint32_t num_workers,
                                uint32_t flow_rule_index, uint32_t max_flow_rules,
                                uint32_t max_key_width, infmon_snap_reply_t *reply)
 {
@@ -78,10 +83,12 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
         return;
     }
 
-    /* Get the current table */
-    infmon_counter_table_t *old_table = __atomic_load_n(&tables[flow_rule_index], __ATOMIC_ACQUIRE);
+    uint32_t nw = num_workers > 0 ? num_workers : 1;
 
-    if (!old_table) {
+    /* Get the current table from worker 0 to check existence */
+    infmon_counter_table_t *old_table0 = __atomic_load_n(&tables_flat[0 * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
+
+    if (!old_table0) {
         reply->result = INFMON_SNAP_NULL_TABLE;
         return;
     }
@@ -92,38 +99,53 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
         return;
     }
 
-    /* Allocate new empty table with same dimensions */
-    infmon_counter_table_t *new_table =
-        infmon_counter_table_create(old_table->num_slots, max_key_width);
-
-    if (!new_table) {
-        reply->result = INFMON_SNAP_ALLOC_FAILED;
-        return;
+    /* Allocate new tables for all workers */
+    infmon_counter_table_t *new_tables[INFMON_MAX_WORKERS] = {0};
+    for (uint32_t w = 0; w < nw; w++) {
+        infmon_counter_table_t *old_w = __atomic_load_n(&tables_flat[w * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
+        if (!old_w) continue;
+        new_tables[w] = infmon_counter_table_create(old_w->num_slots, max_key_width);
+        if (!new_tables[w]) {
+            /* Cleanup already allocated */
+            for (uint32_t cw = 0; cw < w; cw++) {
+                if (new_tables[cw]) {
+                    infmon_counter_table_destroy(new_tables[cw]);
+                }
+            }
+            reply->result = INFMON_SNAP_ALLOC_FAILED;
+            return;
+        }
     }
 
-    /* Set new table metadata */
-    uint64_t new_gen = old_table->generation + 1;
-    new_table->generation = new_gen;
-
-    /* Capture wall-clock once for both new table and retired entry. */
+    /* Capture wall-clock once for all swaps */
     uint64_t now = mgr->clock_ns();
-    new_table->epoch_ns = now;
 
-    /* Bump global epoch for this swap.
-     * NOT thread-safe: caller must serialize (single control thread). */
+    /* Bump global epoch for this swap */
     uint64_t swap_epoch = ++mgr->global_epoch;
 
-    /*
-     * Atomic pointer swap: RELEASE ensures the new table's contents
-     * (zeroed slots, metadata) are visible before any worker observes
-     * the new pointer.  Workers load with ACQUIRE once per frame.
-     */
-    __atomic_store_n(&tables[flow_rule_index], new_table, __ATOMIC_RELEASE);
+    /* Swap each worker's table */
+    infmon_counter_table_t *old_tables[INFMON_MAX_WORKERS] = {0};
+    uint64_t gen = 0;
+    for (uint32_t w = 0; w < nw; w++) {
+        infmon_counter_table_t *old_w = __atomic_load_n(&tables_flat[w * tables_stride + flow_rule_index], __ATOMIC_ACQUIRE);
+        if (!old_w || !new_tables[w]) continue;
 
-    /* Enqueue old table for retirement */
+        uint64_t new_gen = old_w->generation + 1;
+        new_tables[w]->generation = new_gen;
+        new_tables[w]->epoch_ns = now;
+        if (w == 0) gen = old_w->generation;
+
+        __atomic_store_n(&tables_flat[w * tables_stride + flow_rule_index], new_tables[w], __ATOMIC_RELEASE);
+        old_tables[w] = old_w;
+    }
+
+    /* Enqueue one retired entry with all per-worker tables */
     for (uint32_t i = 0; i < INFMON_MAX_RETIRED; i++) {
         if (!mgr->retired[i].pending) {
-            mgr->retired[i].table = old_table;
+            memset(&mgr->retired[i], 0, sizeof(mgr->retired[i]));
+            for (uint32_t w = 0; w < nw; w++)
+                mgr->retired[i].tables[w] = old_tables[w];
+            mgr->retired[i].num_tables = nw;
             mgr->retired[i].swap_epoch = swap_epoch;
             mgr->retired[i].swap_timestamp_ns = now;
             mgr->retired[i].flow_rule_index = flow_rule_index;
@@ -132,13 +154,13 @@ void infmon_snapshot_and_clear(infmon_snapshot_mgr_t *mgr, infmon_counter_table_
             break;
         }
     }
-    /* Should be unreachable: retired_count was checked above */
-    /* (If we exit the loop without break, something is out of sync.) */
 
     /* Fill reply */
     reply->result = INFMON_SNAP_OK;
-    reply->retired_table = old_table;
-    reply->retired_generation = old_table->generation;
+    for (uint32_t w = 0; w < nw; w++)
+        reply->retired_tables[w] = old_tables[w];
+    reply->num_retired = nw;
+    reply->retired_generation = gen;
 }
 
 /* ── Retire poll ─────────────────────────────────────────────────── */
@@ -165,8 +187,12 @@ uint32_t infmon_retire_poll(infmon_snapshot_mgr_t *mgr)
             continue;
 
         /* Safe to free */
-        infmon_counter_table_destroy(rt->table);
-        rt->table = NULL;
+        for (uint32_t w = 0; w < rt->num_tables; w++) {
+            if (rt->tables[w]) {
+                infmon_counter_table_destroy(rt->tables[w]);
+                rt->tables[w] = NULL;
+            }
+        }
         rt->pending = false;
         mgr->retired_count--;
         freed++;

--- a/src/backend/src/vpp/infmon_api_handlers.c
+++ b/src/backend/src/vpp/infmon_api_handlers.c
@@ -110,6 +110,7 @@ static void infmon_vpp_api_ctx_ensure(void)
     infmon_stats_registry_init(&stats_reg, 0);
 
     infmon_api_ctx_init(&infmon_vpp_api_ctx, rs, &stats_reg);
+    /* worker_count includes the main thread (thread 0) + all worker threads. */
     infmon_vpp_api_ctx.worker_count = vlib_num_workers() + 1;
 
     /* Also set plugin_main num_workers */

--- a/src/backend/src/vpp/infmon_api_handlers.c
+++ b/src/backend/src/vpp/infmon_api_handlers.c
@@ -84,7 +84,8 @@ static void infmon_vpp_publish_rules(void)
     __atomic_store_n(&pm->flow_rule_set, &infmon_vpp_rule_set_ref, __ATOMIC_RELEASE);
 
     /* Sync per-worker counter-table pointers */
-    for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++)
+    uint32_t nw = ctx->worker_count > 0 ? ctx->worker_count : 1;
+    for (uint32_t w = 0; w < nw; w++)
         for (uint32_t i = 0; i < INFMON_MAX_ACTIVE_FLOW_RULES; i++)
             __atomic_store_n(&pm->tables[w][i],
                              (i < INFMON_FLOW_RULE_SET_MAX) ? ctx->tables[w][i] : NULL,

--- a/src/backend/src/vpp/infmon_api_handlers.c
+++ b/src/backend/src/vpp/infmon_api_handlers.c
@@ -83,9 +83,10 @@ static void infmon_vpp_publish_rules(void)
 
     __atomic_store_n(&pm->flow_rule_set, &infmon_vpp_rule_set_ref, __ATOMIC_RELEASE);
 
-    /* Sync counter-table pointers */
-    for (uint32_t i = 0; i < INFMON_MAX_ACTIVE_FLOW_RULES; i++)
-        __atomic_store_n(&pm->tables[i], ctx->tables[i], __ATOMIC_RELEASE);
+    /* Sync per-worker counter-table pointers */
+    for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++)
+        for (uint32_t i = 0; i < INFMON_MAX_ACTIVE_FLOW_RULES; i++)
+            __atomic_store_n(&pm->tables[w][i], (i < INFMON_FLOW_RULE_SET_MAX) ? ctx->tables[w][i] : NULL, __ATOMIC_RELEASE);
 }
 
 /**
@@ -106,6 +107,10 @@ static void infmon_vpp_api_ctx_ensure(void)
     infmon_stats_registry_init(&stats_reg, 0);
 
     infmon_api_ctx_init(&infmon_vpp_api_ctx, rs, &stats_reg);
+    infmon_vpp_api_ctx.worker_count = vlib_num_workers() + 1;
+
+    /* Also set plugin_main num_workers */
+    infmon_plugin_main.num_workers = vlib_num_workers() + 1;
 
     /* Create a snapshot manager. */
     static infmon_snapshot_mgr_t snap_mgr;
@@ -428,7 +433,7 @@ static void vl_api_infmon_snapshot_inline_dump_t_handler(vl_api_infmon_snapshot_
     infmon_api_result_t result =
         infmon_api_snapshot_and_clear(&infmon_vpp_api_ctx, id, &snap_reply);
 
-    if (result != INFMON_API_OK || !snap_reply.retired_table) {
+    if (result != INFMON_API_OK || snap_reply.num_retired == 0) {
         /* Send an empty details message so the client does not hang.
          * Dump handlers cannot use REPLY_MACRO — send a bare message. */
         vl_api_infmon_snapshot_inline_details_t *rmp = vl_msg_api_alloc_zero(sizeof(*rmp));
@@ -440,13 +445,19 @@ static void vl_api_infmon_snapshot_inline_dump_t_handler(vl_api_infmon_snapshot_
         return;
     }
 
-    infmon_counter_table_t *tbl = snap_reply.retired_table;
     infmon_stats_descriptor_t *desc = &snap_reply.descriptor;
 
     /*
-     * RCU safety: the retired table is pinned until infmon_api_snap_release()
+     * RCU safety: the retired tables are pinned until infmon_api_snap_release()
      * is called below, so it is safe to iterate for the lifetime of this handler.
+     *
+     * Stream slots from ALL per-worker retired tables.  The frontend merges
+     * entries that share the same key across workers.
      */
+    for (uint32_t w = 0; w < snap_reply.num_retired; w++) {
+        infmon_counter_table_t *tbl = snap_reply.retired_tables[w];
+        if (!tbl) continue;
+
     /* Walk all slots; emit a details message for each occupied one. */
     for (uint32_t i = 0; i < tbl->num_slots; i++) {
         infmon_slot_t *slot = &tbl->slots[i];
@@ -482,6 +493,7 @@ static void vl_api_infmon_snapshot_inline_dump_t_handler(vl_api_infmon_snapshot_
 
         vl_api_send_msg(rp, (u8 *) rmp);
     }
+    } /* end per-worker loop */
 }
 
 /* ── Handler: status_dump ────────────────────────────────────────── */

--- a/src/backend/src/vpp/infmon_api_handlers.c
+++ b/src/backend/src/vpp/infmon_api_handlers.c
@@ -86,7 +86,9 @@ static void infmon_vpp_publish_rules(void)
     /* Sync per-worker counter-table pointers */
     for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++)
         for (uint32_t i = 0; i < INFMON_MAX_ACTIVE_FLOW_RULES; i++)
-            __atomic_store_n(&pm->tables[w][i], (i < INFMON_FLOW_RULE_SET_MAX) ? ctx->tables[w][i] : NULL, __ATOMIC_RELEASE);
+            __atomic_store_n(&pm->tables[w][i],
+                             (i < INFMON_FLOW_RULE_SET_MAX) ? ctx->tables[w][i] : NULL,
+                             __ATOMIC_RELEASE);
 }
 
 /**
@@ -456,43 +458,44 @@ static void vl_api_infmon_snapshot_inline_dump_t_handler(vl_api_infmon_snapshot_
      */
     for (uint32_t w = 0; w < snap_reply.num_retired; w++) {
         infmon_counter_table_t *tbl = snap_reply.retired_tables[w];
-        if (!tbl) continue;
-
-    /* Walk all slots; emit a details message for each occupied one. */
-    for (uint32_t i = 0; i < tbl->num_slots; i++) {
-        infmon_slot_t *slot = &tbl->slots[i];
-        if (slot->flags != INFMON_SLOT_OCCUPIED)
+        if (!tbl)
             continue;
 
-        const uint8_t *key = infmon_counter_table_key(tbl, slot);
-        uint16_t key_len = key ? slot->key_len : 0;
+        /* Walk all slots; emit a details message for each occupied one. */
+        for (uint32_t i = 0; i < tbl->num_slots; i++) {
+            infmon_slot_t *slot = &tbl->slots[i];
+            if (slot->flags != INFMON_SLOT_OCCUPIED)
+                continue;
 
-        u32 msg_size = sizeof(vl_api_infmon_snapshot_inline_details_t) + key_len;
-        vl_api_infmon_snapshot_inline_details_t *rmp = vl_msg_api_alloc(msg_size);
-        clib_memset(rmp, 0, msg_size);
+            const uint8_t *key = infmon_counter_table_key(tbl, slot);
+            uint16_t key_len = key ? slot->key_len : 0;
 
-        rmp->_vl_msg_id = htons(VL_API_INFMON_SNAPSHOT_INLINE_DETAILS + infmon_msg_id_base);
-        rmp->context = mp->context;
+            u32 msg_size = sizeof(vl_api_infmon_snapshot_inline_details_t) + key_len;
+            vl_api_infmon_snapshot_inline_details_t *rmp = vl_msg_api_alloc(msg_size);
+            clib_memset(rmp, 0, msg_size);
 
-        /* Table metadata. */
-        rmp->flow_rule_id.hi = clib_host_to_net_u64(desc->flow_rule_id.hi);
-        rmp->flow_rule_id.lo = clib_host_to_net_u64(desc->flow_rule_id.lo);
-        rmp->generation = clib_host_to_net_u64(desc->generation);
-        rmp->epoch_ns = clib_host_to_net_u64(desc->epoch_ns);
-        rmp->insert_failed = clib_host_to_net_u64(desc->insert_failed);
-        rmp->table_full = clib_host_to_net_u64(desc->table_full);
+            rmp->_vl_msg_id = htons(VL_API_INFMON_SNAPSHOT_INLINE_DETAILS + infmon_msg_id_base);
+            rmp->context = mp->context;
 
-        /* Slot data. */
-        rmp->key_hash = clib_host_to_net_u64(slot->key_hash);
-        rmp->packets = clib_host_to_net_u64(slot->packets);
-        rmp->bytes = clib_host_to_net_u64(slot->bytes);
-        rmp->last_update = clib_host_to_net_u64(slot->last_update);
-        rmp->key_len = clib_host_to_net_u16(key_len);
-        if (key && key_len > 0)
-            clib_memcpy(rmp->key_data, key, key_len);
+            /* Table metadata. */
+            rmp->flow_rule_id.hi = clib_host_to_net_u64(desc->flow_rule_id.hi);
+            rmp->flow_rule_id.lo = clib_host_to_net_u64(desc->flow_rule_id.lo);
+            rmp->generation = clib_host_to_net_u64(desc->generation);
+            rmp->epoch_ns = clib_host_to_net_u64(desc->epoch_ns);
+            rmp->insert_failed = clib_host_to_net_u64(desc->insert_failed);
+            rmp->table_full = clib_host_to_net_u64(desc->table_full);
 
-        vl_api_send_msg(rp, (u8 *) rmp);
-    }
+            /* Slot data. */
+            rmp->key_hash = clib_host_to_net_u64(slot->key_hash);
+            rmp->packets = clib_host_to_net_u64(slot->packets);
+            rmp->bytes = clib_host_to_net_u64(slot->bytes);
+            rmp->last_update = clib_host_to_net_u64(slot->last_update);
+            rmp->key_len = clib_host_to_net_u16(key_len);
+            if (key && key_len > 0)
+                clib_memcpy(rmp->key_data, key, key_len);
+
+            vl_api_send_msg(rp, (u8 *) rmp);
+        }
     } /* end per-worker loop */
 }
 

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -355,10 +355,11 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
     u32 n_left = frame->n_vectors;
     u32 *from = vlib_frame_vector_args(frame);
 
-    /* Load table pointers with ACQUIRE once per frame (§8) */
+    /* Load table pointers with ACQUIRE once per frame (§8) — per-worker */
+    u32 worker_id = vlib_get_thread_index();
     infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES];
     for (uint32_t i = 0; i < INFMON_MAX_ACTIVE_FLOW_RULES; i++)
-        tables[i] = __atomic_load_n(&pm->tables[i], __ATOMIC_ACQUIRE);
+        tables[i] = __atomic_load_n(&pm->tables[worker_id][i], __ATOMIC_ACQUIRE);
 
     /* Bump tick once per frame */
     uint64_t tick = __atomic_fetch_add(&pm->tick, 1, __ATOMIC_RELAXED);
@@ -519,15 +520,18 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
         return clib_error_return(0, "flow_rule_add failed: %d", (int) rc);
     }
 
-    /* Find the rule index to allocate a counter table */
+    /* Find the rule index to allocate per-worker counter tables */
     uint32_t n = infmon_flow_rule_count(infmon_cli_rule_set);
     const infmon_flow_rule_t *added = infmon_flow_rule_get(infmon_cli_rule_set, n - 1);
     if (added) {
         if ((n - 1) < INFMON_MAX_ACTIVE_FLOW_RULES) {
-            infmon_counter_table_t *ct =
-                infmon_counter_table_create(added->max_keys, added->key_width);
-            if (ct)
-                __atomic_store_n(&infmon_plugin_main.tables[n - 1], ct, __ATOMIC_RELEASE);
+            uint32_t nw = infmon_plugin_main.num_workers > 0 ? infmon_plugin_main.num_workers : 1;
+            for (uint32_t w = 0; w < nw; w++) {
+                infmon_counter_table_t *ct =
+                    infmon_counter_table_create(added->max_keys, added->key_width);
+                if (ct)
+                    __atomic_store_n(&infmon_plugin_main.tables[w][n - 1], ct, __ATOMIC_RELEASE);
+            }
         }
     }
 

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -357,6 +357,12 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
 
     /* Load table pointers with ACQUIRE once per frame (§8) — per-worker */
     u32 worker_id = vlib_get_thread_index();
+    if (PREDICT_FALSE(worker_id >= INFMON_MAX_WORKERS)) {
+        vlib_node_increment_counter(vm, node->node_index, INFMON_COUNTER_ERROR_DROP,
+                                    frame->n_vectors);
+        vlib_buffer_free(vm, vlib_frame_vector_args(frame), frame->n_vectors);
+        return frame->n_vectors;
+    }
     infmon_counter_table_t *tables[INFMON_MAX_ACTIVE_FLOW_RULES];
     for (uint32_t i = 0; i < INFMON_MAX_ACTIVE_FLOW_RULES; i++)
         tables[i] = __atomic_load_n(&pm->tables[worker_id][i], __ATOMIC_ACQUIRE);
@@ -529,8 +535,18 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
             for (uint32_t w = 0; w < nw; w++) {
                 infmon_counter_table_t *ct =
                     infmon_counter_table_create(added->max_keys, added->key_width);
-                if (ct)
+                if (ct) {
                     __atomic_store_n(&infmon_plugin_main.tables[w][n - 1], ct, __ATOMIC_RELEASE);
+                } else {
+                    /* Allocation failed — roll back tables created for workers 0..w-1 */
+                    for (uint32_t rw = 0; rw < w; rw++) {
+                        infmon_counter_table_t *prev = __atomic_exchange_n(
+                            &infmon_plugin_main.tables[rw][n - 1], NULL, __ATOMIC_RELEASE);
+                        if (prev)
+                            infmon_counter_table_destroy(prev);
+                    }
+                    break;
+                }
             }
         }
     }

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -531,6 +531,11 @@ static clib_error_t *infmon_flow_rule_add_command_fn(CLIB_UNUSED(vlib_main_t *vm
     const infmon_flow_rule_t *added = infmon_flow_rule_get(infmon_cli_rule_set, n - 1);
     if (added) {
         if ((n - 1) < INFMON_MAX_ACTIVE_FLOW_RULES) {
+            /* NOTE: num_workers is latched from vlib_num_workers()+1 during
+             * infmon_vpp_api_ctx_ensure, which runs post-worker-init.  CLI commands
+             * also execute after workers are active.  If num_workers is 0 (e.g.
+             * startup-config before workers launch — not currently supported),
+             * fall back to 1 so the main thread always gets a table. */
             uint32_t nw = infmon_plugin_main.num_workers > 0 ? infmon_plugin_main.num_workers : 1;
             for (uint32_t w = 0; w < nw; w++) {
                 infmon_counter_table_t *ct =

--- a/src/backend/test/test_api_handler.cc
+++ b/src/backend/test/test_api_handler.cc
@@ -92,9 +92,9 @@ TEST_F(ApiHandlerTest, AddMultipleThenDeleteFirst)
     ASSERT_NE(found, nullptr);
     EXPECT_STREQ(found->name, "rule_bb");
 
-    /* counter table for rule_bb should have been compacted into slot 0. */
-    EXPECT_NE(ctx_.tables[0], nullptr);
-    EXPECT_EQ(ctx_.tables[1], nullptr);
+    /* counter table for rule_bb should have been compacted into slot 0 (worker 0). */
+    EXPECT_NE(ctx_.tables[0][0], nullptr);
+    EXPECT_EQ(ctx_.tables[0][1], nullptr);
 }
 
 TEST_F(ApiHandlerTest, NullInputsReturnInvalidRule)
@@ -309,9 +309,9 @@ TEST_F(ApiHandlerSnapTest, SnapshotAndClearBasic)
     EXPECT_EQ(reply.descriptor.generation, 0u); /* retired table is gen 0 */
     EXPECT_EQ(reply.descriptor.active, 1u);
 
-    /* New table should be at generation 1. */
-    EXPECT_NE(ctx_.tables[0], nullptr);
-    EXPECT_EQ(ctx_.tables[0]->generation, 1u);
+    /* New table should be at generation 1 (worker 0). */
+    EXPECT_NE(ctx_.tables[0][0], nullptr);
+    EXPECT_EQ(ctx_.tables[0][0]->generation, 1u);
 }
 
 TEST_F(ApiHandlerSnapTest, SnapshotAndClearNotFoundId)
@@ -380,7 +380,7 @@ TEST_F(ApiHandlerSnapTest, SnapshotAndClearMultipleSwaps)
     infmon_api_snapshot_and_clear(&ctx_, id, &reply2);
     ASSERT_EQ(reply2.result, INFMON_API_OK);
     EXPECT_EQ(reply2.descriptor.generation, 1u);
-    EXPECT_EQ(ctx_.tables[0]->generation, 2u);
+    EXPECT_EQ(ctx_.tables[0][0]->generation, 2u);
 }
 
 TEST_F(ApiHandlerSnapTest, AddWithIdPreservesIdAcrossDelete)

--- a/src/backend/test/test_snapshot.cc
+++ b/src/backend/test/test_snapshot.cc
@@ -34,12 +34,13 @@ static void advance_clock_ns(uint64_t delta)
 /* Max flow rules (matches graph_node.h) */
 #define MAX_FLOW_RULES 64
 #define MAX_KEY_WIDTH 32
+#define TEST_NUM_WORKERS 1
 
 class SnapshotTest : public ::testing::Test
 {
   protected:
     infmon_snapshot_mgr_t mgr{};
-    infmon_counter_table_t *tables[MAX_FLOW_RULES]{};
+    infmon_counter_table_t *tables[INFMON_MAX_WORKERS][MAX_FLOW_RULES]{};
 
     void SetUp() override
     {
@@ -50,27 +51,37 @@ class SnapshotTest : public ::testing::Test
     void TearDown() override
     {
         infmon_snapshot_mgr_destroy(&mgr);
-        for (uint32_t i = 0; i < MAX_FLOW_RULES; i++) {
-            if (tables[i]) {
-                infmon_counter_table_destroy(tables[i]);
-                tables[i] = nullptr;
+        for (uint32_t w = 0; w < INFMON_MAX_WORKERS; w++) {
+            for (uint32_t i = 0; i < MAX_FLOW_RULES; i++) {
+                if (tables[w][i]) {
+                    infmon_counter_table_destroy(tables[w][i]);
+                    tables[w][i] = nullptr;
+                }
             }
         }
     }
 
-    /* Install a table at the given index with some data */
+    /* Install a table at the given index for worker 0 */
     void install_table(uint32_t idx, uint32_t max_keys = 1024)
     {
-        tables[idx] = infmon_counter_table_create(max_keys, MAX_KEY_WIDTH);
-        ASSERT_NE(tables[idx], nullptr);
+        tables[0][idx] = infmon_counter_table_create(max_keys, MAX_KEY_WIDTH);
+        ASSERT_NE(tables[0][idx], nullptr);
     }
 
-    /* Insert a key into a table and return whether it succeeded */
+    /* Insert a key into worker 0's table and return whether it succeeded */
     bool insert_key(uint32_t table_idx, uint64_t hash, uint64_t pkt_bytes)
     {
         uint8_t key[8];
         memcpy(key, &hash, sizeof(key));
-        return infmon_counter_table_update(tables[table_idx], hash, key, 8, pkt_bytes, 1);
+        return infmon_counter_table_update(tables[0][table_idx], hash, key, 8, pkt_bytes, 1);
+    }
+
+    /* Helper to call snapshot_and_clear with our 2D tables */
+    void do_snapshot(uint32_t flow_rule_index, uint32_t num_workers, infmon_snap_reply_t *reply)
+    {
+        infmon_snapshot_and_clear(&mgr, &tables[0][0], MAX_FLOW_RULES,
+                                  num_workers, flow_rule_index, MAX_FLOW_RULES,
+                                  MAX_KEY_WIDTH, reply);
     }
 };
 
@@ -84,22 +95,22 @@ TEST_F(SnapshotTest, BasicSwap)
     ASSERT_TRUE(insert_key(0, 0xAAAA, 100));
     ASSERT_TRUE(insert_key(0, 0xBBBB, 200));
 
-    infmon_counter_table_t *original = tables[0];
+    infmon_counter_table_t *original = tables[0][0];
     ASSERT_EQ(original->generation, 0u);
     ASSERT_EQ(original->occupied_count, 2u);
 
     /* Perform snapshot */
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
 
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
-    ASSERT_EQ(reply.retired_table, original);
+    ASSERT_EQ(reply.retired_tables[0], original);
     ASSERT_EQ(reply.retired_generation, 0u);
 
     /* New table is empty with generation = 1 */
-    ASSERT_NE(tables[0], original);
-    ASSERT_EQ(tables[0]->generation, 1u);
-    ASSERT_EQ(tables[0]->occupied_count, 0u);
+    ASSERT_NE(tables[0][0], original);
+    ASSERT_EQ(tables[0][0]->generation, 1u);
+    ASSERT_EQ(tables[0][0]->occupied_count, 0u);
 
     /* Old table data is still intact (immutable post-swap) */
     ASSERT_EQ(original->occupied_count, 2u);
@@ -116,10 +127,10 @@ TEST_F(SnapshotTest, SequentialSwaps)
         insert_key(0, 0x1000 + gen, 64);
 
         infmon_snap_reply_t reply{};
-        infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+        do_snapshot(0, TEST_NUM_WORKERS, &reply);
         ASSERT_EQ(reply.result, INFMON_SNAP_OK);
         ASSERT_EQ(reply.retired_generation, gen);
-        ASSERT_EQ(tables[0]->generation, gen + 1);
+        ASSERT_EQ(tables[0][0]->generation, gen + 1);
 
         /* Advance workers past the swap epoch (need epoch > swap_epoch) */
         for (int bump = 0; bump <= (int) gen + 1; bump++)
@@ -140,14 +151,14 @@ TEST_F(SnapshotTest, SequentialSwaps)
 TEST_F(SnapshotTest, GenerationIncrement)
 {
     install_table(0);
-    tables[0]->generation = 42;
+    tables[0][0]->generation = 42;
 
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
 
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
     ASSERT_EQ(reply.retired_generation, 42u);
-    ASSERT_EQ(tables[0]->generation, 43u);
+    ASSERT_EQ(tables[0][0]->generation, 43u);
 }
 
 /* ── New table has epoch_ns set ──────────────────────────────────── */
@@ -157,10 +168,10 @@ TEST_F(SnapshotTest, EpochNsSet)
     install_table(0);
 
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
 
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
-    ASSERT_GT(tables[0]->epoch_ns, 0u);
+    ASSERT_GT(tables[0][0]->epoch_ns, 0u);
 }
 
 /* ── Error: invalid index ────────────────────────────────────────── */
@@ -168,7 +179,7 @@ TEST_F(SnapshotTest, EpochNsSet)
 TEST_F(SnapshotTest, InvalidIndex)
 {
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, MAX_FLOW_RULES, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(MAX_FLOW_RULES, TEST_NUM_WORKERS, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_INVALID_INDEX);
 }
 
@@ -177,7 +188,7 @@ TEST_F(SnapshotTest, InvalidIndex)
 TEST_F(SnapshotTest, NullTable)
 {
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_NULL_TABLE);
 }
 
@@ -189,7 +200,7 @@ TEST_F(SnapshotTest, GracePeriodRespected)
     insert_key(0, 0xDEAD, 512);
 
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
     ASSERT_EQ(mgr.retired_count, 1u);
 
@@ -217,7 +228,7 @@ TEST_F(SnapshotTest, WorkersMustAdvance)
     install_table(0);
 
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
 
     /* Advance clock but NOT workers */
@@ -251,16 +262,16 @@ TEST_F(SnapshotTest, RetiredRingFull)
     for (uint32_t i = 0; i < INFMON_MAX_RETIRED; i++) {
         install_table(i);
         infmon_snap_reply_t reply{};
-        infmon_snapshot_and_clear(&mgr, tables, i, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+        do_snapshot(i, TEST_NUM_WORKERS, &reply);
         ASSERT_EQ(reply.result, INFMON_SNAP_OK);
     }
 
     /* Next swap should fail with TOO_MANY_RETIRED */
-    infmon_counter_table_destroy(tables[0]);
-    tables[0] = nullptr;
-    install_table(0); /* tables[0] was swapped above, so it's a fresh table */
+    infmon_counter_table_destroy(tables[0][0]);
+    tables[0][0] = nullptr;
+    install_table(0); /* tables[0][0] was swapped above, so it's a fresh table */
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_TOO_MANY_RETIRED);
 }
 
@@ -303,7 +314,7 @@ TEST_F(SnapshotTest, ConcurrentEpochBumps)
     /* Perform several snapshots while workers are running */
     for (int i = 0; i < 10; i++) {
         infmon_snap_reply_t reply{};
-        infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+        do_snapshot(0, TEST_NUM_WORKERS, &reply);
         ASSERT_EQ(reply.result, INFMON_SNAP_OK);
 
         advance_clock_ns(INFMON_RETIRE_GRACE_NS + 1);
@@ -331,7 +342,7 @@ TEST_F(SnapshotTest, ConcurrentEpochBumps)
 TEST_F(SnapshotTest, AtomicSwapVisibility)
 {
     install_table(0);
-    infmon_counter_table_t *original = tables[0];
+    infmon_counter_table_t *original = tables[0][0];
 
     std::atomic<bool> swapped{false};
     std::atomic<infmon_counter_table_t *> observed{nullptr};
@@ -342,13 +353,13 @@ TEST_F(SnapshotTest, AtomicSwapVisibility)
             /* nothing */
         }
         /* After swap flag is set, load the table pointer with ACQUIRE */
-        infmon_counter_table_t *t = __atomic_load_n(&tables[0], __ATOMIC_ACQUIRE);
+        infmon_counter_table_t *t = __atomic_load_n(&tables[0][0], __ATOMIC_ACQUIRE);
         observed.store(t, std::memory_order_release);
     });
 
     /* Perform snapshot (writes with RELEASE) */
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
 
     swapped.store(true, std::memory_order_release);
@@ -357,7 +368,7 @@ TEST_F(SnapshotTest, AtomicSwapVisibility)
     /* Reader must see the new table, not the old one */
     ASSERT_NE(observed.load(), nullptr);
     ASSERT_NE(observed.load(), original);
-    ASSERT_EQ(observed.load(), tables[0]);
+    ASSERT_EQ(observed.load(), tables[0][0]);
 }
 
 /* ── Zero-worker edge case ───────────────────────────────────────── */
@@ -373,7 +384,9 @@ TEST_F(SnapshotTest, ZeroWorkers)
 
     install_table(0);
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr0, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    infmon_snapshot_and_clear(&mgr0, &tables[0][0], MAX_FLOW_RULES,
+                              TEST_NUM_WORKERS, 0, MAX_FLOW_RULES,
+                              MAX_KEY_WIDTH, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
 
     /* Should be freeable after grace period only */
@@ -391,7 +404,7 @@ TEST_F(SnapshotTest, DestroyFreesPending)
     install_table(0);
 
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 0, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(0, TEST_NUM_WORKERS, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
     ASSERT_EQ(mgr.retired_count, 1u);
 
@@ -417,17 +430,17 @@ TEST_F(SnapshotTest, MultipleFlowRules)
 
     /* Snapshot flow_rule 1 only */
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr, tables, 1, MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
+    do_snapshot(1, TEST_NUM_WORKERS, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
 
     /* flow_rule 0 and 2 untouched */
-    ASSERT_EQ(tables[0]->occupied_count, 1u);
-    ASSERT_EQ(tables[2]->occupied_count, 1u);
+    ASSERT_EQ(tables[0][0]->occupied_count, 1u);
+    ASSERT_EQ(tables[0][2]->occupied_count, 1u);
 
     /* flow_rule 1 has a fresh empty table */
-    ASSERT_EQ(tables[1]->occupied_count, 0u);
-    ASSERT_EQ(tables[1]->generation, 1u);
+    ASSERT_EQ(tables[0][1]->occupied_count, 0u);
+    ASSERT_EQ(tables[0][1]->generation, 1u);
 
     /* Retired table has the old data */
-    ASSERT_EQ(reply.retired_table->occupied_count, 1u);
+    ASSERT_EQ(reply.retired_tables[0]->occupied_count, 1u);
 }

--- a/src/backend/test/test_snapshot.cc
+++ b/src/backend/test/test_snapshot.cc
@@ -442,3 +442,59 @@ TEST_F(SnapshotTest, MultipleFlowRules)
     /* Retired table has the old data */
     ASSERT_EQ(reply.retired_tables[0]->occupied_count, 1u);
 }
+
+/* ── Multi-worker tests ─────────────────────────────────────────── */
+
+static constexpr uint32_t TEST_MULTI_WORKERS = 4;
+
+TEST_F(SnapshotTest, MultiWorkerBasicSwap)
+{
+    /* Install tables for all workers at flow-rule index 0 */
+    for (uint32_t w = 0; w < TEST_MULTI_WORKERS; w++) {
+        tables[w][0] = infmon_counter_table_create(1024, MAX_KEY_WIDTH);
+        ASSERT_NE(tables[w][0], nullptr);
+    }
+
+    /* Insert different data into each worker's table */
+    for (uint32_t w = 0; w < TEST_MULTI_WORKERS; w++) {
+        uint8_t key[8];
+        uint64_t hash = 0xAA00 + w;
+        memcpy(key, &hash, sizeof(key));
+        ASSERT_TRUE(infmon_counter_table_update(tables[w][0], hash, key, 8, (w + 1) * 100, 1));
+    }
+
+    infmon_snap_reply_t reply{};
+    do_snapshot(0, TEST_MULTI_WORKERS, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+
+    /* Each worker gets a fresh empty table */
+    for (uint32_t w = 0; w < TEST_MULTI_WORKERS; w++) {
+        ASSERT_NE(tables[w][0], nullptr);
+        ASSERT_EQ(tables[w][0]->occupied_count, 0u);
+        ASSERT_EQ(tables[w][0]->generation, 1u);
+    }
+
+    /* Retired tables bundle all workers */
+    ASSERT_EQ(reply.num_retired, TEST_MULTI_WORKERS);
+    for (uint32_t w = 0; w < TEST_MULTI_WORKERS; w++) {
+        ASSERT_NE(reply.retired_tables[w], nullptr);
+        ASSERT_EQ(reply.retired_tables[w]->occupied_count, 1u);
+    }
+}
+
+TEST_F(SnapshotTest, MultiWorkerRetiredCountMatchesWorkers)
+{
+    /* Set up 2 workers */
+    constexpr uint32_t nw = 2;
+    for (uint32_t w = 0; w < nw; w++) {
+        tables[w][0] = infmon_counter_table_create(256, MAX_KEY_WIDTH);
+        ASSERT_NE(tables[w][0], nullptr);
+    }
+
+    infmon_snap_reply_t reply{};
+    do_snapshot(0, nw, &reply);
+    ASSERT_EQ(reply.result, INFMON_SNAP_OK);
+    ASSERT_EQ(reply.num_retired, nw);
+    for (uint32_t w = 0; w < nw; w++)
+        ASSERT_NE(reply.retired_tables[w], nullptr);
+}

--- a/src/backend/test/test_snapshot.cc
+++ b/src/backend/test/test_snapshot.cc
@@ -79,9 +79,8 @@ class SnapshotTest : public ::testing::Test
     /* Helper to call snapshot_and_clear with our 2D tables */
     void do_snapshot(uint32_t flow_rule_index, uint32_t num_workers, infmon_snap_reply_t *reply)
     {
-        infmon_snapshot_and_clear(&mgr, &tables[0][0], MAX_FLOW_RULES,
-                                  num_workers, flow_rule_index, MAX_FLOW_RULES,
-                                  MAX_KEY_WIDTH, reply);
+        infmon_snapshot_and_clear(&mgr, &tables[0][0], MAX_FLOW_RULES, num_workers, flow_rule_index,
+                                  MAX_FLOW_RULES, MAX_KEY_WIDTH, reply);
     }
 };
 
@@ -384,9 +383,8 @@ TEST_F(SnapshotTest, ZeroWorkers)
 
     install_table(0);
     infmon_snap_reply_t reply{};
-    infmon_snapshot_and_clear(&mgr0, &tables[0][0], MAX_FLOW_RULES,
-                              TEST_NUM_WORKERS, 0, MAX_FLOW_RULES,
-                              MAX_KEY_WIDTH, &reply);
+    infmon_snapshot_and_clear(&mgr0, &tables[0][0], MAX_FLOW_RULES, TEST_NUM_WORKERS, 0,
+                              MAX_FLOW_RULES, MAX_KEY_WIDTH, &reply);
     ASSERT_EQ(reply.result, INFMON_SNAP_OK);
 
     /* Should be freeable after grace period only */


### PR DESCRIPTION
## Summary

Change the shared counter table array from `tables[flow_rule_index]` to `tables[worker_id][flow_rule_index]` so each VPP worker thread updates its own table without CAS contention on hot-path inserts.

## Changes

- **graph_node.h**: `infmon_plugin_main_t.tables` is now 2D: `[MAX_WORKERS][MAX_ACTIVE_FLOW_RULES]`; added `num_workers` field
- **infmon_nodes.c**: Workers load their own table slice via `vlib_get_thread_index()`
- **snapshot.h/c**: `infmon_snapshot_and_clear()` takes flattened 2D array + stride + num_workers; swaps all per-worker tables; `infmon_snap_reply_t` returns array of retired tables; `infmon_retired_table_t` holds per-worker tables for RCU retirement
- **api_handler.h/c**: `tables` is 2D `[MAX_WORKERS][FLOW_RULE_SET_MAX]`; `worker_count` field added; add/del/snapshot iterate all workers
- **infmon_api_handlers.c**: Syncs 2D table array on publish; streams slots from all per-worker retired tables in dump handler; sets `worker_count` from `vlib_num_workers()`
- **Tests**: Updated for 2D table layout (9 files changed, all 10 tests pass)

Closes #156