### PR TITLE
feat: merge per-worker flow entries in frontend stats client

### DIFF
--- a/src/frontend/src/vapi_ffi/infmon_vapi_client.c
+++ b/src/frontend/src/vapi_ffi/infmon_vapi_client.c
@@ -252,7 +252,7 @@ int infmon_vapi_flow_rule_add(void *handle, const char *name, const uint8_t *fie
     msg->payload.eviction_policy = eviction_policy;
 
     /* Send as blocking request */
-    vapi_error_e rv = vapi_infmon_flow_rule_add(ctx, msg);
+    vapi_error_e rv = vapi_infmon_flow_rule_add(ctx, msg, NULL, NULL);
     if (rv != VAPI_OK)
         return -1;
 
@@ -295,7 +295,7 @@ int infmon_vapi_flow_rule_del(void *handle, uint64_t id_hi, uint64_t id_lo)
     msg->payload.flow_rule_id.hi = htobe64(id_hi);
     msg->payload.flow_rule_id.lo = htobe64(id_lo);
 
-    vapi_error_e rv = vapi_infmon_flow_rule_del(ctx, msg);
+    vapi_error_e rv = vapi_infmon_flow_rule_del(ctx, msg, NULL, NULL);
     if (rv != VAPI_OK)
         return -1;
 

--- a/src/frontend/src/vapi_stats_client.rs
+++ b/src/frontend/src/vapi_stats_client.rs
@@ -146,6 +146,10 @@ impl VapiStatsClient {
             // Merge entries that share the same flow key across workers.
             // With per-worker counter tables, the same key can appear once per
             // worker. We merge: sum packets/bytes, max last_update.
+            // `first` captures snapshot-level metadata (generation, epoch_ns,
+            // insert_failed, table_full) from entries[0] — these fields are
+            // identical across workers for the same flow rule, so any entry
+            // would do.
             let first = &entries[0];
             let merged = merge_worker_entries(&entries);
 
@@ -174,8 +178,14 @@ impl VapiStatsClient {
                 epoch_ns: first.epoch_ns,
                 slots,
                 key_arena,
-                insert_failed: first.insert_failed,
-                table_full: first.table_full,
+                insert_failed: merged
+                    .iter()
+                    .map(|e| e.insert_failed)
+                    .fold(0u64, u64::saturating_add),
+                table_full: merged
+                    .iter()
+                    .map(|e| e.table_full)
+                    .fold(0u64, u64::saturating_add),
             });
         }
 
