### PR TITLE
fix(vpp): republish rules after snapshot_and_clear + add node logging

### DIFF
--- a/src/backend/src/vpp/infmon_api_handlers.c
+++ b/src/backend/src/vpp/infmon_api_handlers.c
@@ -163,7 +163,7 @@ static void vl_api_infmon_flow_rule_add_t_handler(vl_api_infmon_flow_rule_add_t 
     infmon_vpp_api_ctx_ensure();
 
     INFMON_RULE_INFO("vapi: flow_rule_add name='%.*s' fields=%u max_keys=%u",
-                     (int) strnlen(mp->name, sizeof(mp->name)), mp->name,
+                     (int) strnlen((const char *) mp->name, sizeof(mp->name)), mp->name,
                      clib_net_to_host_u32(mp->field_count), clib_net_to_host_u32(mp->max_keys));
     infmon_flow_rule_t rule;
     clib_memset(&rule, 0, sizeof(rule));
@@ -418,6 +418,12 @@ static void vl_api_infmon_snapshot_and_clear_t_handler(vl_api_infmon_snapshot_an
 
     INFMON_CTR_DEBUG("vapi: snapshot_and_clear result=%d rv=%d", (int) result, (int) rv);
 
+    /* After swapping, ctx->tables[][] now holds the fresh table.
+     * Republish so the data-plane (pm->tables) picks up the new pointer;
+     * otherwise workers keep writing to the retired table. */
+    if (result == INFMON_API_OK)
+        infmon_vpp_publish_rules();
+
     REPLY_MACRO2(VL_API_INFMON_SNAPSHOT_AND_CLEAR_REPLY, ({
                      if (result == INFMON_API_OK) {
                          infmon_stats_descriptor_t *desc = &snap_reply.descriptor;
@@ -469,6 +475,10 @@ static void vl_api_infmon_snapshot_inline_dump_t_handler(vl_api_infmon_snapshot_
 
     infmon_api_result_t result =
         infmon_api_snapshot_and_clear(&infmon_vpp_api_ctx, id, &snap_reply);
+
+    /* Republish so the data-plane picks up the fresh table pointer. */
+    if (result == INFMON_API_OK)
+        infmon_vpp_publish_rules();
 
     if (result != INFMON_API_OK || snap_reply.num_retired == 0) {
         INFMON_CTR_DEBUG("vapi: snapshot_inline_dump — empty (result=%d retired=%u)", (int) result,

--- a/src/backend/src/vpp/infmon_log.c
+++ b/src/backend/src/vpp/infmon_log.c
@@ -7,8 +7,10 @@
 
 #ifdef INFMON_VPP_BUILD
 
+// clang-format off
+#include <vlib/vlib.h>  /* must precede vlib/log.h — provides vlib_log_class_t */
 #include <vlib/log.h>
-#include <vlib/vlib.h>
+// clang-format on
 
 vlib_log_class_t infmon_log_general;
 vlib_log_class_t infmon_log_api;

--- a/src/backend/src/vpp/infmon_nodes.c
+++ b/src/backend/src/vpp/infmon_nodes.c
@@ -15,6 +15,7 @@
 
 #ifdef INFMON_VPP_BUILD
 
+#include <inttypes.h>
 #include <vlib/unix/plugin.h>
 #include <vlib/vlib.h>
 #include <vnet/buffer.h>
@@ -24,6 +25,7 @@
 
 #include "infmon/counter_table.h"
 #include "infmon/graph_node.h"
+#include "infmon/log.h"
 
 /* ── VPP plugin registration ─────────────────────────────────────── */
 
@@ -239,6 +241,8 @@ static uword infmon_erspan_decap_node_fn(vlib_main_t *vm, vlib_node_runtime_t *n
     vlib_put_next_frame(vm, node, next_match, n_left_match);
     vlib_put_next_frame(vm, node, next_pass, n_left_pass);
 
+    INFMON_NODE_DEBUG("erspan-decap: processed %u pkts", frame->n_vectors);
+
     return frame->n_vectors;
 }
 
@@ -277,6 +281,9 @@ static uword infmon_flow_match_node_fn(vlib_main_t *vm, vlib_node_runtime_t *nod
     const infmon_flow_rule_set_ref_t *rs = __atomic_load_n(&pm->flow_rule_set, __ATOMIC_ACQUIRE);
     const infmon_flow_rule_t *rules = rs ? rs->rules : NULL;
     uint32_t rule_count = rs ? rs->count : 0;
+
+    INFMON_NODE_DEBUG("flow-match: frame %u pkts, rule_count=%u rs=%p", frame->n_vectors,
+                      rule_count, (void *) rs);
 
     infmon_scratch_reset(&infmon_tls_scratch);
 
@@ -389,6 +396,10 @@ static uword infmon_counter_node_fn(vlib_main_t *vm, vlib_node_runtime_t *node, 
 
     /* Update counters once for the entire scratch vector */
     infmon_counter_update(&infmon_tls_scratch, tables, tick, &insert_retry, &table_full);
+
+    INFMON_NODE_DEBUG("counter: frame %u pkts, worker=%u tick=%" PRIu64 " insert_retry=%" PRIu64
+                      " table_full=%" PRIu64,
+                      frame->n_vectors, worker_id, tick, insert_retry, table_full);
 
     node->errors[INFMON_NODE_ERR_COUNTER_INSERT_RETRY_EXHAUSTED] += insert_retry;
     node->errors[INFMON_NODE_ERR_COUNTER_TABLE_FULL] += table_full;


### PR DESCRIPTION
## Summary

Fix the 0-flow-count bug and add node-level logging to the VPP plugin.

### Bug fix: republish rules after snapshot_and_clear

`snapshot_and_clear` swaps `ctx->tables[][]` to a fresh empty table, but `pm->tables[][]` (the data-plane pointer) still references the retired table. Without calling `infmon_vpp_publish_rules()` afterward, workers keep writing counters to the old table while subsequent snapshots read the empty new one — always returning 0 flows.

Fixed in both `snapshot_and_clear` and `snapshot_inline_dump` VAPI handlers.

### Node-level debug logging

Added `INFMON_NODE_DEBUG` calls to all three data-plane nodes:
- **erspan-decap**: logs packet count per frame
- **flow-match**: logs frame size, rule count, and rule-set pointer
- **counter**: logs frame size, worker ID, tick, insert retries, and table-full events

Enable with: `vppctl set logging class infmon level debug`

### Build fixes

- `infmon_log.c`: `vlib/vlib.h` must be included before `vlib/log.h` (provides `vlib_log_class_t`). Protected with `clang-format off` to prevent re-sorting.
- `infmon_api_handlers.c`: cast `mp->name` to `const char *` for `strnlen` to fix `-Werror=pointer-sign`.

## Testing

- Plugin builds clean with `-Werror`
- Logging verified via `vppctl show log | grep infmon/`
