### PR TITLE
fix(frontend): wire poller snapshots to ControlState for stats show

### DIFF
--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -52,6 +52,14 @@ impl ControlState {
         }
     }
 
+    /// Replace the latest snapshot (called by the snapshot‐forwarding thread).
+    pub fn update_snapshot(&self, snap: Arc<FlowStatsSnapshot>) {
+        *self
+            .latest_snapshot
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(snap);
+    }
+
     /// Create a ControlState with a VAPI control client for backend forwarding.
     #[cfg(feature = "vapi")]
     pub fn with_vapi(initial_rules: Vec<FlowRule>, client: VapiControlClient) -> Self {

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -53,6 +53,9 @@ impl ControlState {
     }
 
     /// Replace the latest snapshot (called by the snapshot‐forwarding thread).
+    ///
+    /// Intentionally recovers from mutex poison (`into_inner()`) — losing a
+    /// snapshot is preferable to panicking on the stats path.
     pub fn update_snapshot(&self, snap: Arc<FlowStatsSnapshot>) {
         *self
             .latest_snapshot

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -12,6 +12,8 @@ use crate::exporter::{
 };
 use crate::poller::{self, PollerConfig, PollerHandle};
 
+use infmon_common::ipc::types::FlowStatsSnapshot;
+
 /// Errors during lifecycle operations.
 #[derive(Debug)]
 pub enum LifecycleError {
@@ -143,13 +145,7 @@ impl Frontend {
             interval: Duration::from_millis(frontend_cfg.polling_interval_ms),
         };
 
-        let raw_senders: Vec<_> = exporter_senders
-            .iter()
-            .map(|s| s.as_raw_sender().clone())
-            .collect();
-        let poller_handle = poller::spawn(poller_config, raw_senders);
-
-        // Spawn control server for CLI RPCs
+        // Spawn control server for CLI RPCs (before poller so we can wire the snapshot channel)
         let control_socket = PathBuf::from(&frontend_cfg.control_socket);
         #[cfg(feature = "vapi")]
         let control_state = {
@@ -166,7 +162,7 @@ impl Frontend {
         };
         #[cfg(not(feature = "vapi"))]
         let control_state = Arc::new(ControlState::new(config.flow_rules.clone()));
-        let control_handle = match control::spawn(&control_socket, control_state) {
+        let control_handle = match control::spawn(&control_socket, control_state.clone()) {
             Ok(h) => {
                 tracing::info!("control server listening on {}", control_socket.display());
                 Some(h)
@@ -176,6 +172,30 @@ impl Frontend {
                 None
             }
         };
+
+        // Create a snapshot channel that forwards to the control state so
+        // `infmonctl stats show` can read the latest counters.
+        let (stats_tx, stats_rx) = std::sync::mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(1);
+        {
+            let cs = control_state.clone();
+            std::thread::Builder::new()
+                .name("snapshot-to-control".into())
+                .spawn(move || {
+                    while let Ok(snap) = stats_rx.recv() {
+                        cs.update_snapshot(snap);
+                    }
+                    tracing::debug!("snapshot-to-control thread exiting");
+                })
+                .expect("failed to spawn snapshot-to-control thread");
+        }
+
+        // Spawn poller with exporter senders + control-state sender
+        let mut raw_senders: Vec<_> = exporter_senders
+            .iter()
+            .map(|s| s.as_raw_sender().clone())
+            .collect();
+        raw_senders.push(stats_tx);
+        let poller_handle = poller::spawn(poller_config, raw_senders);
 
         Ok(Frontend {
             poller_handle: Some(poller_handle),

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -176,20 +176,28 @@ impl Frontend {
         };
 
         // Create a snapshot channel that forwards to the control state so
-        // `infmonctl stats show` can read the latest counters.
+        // `infmonctl stats show` can read the latest counters.  Only useful
+        // when the control server is running — skip if it failed to start.
         // Capacity 1: poller drops stale snapshots via try_send, we only need the latest.
-        let (stats_tx, stats_rx) = std::sync::mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(1);
-        let snapshot_thread = {
+        let (snapshot_thread, stats_tx) = if control_handle.is_some() {
+            let (tx, stats_rx) = std::sync::mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(1);
             let cs = control_state.clone();
-            std::thread::Builder::new()
+            match std::thread::Builder::new()
                 .name("snapshot-to-control".into())
                 .spawn(move || {
                     while let Ok(snap) = stats_rx.recv() {
                         cs.update_snapshot(snap);
                     }
                     tracing::debug!("snapshot-to-control thread exiting");
-                })
-                .expect("failed to spawn snapshot-to-control thread")
+                }) {
+                Ok(h) => (Some(h), Some(tx)),
+                Err(e) => {
+                    tracing::warn!("failed to spawn snapshot-to-control thread: {e}");
+                    (None, None)
+                }
+            }
+        } else {
+            (None, None)
         };
 
         // Spawn poller with exporter senders + control-state sender
@@ -197,7 +205,9 @@ impl Frontend {
             .iter()
             .map(|s| s.as_raw_sender().clone())
             .collect();
-        raw_senders.push(stats_tx);
+        if let Some(tx) = stats_tx {
+            raw_senders.push(tx);
+        }
         let poller_handle = poller::spawn(poller_config, raw_senders);
 
         Ok(Frontend {
@@ -205,7 +215,7 @@ impl Frontend {
             exporter_handles,
             exporter_senders,
             control_handle,
-            snapshot_thread: Some(snapshot_thread),
+            snapshot_thread,
             config_path: config_path.to_path_buf(),
             shutdown,
         })

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 use crate::control::{self, ControlHandle, ControlState};
@@ -49,6 +50,7 @@ pub struct Frontend {
     exporter_handles: Vec<ExporterHandle>,
     exporter_senders: Vec<SnapshotSender>,
     control_handle: Option<ControlHandle>,
+    snapshot_thread: Option<JoinHandle<()>>,
     config_path: PathBuf,
     shutdown: Arc<AtomicBool>,
 }
@@ -175,8 +177,9 @@ impl Frontend {
 
         // Create a snapshot channel that forwards to the control state so
         // `infmonctl stats show` can read the latest counters.
+        // Capacity 1: poller drops stale snapshots via try_send, we only need the latest.
         let (stats_tx, stats_rx) = std::sync::mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(1);
-        {
+        let snapshot_thread = {
             let cs = control_state.clone();
             std::thread::Builder::new()
                 .name("snapshot-to-control".into())
@@ -186,8 +189,8 @@ impl Frontend {
                     }
                     tracing::debug!("snapshot-to-control thread exiting");
                 })
-                .expect("failed to spawn snapshot-to-control thread");
-        }
+                .expect("failed to spawn snapshot-to-control thread")
+        };
 
         // Spawn poller with exporter senders + control-state sender
         let mut raw_senders: Vec<_> = exporter_senders
@@ -202,6 +205,7 @@ impl Frontend {
             exporter_handles,
             exporter_senders,
             control_handle,
+            snapshot_thread: Some(snapshot_thread),
             config_path: config_path.to_path_buf(),
             shutdown,
         })
@@ -243,6 +247,12 @@ impl Frontend {
         if let Some(handle) = self.poller_handle.take() {
             handle.stop();
             tracing::info!("poller stopped");
+        }
+
+        // 1b. Join snapshot-to-control thread (exits when poller drops stats_tx)
+        if let Some(h) = self.snapshot_thread.take() {
+            let _ = h.join();
+            tracing::info!("snapshot-to-control thread joined");
         }
 
         // 2. Close exporter channels (drop senders) so exporters drain


### PR DESCRIPTION
## Problem

`infmonctl stats show` always returns zeros even when VPP nodes are actively processing and counting flows.

**Root cause:** `ControlState.latest_snapshot` is initialized to `None` and never written to. The poller produces `FlowStatsSnapshot` via VAPI `snapshot_inline_dump` every polling interval, but only forwards snapshots to exporter channels (e.g. Kafka, file). The control server — which serves `infmonctl stats show` — reads from `ControlState.latest_snapshot` which stays `None` forever, so it always returns zero counters.

## Fix

- Add `ControlState::update_snapshot()` method to write a new snapshot into the `Mutex<Option<Arc<FlowStatsSnapshot>>>`.
- Create a `sync_channel(1)` whose receiver drives a small `snapshot-to-control` thread that calls `update_snapshot()` on each snapshot.
- Append the sender to the poller's `raw_senders` list so it participates in the existing broadcast mechanism alongside exporters.
- Clone the `control_state` Arc before passing it to the control server so the forwarding thread can share ownership.

## Testing

- `cargo build --release -p infmon-frontend` passes
- Pre-commit hooks (rustfmt, clippy, DCO) pass
