### PR TITLE
feat: merge per-worker counter tables in frontend decode_snapshot

### DIFF
--- a/specs/004-backend-architecture.md
+++ b/specs/004-backend-architecture.md
@@ -111,7 +111,10 @@ place where the data path could plausibly block.
 
 ### 5.1 Layout
 
-For each `flow_rule` the plugin owns one **counter table**:
+For each `(worker, flow_rule)` pair the plugin owns one **counter table**
+(i.e. `tables[worker_id][flow_rule_index]`). Each VPP worker thread writes
+exclusively to its own table, eliminating all cross-core CAS on the data
+path. The per-worker layout is:
 
 - A bounded-size open-addressing hash table with **linear probing** sized
   at plugin init from a CLI argument (`max_keys_per_flow_rule`, default
@@ -244,16 +247,15 @@ This is the export primitive. Frontends call it once per export interval
 **Contract:**
 
 1. Caller invokes `infmon_snapshot_and_clear(flow_rule_id)`.
-2. Plugin allocates a new, empty counter table (`generation = G+1`) for
-   this `flow_rule_id`. Allocation happens off the worker thread; the
-   table is zeroed by a control thread before installation.
-3. Plugin atomically swaps the table pointer published in the
-   `infmon-counter` node's per-flow_rule context. The control thread
-   issues `__atomic_store_n(..., RELEASE)` on the pointer; workers MUST
-   load it with `__atomic_load_n(..., ACQUIRE)` (once per frame, not
-   per packet — see §8). The release/acquire pair guarantees the new
-   table's contents are visible when the new pointer is observed; the
-   bounded-staleness window is exactly one frame (≤ `VLIB_FRAME_SIZE`
+2. Plugin allocates a **new, empty counter table** (`generation = G+1`) for
+   each worker for this `flow_rule_id`. Allocation happens off the worker
+   thread; each table is zeroed by a control thread before installation.
+3. Plugin atomically swaps **every worker's table pointer** for this
+   flow_rule (one `__atomic_store_n(..., RELEASE)` per worker). Workers MUST
+   load their own pointer with `__atomic_load_n(..., ACQUIRE)` (once per
+   frame, not per packet — see §8). The release/acquire pair guarantees
+   the new table's contents are visible when the new pointer is observed;
+   the bounded-staleness window is exactly one frame (≤ `VLIB_FRAME_SIZE`
    packets) on each worker, after which every subsequent packet counts
    into `G+1`. No worker thread stalls, no lock is taken, no packet is
    dropped.
@@ -405,9 +407,12 @@ the frontend reports them as gauges so operators can wire alerts.
    plugin will require operators to bump `statseg { size }` and will
    refuse to start otherwise; whether to ship a recommended value as a
    tunable in spec 005 is open.
-3. **Per-CPU sharded tables.** A sharded design (one sub-table per
-   worker, merged at snapshot) avoids cross-core CAS entirely but
-   complicates §7.2. Defer to v2 unless the §10 targets miss.
+3. **Per-CPU sharded tables.** ~~Deferred to v2.~~ **Resolved** — the
+   implementation uses per-worker tables (`tables[worker_id][flow_rule_index]`).
+   Each VPP worker writes exclusively to its own table, eliminating
+   cross-core CAS on the data path. At snapshot time all per-worker tables
+   for a flow rule are swapped and retired together; the frontend merges
+   duplicate keys across workers (sum packets/bytes, max last_update).
 
 ## 13. Acceptance
 

--- a/specs/005-frontend-architecture.md
+++ b/specs/005-frontend-architecture.md
@@ -342,12 +342,18 @@ socket (`/run/vpp/api.sock`). This replaces the earlier shared-memory
 approach with a simpler, single-channel design.
 
 The dump uses a **lock-free atomic pointer swap** on the data path:
-the control plane allocates a new empty table, atomically swaps the
-table pointer (single `RELEASE` store — effectively zero data-path
-blocking), and enqueues the old table for RCU retirement (5 s grace
-period). The frontend then walks the retired table and receives one
+the control plane allocates a new empty table per worker, atomically
+swaps each worker's table pointer (one `RELEASE` store per worker —
+effectively zero data-path blocking), and enqueues the old per-worker
+tables for RCU retirement (5 s grace period). The frontend then walks
+all per-worker retired tables and receives one
 `infmon_snapshot_inline_details` message per occupied slot, with key
 bytes and counters inline.
+
+Because each VPP worker maintains its own counter table, the same flow
+key may appear in multiple workers' tables. The poller's `decode_snapshot`
+merges these duplicates by raw key bytes: packets and bytes are summed,
+and `last_update` takes the maximum across workers.
 
 The client crate (`ipc`) exposes:
 

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -176,7 +176,6 @@ fn decode_snapshot(
             use std::collections::HashMap;
 
             struct MergedSlot {
-                key_bytes: Vec<u8>,
                 packets: u64,
                 bytes: u64,
                 last_update: u64,
@@ -196,14 +195,13 @@ fn decode_snapshot(
                 }
                 let key_bytes = desc.key_arena[start..end].to_vec();
                 merged
-                    .entry(key_bytes.clone())
+                    .entry(key_bytes)
                     .and_modify(|m| {
-                        m.packets += slot.packets;
-                        m.bytes += slot.bytes;
+                        m.packets = m.packets.saturating_add(slot.packets);
+                        m.bytes = m.bytes.saturating_add(slot.bytes);
                         m.last_update = m.last_update.max(slot.last_update);
                     })
                     .or_insert(MergedSlot {
-                        key_bytes,
                         packets: slot.packets,
                         bytes: slot.bytes,
                         last_update: slot.last_update,
@@ -211,9 +209,9 @@ fn decode_snapshot(
             }
 
             let flows = merged
-                .into_values()
-                .filter_map(|m| {
-                    let key = match decode_key(&fields, &m.key_bytes) {
+                .into_iter()
+                .filter_map(|(key_bytes, m)| {
+                    let key = match decode_key(&fields, &key_bytes) {
                         Ok(k) => k,
                         Err(e) => {
                             tracing::warn!("failed to decode flow key: {}", e);

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -181,7 +181,7 @@ fn decode_snapshot(
                 last_update: u64,
             }
 
-            let mut merged: HashMap<Vec<u8>, MergedSlot> = HashMap::new();
+            let mut merged: HashMap<Vec<u8>, MergedSlot> = HashMap::with_capacity(desc.slots.len());
 
             for slot in &desc.slots {
                 if slot.key_len == 0 {
@@ -208,6 +208,9 @@ fn decode_snapshot(
                     });
             }
 
+            // Note: HashMap::into_iter() yields entries in arbitrary order.
+            // Downstream consumers do not depend on flow ordering (snapshots
+            // are keyed by flow key, not position), so this is acceptable.
             let flows = merged
                 .into_iter()
                 .filter_map(|(key_bytes, m)| {

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -169,19 +169,51 @@ fn decode_snapshot(
             // keys are decoded with an empty schema.
             let fields: Vec<FieldId> = Vec::new();
 
-            let flows = desc
-                .slots
-                .into_iter()
-                .filter(|slot| slot.key_len > 0)
-                .filter_map(|slot| {
-                    let start = slot.key_offset as usize;
-                    let end = start + slot.key_len as usize;
-                    if end > desc.key_arena.len() {
-                        tracing::warn!("slot key extends past arena, skipping");
-                        return None;
-                    }
-                    let key_bytes = &desc.key_arena[start..end];
-                    let key = match decode_key(&fields, key_bytes) {
+            // Per-worker merge: the backend streams slots from all per-worker
+            // retired tables for this flow rule. The same key may appear in
+            // multiple workers' tables. We merge by raw key bytes: sum
+            // packets/bytes and take max(last_update).
+            use std::collections::HashMap;
+
+            struct MergedSlot {
+                key_bytes: Vec<u8>,
+                packets: u64,
+                bytes: u64,
+                last_update: u64,
+            }
+
+            let mut merged: HashMap<Vec<u8>, MergedSlot> = HashMap::new();
+
+            for slot in &desc.slots {
+                if slot.key_len == 0 {
+                    continue;
+                }
+                let start = slot.key_offset as usize;
+                let end = start + slot.key_len as usize;
+                if end > desc.key_arena.len() {
+                    tracing::warn!("slot key extends past arena, skipping");
+                    continue;
+                }
+                let key_bytes = desc.key_arena[start..end].to_vec();
+                merged
+                    .entry(key_bytes.clone())
+                    .and_modify(|m| {
+                        m.packets += slot.packets;
+                        m.bytes += slot.bytes;
+                        m.last_update = m.last_update.max(slot.last_update);
+                    })
+                    .or_insert(MergedSlot {
+                        key_bytes,
+                        packets: slot.packets,
+                        bytes: slot.bytes,
+                        last_update: slot.last_update,
+                    });
+            }
+
+            let flows = merged
+                .into_values()
+                .filter_map(|m| {
+                    let key = match decode_key(&fields, &m.key_bytes) {
                         Ok(k) => k,
                         Err(e) => {
                             tracing::warn!("failed to decode flow key: {}", e);
@@ -191,12 +223,12 @@ fn decode_snapshot(
                     Some(FlowStats {
                         key,
                         counters: FlowCounters {
-                            packets: slot.packets,
-                            bytes: slot.bytes,
+                            packets: m.packets,
+                            bytes: m.bytes,
                             // TODO: first_seen_ns is not available in the raw
                             // slot data. Wire it in once the backend tracks it.
                             first_seen_ns: 0,
-                            last_seen_ns: slot.last_update,
+                            last_seen_ns: m.last_update,
                         },
                     })
                 })

--- a/src/frontend/src/poller_tests.rs
+++ b/src/frontend/src/poller_tests.rs
@@ -203,6 +203,63 @@ fn decode_snapshot_skips_zero_key_len_slots() {
 }
 
 #[test]
+fn decode_snapshot_merges_per_worker_duplicate_keys() {
+    use infmon_common::ipc::stats_client::{RawDescriptor, RawSlot};
+    use infmon_common::ipc::types::FlowRuleId;
+
+    // Two slots with identical key bytes simulating the same flow seen by
+    // two workers. With empty field schema, decode_key rejects non-empty
+    // keys, so we verify the merge doesn't panic and the flow_rule still
+    // appears. Full end-to-end merge verification requires wired field
+    // metadata (tracked as a separate TODO in decode_snapshot).
+    let key: Vec<u8> = vec![0xAA; 4];
+    let mut key_arena = Vec::new();
+    let off1 = key_arena.len() as u32;
+    key_arena.extend_from_slice(&key);
+    let off2 = key_arena.len() as u32;
+    key_arena.extend_from_slice(&key);
+
+    let raw = infmon_common::ipc::stats_client::RawSnapshot {
+        descriptors: vec![RawDescriptor {
+            flow_rule_id: FlowRuleId { hi: 0, lo: 1 },
+            flow_rule_index: 0,
+            generation: 1,
+            epoch_ns: 0,
+            slots: vec![
+                RawSlot {
+                    key_hash: 42,
+                    packets: 100,
+                    bytes: 5000,
+                    key_offset: off1,
+                    key_len: key.len() as u16,
+                    flags: 1,
+                    last_update: 10,
+                },
+                RawSlot {
+                    key_hash: 42,
+                    packets: 200,
+                    bytes: 8000,
+                    key_offset: off2,
+                    key_len: key.len() as u16,
+                    flags: 1,
+                    last_update: 20,
+                },
+            ],
+            key_arena,
+            insert_failed: 0,
+            table_full: 0,
+        }],
+    };
+    let snap = decode_snapshot(raw, 1, 0, 0, 0);
+    assert_eq!(snap.flow_rules.len(), 1);
+    // Once field metadata is wired from the backend descriptor, uncomment:
+    // assert_eq!(snap.flow_rules[0].flows.len(), 1);
+    // assert_eq!(snap.flow_rules[0].flows[0].counters.packets, 300);
+    // assert_eq!(snap.flow_rules[0].flows[0].counters.bytes, 13000);
+    // assert_eq!(snap.flow_rules[0].flows[0].counters.last_seen_ns, 20);
+}
+
+#[test]
 fn decode_snapshot_skips_out_of_bounds_key() {
     use infmon_common::ipc::types::FlowRuleId;
     let raw = infmon_common::ipc::stats_client::RawSnapshot {

--- a/src/frontend/src/poller_tests.rs
+++ b/src/frontend/src/poller_tests.rs
@@ -259,6 +259,55 @@ fn decode_snapshot_merges_per_worker_duplicate_keys() {
     // assert_eq!(snap.flow_rules[0].flows[0].counters.last_seen_ns, 20);
 }
 
+/// Focused unit test for the HashMap-based per-worker merge logic.
+/// Exercises the merge directly (sum counters, max last_update) without
+/// depending on `decode_key` / field schemas.
+#[test]
+fn merge_duplicate_keys_sums_counters_and_takes_max_last_update() {
+    use std::collections::HashMap;
+
+    // Reproduce the merge logic from decode_snapshot:
+    struct MergedSlot {
+        packets: u64,
+        bytes: u64,
+        last_update: u64,
+    }
+
+    let slots: Vec<(Vec<u8>, u64, u64, u64)> = vec![
+        (vec![1, 2, 3], 100, 5000, 10), // worker 0
+        (vec![1, 2, 3], 200, 8000, 20), // worker 1 (same key)
+        (vec![4, 5, 6], 50, 2000, 15),  // different key
+    ];
+
+    let mut merged: HashMap<Vec<u8>, MergedSlot> = HashMap::new();
+    for (key_bytes, packets, bytes, last_update) in &slots {
+        merged
+            .entry(key_bytes.clone())
+            .and_modify(|m| {
+                m.packets = m.packets.saturating_add(*packets);
+                m.bytes = m.bytes.saturating_add(*bytes);
+                m.last_update = m.last_update.max(*last_update);
+            })
+            .or_insert(MergedSlot {
+                packets: *packets,
+                bytes: *bytes,
+                last_update: *last_update,
+            });
+    }
+
+    assert_eq!(merged.len(), 2, "two distinct keys after merge");
+
+    let k123 = merged.get(&vec![1u8, 2, 3]).expect("key [1,2,3] present");
+    assert_eq!(k123.packets, 300);
+    assert_eq!(k123.bytes, 13000);
+    assert_eq!(k123.last_update, 20);
+
+    let k456 = merged.get(&vec![4u8, 5, 6]).expect("key [4,5,6] present");
+    assert_eq!(k456.packets, 50);
+    assert_eq!(k456.bytes, 2000);
+    assert_eq!(k456.last_update, 15);
+}
+
 #[test]
 fn decode_snapshot_skips_out_of_bounds_key() {
     use infmon_common::ipc::types::FlowRuleId;


### PR DESCRIPTION
## Summary

VPP workers each maintain their own counter table for the same flow rule. When the frontend reads a snapshot, duplicate flow keys (same raw bytes across workers) are now merged: packets and bytes are summed, `last_update` takes the max value.

## Changes

- **`src/frontend/src/poller.rs`**: Replace linear slot iteration with HashMap-based per-worker merge in `decode_snapshot`. Keys are aggregated by raw bytes before decoding.
- **`src/frontend/src/poller_tests.rs`**: Add `decode_snapshot_merges_per_worker_duplicate_keys` test.
- **`specs/004-backend-architecture.md`**: Update §5.1 (per-worker tables), §7.2 (swap contract), §12.3 (mark resolved).
- **`specs/005-frontend-architecture.md`**: Update §8.1 with per-worker merge description.

## Test Plan

- [x] All 13 frontend unit tests pass (2 ignored — require live VPP)

Closes #156