@@ -202,8 +212,8 @@ fn merge_worker_entries(entries: &[CollectedEntry]) -> Vec<CollectedEntry> {
     use std::collections::HashMap;
 
     // Map from (key_hash, key_bytes) → index into `merged`.
-    let mut index_map: HashMap<(u64, &[u8]), usize> = HashMap::new();
-    let mut merged: Vec<CollectedEntry> = Vec::new();
+    let mut index_map: HashMap<(u64, &[u8]), usize> = HashMap::with_capacity(entries.len());
+    let mut merged: Vec<CollectedEntry> = Vec::with_capacity(entries.len());
 
     for e in entries {
         let identity = (e.key_hash, e.key_bytes.as_slice());
@@ -214,6 +224,8 @@ fn merge_worker_entries(entries: &[CollectedEntry]) -> Vec<CollectedEntry> {
             if e.last_update > m.last_update {
                 m.last_update = e.last_update;
             }
+            m.insert_failed = m.insert_failed.saturating_add(e.insert_failed);
+            m.table_full = m.table_full.saturating_add(e.table_full);
         } else {
             let idx = merged.len();
             index_map.insert(identity, idx);

--- a/src/frontend/src/vapi_stats_client.rs
+++ b/src/frontend/src/vapi_stats_client.rs
@@ -143,16 +143,17 @@ impl VapiStatsClient {
                 continue;
             }
 
-            // Build a RawDescriptor from the collected entries.
-            // We assemble a key_arena by concatenating all key bytes.
+            // Merge entries that share the same flow key across workers.
+            // With per-worker counter tables, the same key can appear once per
+            // worker. We merge: sum packets/bytes, max last_update.
             let first = &entries[0];
+            let merged = merge_worker_entries(&entries);
+
+            // Build a RawDescriptor from the merged entries.
             let mut key_arena = Vec::new();
             let mut slots = Vec::new();
 
-            // Table-level metadata (generation, epoch, counters) comes from the
-            // first entry in the dump — all entries share the same snapshot context.
-
-            for e in &entries {
+            for e in &merged {
                 let key_offset = key_arena.len() as u32;
                 key_arena.extend_from_slice(&e.key_bytes);
                 slots.push(RawSlot {
@@ -193,6 +194,48 @@ impl Drop for VapiStatsClient {
     }
 }
 
+/// Merge entries from multiple workers that share the same flow key.
+///
+/// Identity: `(key_hash, key_bytes)`. For matching entries we sum
+/// `packets` and `bytes`, and take `max(last_update)`.
+fn merge_worker_entries(entries: &[CollectedEntry]) -> Vec<CollectedEntry> {
+    use std::collections::HashMap;
+
+    // Map from (key_hash, key_bytes) → index into `merged`.
+    let mut index_map: HashMap<(u64, &[u8]), usize> = HashMap::new();
+    let mut merged: Vec<CollectedEntry> = Vec::new();
+
+    for e in entries {
+        let identity = (e.key_hash, e.key_bytes.as_slice());
+        if let Some(&idx) = index_map.get(&identity) {
+            let m = &mut merged[idx];
+            m.packets = m.packets.saturating_add(e.packets);
+            m.bytes = m.bytes.saturating_add(e.bytes);
+            if e.last_update > m.last_update {
+                m.last_update = e.last_update;
+            }
+        } else {
+            let idx = merged.len();
+            index_map.insert(identity, idx);
+            merged.push(CollectedEntry {
+                _flow_rule_id_hi: e._flow_rule_id_hi,
+                _flow_rule_id_lo: e._flow_rule_id_lo,
+                generation: e.generation,
+                epoch_ns: e.epoch_ns,
+                insert_failed: e.insert_failed,
+                table_full: e.table_full,
+                key_hash: e.key_hash,
+                packets: e.packets,
+                bytes: e.bytes,
+                last_update: e.last_update,
+                key_bytes: e.key_bytes.clone(),
+            });
+        }
+    }
+
+    merged
+}
+
 /// Internal struct for collecting entries from the FFI callback.
 struct CollectedEntry {
     _flow_rule_id_hi: u64,
@@ -206,4 +249,113 @@ struct CollectedEntry {
     bytes: u64,
     last_update: u64,
     key_bytes: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(
+        key: &[u8],
+        key_hash: u64,
+        packets: u64,
+        bytes: u64,
+        last_update: u64,
+    ) -> CollectedEntry {
+        CollectedEntry {
+            _flow_rule_id_hi: 1,
+            _flow_rule_id_lo: 2,
+            generation: 1,
+            epoch_ns: 0,
+            insert_failed: 0,
+            table_full: 0,
+            key_hash,
+            packets,
+            bytes,
+            last_update,
+            key_bytes: key.to_vec(),
+        }
+    }
+
+    #[test]
+    fn merge_no_duplicates() {
+        let entries = vec![
+            make_entry(&[1, 2, 3, 4], 0xAABB, 100, 5000, 1000),
+            make_entry(&[5, 6, 7, 8], 0xCCDD, 200, 8000, 2000),
+        ];
+        let merged = merge_worker_entries(&entries);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].packets, 100);
+        assert_eq!(merged[1].packets, 200);
+    }
+
+    #[test]
+    fn merge_two_workers_same_key() {
+        let entries = vec![
+            make_entry(&[1, 2, 3, 4], 0xAABB, 100, 5000, 1000),
+            make_entry(&[1, 2, 3, 4], 0xAABB, 50, 2500, 2000),
+        ];
+        let merged = merge_worker_entries(&entries);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].packets, 150);
+        assert_eq!(merged[0].bytes, 7500);
+        assert_eq!(merged[0].last_update, 2000);
+    }
+
+    #[test]
+    fn merge_three_workers_same_key() {
+        let entries = vec![
+            make_entry(&[10], 0x11, 10, 100, 500),
+            make_entry(&[10], 0x11, 20, 200, 300),
+            make_entry(&[10], 0x11, 30, 300, 800),
+        ];
+        let merged = merge_worker_entries(&entries);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].packets, 60);
+        assert_eq!(merged[0].bytes, 600);
+        assert_eq!(merged[0].last_update, 800);
+    }
+
+    #[test]
+    fn merge_mixed_unique_and_duplicate() {
+        let entries = vec![
+            make_entry(&[1], 0xAA, 10, 100, 100),
+            make_entry(&[2], 0xBB, 20, 200, 200),
+            make_entry(&[1], 0xAA, 30, 300, 300), // dup of first
+        ];
+        let merged = merge_worker_entries(&entries);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].packets, 40); // 10 + 30
+        assert_eq!(merged[0].bytes, 400);
+        assert_eq!(merged[0].last_update, 300);
+        assert_eq!(merged[1].packets, 20);
+    }
+
+    #[test]
+    fn merge_same_hash_different_key_not_merged() {
+        // Hash collision: same hash but different key bytes
+        let entries = vec![
+            make_entry(&[1, 2], 0xAAAA, 10, 100, 100),
+            make_entry(&[3, 4], 0xAAAA, 20, 200, 200),
+        ];
+        let merged = merge_worker_entries(&entries);
+        assert_eq!(merged.len(), 2);
+    }
+
+    #[test]
+    fn merge_empty() {
+        let merged = merge_worker_entries(&[]);
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn merge_saturating_add() {
+        let entries = vec![
+            make_entry(&[1], 0xAA, u64::MAX - 10, u64::MAX, 100),
+            make_entry(&[1], 0xAA, 20, 500, 200),
+        ];
+        let merged = merge_worker_entries(&entries);
+        assert_eq!(merged[0].packets, u64::MAX); // saturating
+        assert_eq!(merged[0].bytes, u64::MAX);
+    }
 }

--- a/src/frontend/src/vapi_stats_client.rs
+++ b/src/frontend/src/vapi_stats_client.rs
@@ -224,6 +224,11 @@ fn merge_worker_entries(entries: &[CollectedEntry]) -> Vec<CollectedEntry> {
             if e.last_update > m.last_update {
                 m.last_update = e.last_update;
             }
+            // generation is identical across workers for the same flow rule
+            // (set at rule-add time), so no merge needed.
+            if e.epoch_ns > m.epoch_ns {
+                m.epoch_ns = e.epoch_ns;
+            }
             m.insert_failed = m.insert_failed.saturating_add(e.insert_failed);
             m.table_full = m.table_full.saturating_add(e.table_full);
         } else {

--- a/src/frontend/src/vapi_stats_client.rs
+++ b/src/frontend/src/vapi_stats_client.rs
@@ -178,14 +178,11 @@ impl VapiStatsClient {
                 epoch_ns: first.epoch_ns,
                 slots,
                 key_arena,
-                insert_failed: merged
-                    .iter()
-                    .map(|e| e.insert_failed)
-                    .fold(0u64, u64::saturating_add),
-                table_full: merged
-                    .iter()
-                    .map(|e| e.table_full)
-                    .fold(0u64, u64::saturating_add),
+                // insert_failed / table_full are table-level snapshot
+                // counters, identical across entries from the same worker.
+                // Use first entry's value (same as any other entry's).
+                insert_failed: first.insert_failed,
+                table_full: first.table_full,
             });
         }
 
@@ -229,8 +226,8 @@ fn merge_worker_entries(entries: &[CollectedEntry]) -> Vec<CollectedEntry> {
             if e.epoch_ns > m.epoch_ns {
                 m.epoch_ns = e.epoch_ns;
             }
-            m.insert_failed = m.insert_failed.saturating_add(e.insert_failed);
-            m.table_full = m.table_full.saturating_add(e.table_full);
+            // insert_failed and table_full are table-level counters, identical
+            // across all entries from the same worker — no per-key merge needed.
         } else {
             let idx = merged.len();
             index_map.insert(identity, idx);


### PR DESCRIPTION
## Summary

Implements the frontend merge logic for per-worker counter tables (#156).

### Problem

With per-worker counter tables, the backend's `snapshot_inline_dump` handler streams slots from **all** worker tables independently. When multiple VPP workers process packets for the same flow, the frontend receives duplicate entries — one per worker — with partial counters.

### Solution

Add `merge_worker_entries()` in the VAPI stats client that groups entries by `(key_hash, key_bytes)` identity and merges:
- **packets/bytes**: saturating sum across workers
- **last_update**: take the maximum

This runs before building the `RawDescriptor`, so the existing decode pipeline sees already-merged data with no changes needed downstream.

### Also included

Fix VAPI FFI build break: `vapi_infmon_flow_rule_{add,del}` signatures changed after API regeneration — now require callback+context args. Pass `NULL, NULL` for blocking mode.

### Tests

- 7 new unit tests for `merge_worker_entries`:
  - No duplicates (passthrough)
  - Two/three workers same key
  - Mixed unique + duplicate keys
  - Hash collision (different keys, same hash — not merged)
  - Empty input
  - Saturating arithmetic at u64::MAX
- All 85 existing tests pass

Closes #156
