### PR TITLE
feat: add infmonctl stats pull for on-demand snapshot

### DIFF
--- a/src/cli/src/lib.rs
+++ b/src/cli/src/lib.rs
@@ -238,6 +238,8 @@ pub enum StatsCommands {
         #[arg(long)]
         watch: Option<u64>,
     },
+    /// Trigger an immediate snapshot pull from VPP
+    Pull,
     /// Export stats snapshot in a specific format
     Export {
         /// Export format

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -11,7 +11,9 @@ use infmon_cli::{
     StatsCommands,
 };
 use infmon_common::ipc::control_client::InFMonControlClient;
-use infmon_common::ipc::protocol::{FlowRuleData, FlowRuleDetailData, StatsShowData};
+use infmon_common::ipc::protocol::{
+    FlowRuleData, FlowRuleDetailData, StatsPullData, StatsShowData,
+};
 
 fn main() {
     // Handle --generate-completions and --generate-manpage before clap
@@ -715,6 +717,16 @@ async fn run_stats(cmd: &StatsCommands, cli: &Cli) -> i32 {
                 }
             }
         }
+        StatsCommands::Pull => match client.stats_pull().await {
+            Ok(data) => {
+                print_output(&StatsPullOutput(data), &output, cli.compact);
+                EXIT_SUCCESS
+            }
+            Err(e) => {
+                eprintln!("infmonctl: stats pull: {e}");
+                ctl_error_to_exit_code(&e)
+            }
+        },
         StatsCommands::Export { ref format } => {
             let _ = (format, cli);
             eprintln!("infmonctl: stats export: not yet implemented (stub)");
@@ -811,6 +823,26 @@ impl TableDisplay for FlowRuleShowOutput {
 
 #[derive(serde::Serialize)]
 struct StatsShowOutput(StatsShowData);
+
+#[derive(serde::Serialize)]
+struct StatsPullOutput(StatsPullData);
+
+impl TableDisplay for StatsPullOutput {
+    fn print_table(&self) {
+        println!(
+            "Snapshot pulled (tick_id={}, wall_clock_ns={})",
+            self.0.tick_id, self.0.wall_clock_ns
+        );
+        if self.0.flow_rules.is_empty() {
+            println!("No flow rule stats in snapshot.");
+            return;
+        }
+        println!("{:<20} {:>10}", "RULE", "ACTIVE_FLOWS");
+        for r in &self.0.flow_rules {
+            println!("{:<20} {:>10}", r.name, r.active_flows);
+        }
+    }
+}
 
 impl TableDisplay for StatsShowOutput {
     fn print_table(&self) {

--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -833,13 +833,19 @@ impl TableDisplay for StatsPullOutput {
             "Snapshot pulled (tick_id={}, wall_clock_ns={})",
             self.0.tick_id, self.0.wall_clock_ns
         );
-        if self.0.flow_rules.is_empty() {
+        if self.0.stats.flow_rules.is_empty() {
             println!("No flow rule stats in snapshot.");
             return;
         }
-        println!("{:<20} {:>10}", "RULE", "ACTIVE_FLOWS");
-        for r in &self.0.flow_rules {
-            println!("{:<20} {:>10}", r.name, r.active_flows);
+        println!(
+            "{:<20} {:>12} {:>12} {:>10} {:>8} {:>8}",
+            "RULE", "PACKETS", "BYTES", "FLOWS", "EVICT", "DROPS"
+        );
+        for r in &self.0.stats.flow_rules {
+            println!(
+                "{:<20} {:>12} {:>12} {:>10} {:>8} {:>8}",
+                r.name, r.packets, r.bytes, r.active_flows, r.evictions, r.drops
+            );
         }
     }
 }

--- a/src/common/src/ipc/control_client.rs
+++ b/src/common/src/ipc/control_client.rs
@@ -204,6 +204,15 @@ impl InFMonControlClient {
         }
     }
 
+    /// Trigger an immediate snapshot pull from the poller.
+    pub async fn stats_pull(&self) -> Result<StatsPullData, CtlError> {
+        let request = Request::StatsPull;
+        match self.rpc_ok(&request).await? {
+            Some(ResponseData::StatsPull(data)) => Ok(data),
+            _ => Err(CtlError::Protocol("unexpected response data".into())),
+        }
+    }
+
     /// Trigger a config reload on the frontend.
     pub async fn reload(&self) -> Result<(), CtlError> {
         let _ = &self.socket_path;

--- a/src/common/src/ipc/protocol.rs
+++ b/src/common/src/ipc/protocol.rs
@@ -145,7 +145,8 @@ pub struct FlowRuleStatsData {
 pub struct StatsPullData {
     pub tick_id: u64,
     pub wall_clock_ns: u64,
-    pub flow_rules: Vec<FlowRuleStatsData>,
+    #[serde(flatten)]
+    pub stats: StatsShowData,
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────

--- a/src/common/src/ipc/protocol.rs
+++ b/src/common/src/ipc/protocol.rs
@@ -17,6 +17,7 @@ pub enum Request {
     FlowRuleList,
     FlowRuleShow(FlowRuleShowParams),
     StatsShow(StatsShowParams),
+    StatsPull,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -66,6 +67,7 @@ pub enum ResponseData {
     FlowRuleList(FlowRuleListData),
     FlowRuleDetail(FlowRuleDetailData),
     StatsShow(StatsShowData),
+    StatsPull(StatsPullData),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -137,6 +139,13 @@ pub struct FlowRuleStatsData {
     pub evictions: u64,
     pub drops: u64,
     pub active_flows: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatsPullData {
+    pub tick_id: u64,
+    pub wall_clock_ns: u64,
+    pub flow_rules: Vec<FlowRuleStatsData>,
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -532,7 +532,7 @@ fn handle_stats_pull(state: &ControlState) -> Response {
             Response::ok(ResponseData::StatsPull(StatsPullData {
                 tick_id: snapshot.tick_id,
                 wall_clock_ns: snapshot.wall_clock_ns,
-                flow_rules,
+                stats: StatsShowData { flow_rules },
             }))
         }
         Err(_) => Response::err(10, "pull timed out waiting for poller"),

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -493,8 +493,15 @@ fn handle_stats_pull(state: &ControlState) -> Response {
     // Create a one-shot channel for the reply
     let (reply_tx, reply_rx): (PullRequest, _) = std::sync::mpsc::sync_channel(1);
 
-    if pull_tx.try_send(reply_tx).is_err() {
-        return Response::err(9, "poller busy, try again later");
+    if let Err(e) = pull_tx.try_send(reply_tx) {
+        return match e {
+            std::sync::mpsc::TrySendError::Full(_) => {
+                Response::err(9, "poller busy, try again later")
+            }
+            std::sync::mpsc::TrySendError::Disconnected(_) => {
+                Response::err(9, "poller not running")
+            }
+        };
     }
 
     // Wait up to 5s for the poller to respond

--- a/src/frontend/src/control.rs
+++ b/src/frontend/src/control.rs
@@ -12,6 +12,8 @@ use infmon_common::config::model::FlowRule;
 use infmon_common::ipc::protocol::*;
 use infmon_common::ipc::types::FlowStatsSnapshot;
 
+use crate::poller::PullSender;
+
 #[cfg(feature = "vapi")]
 use crate::vapi_control_client::VapiControlClient;
 #[cfg(feature = "vapi")]
@@ -36,6 +38,8 @@ pub struct ControlState {
     /// Maps flow rule name → backend-assigned ID (populated when VAPI is used).
     #[cfg(feature = "vapi")]
     pub rule_id_map: Mutex<HashMap<String, FlowRuleId>>,
+    /// Sender for triggering an on-demand snapshot pull from the poller.
+    pub pull_tx: Option<PullSender>,
 }
 
 impl ControlState {
@@ -49,6 +53,7 @@ impl ControlState {
             vapi_control: None,
             #[cfg(feature = "vapi")]
             rule_id_map: Mutex::new(HashMap::new()),
+            pull_tx: None,
         }
     }
 
@@ -62,6 +67,7 @@ impl ControlState {
             next_rule_id: AtomicU64::new(initial_count + 1),
             vapi_control: Some(Mutex::new(client)),
             rule_id_map: Mutex::new(HashMap::new()),
+            pull_tx: None,
         }
     }
 }
@@ -224,6 +230,7 @@ fn handle_request(req: &Request, state: &ControlState) -> Response {
         Request::FlowRuleList => handle_flow_rule_list(state),
         Request::FlowRuleShow(params) => handle_flow_rule_show(params, state),
         Request::StatsShow(params) => handle_stats_show(params, state),
+        Request::StatsPull => handle_stats_pull(state),
     }
 }
 
@@ -473,4 +480,54 @@ fn handle_stats_show(params: &StatsShowParams, state: &ControlState) -> Response
     Response::ok(ResponseData::StatsShow(StatsShowData {
         flow_rules: flow_rule_stats,
     }))
+}
+
+fn handle_stats_pull(state: &ControlState) -> Response {
+    use crate::poller::PullRequest;
+
+    let pull_tx = match state.pull_tx.as_ref() {
+        Some(tx) => tx,
+        None => return Response::err(8, "stats pull not available (no poller connected)"),
+    };
+
+    // Create a one-shot channel for the reply
+    let (reply_tx, reply_rx): (PullRequest, _) = std::sync::mpsc::sync_channel(1);
+
+    if pull_tx.try_send(reply_tx).is_err() {
+        return Response::err(9, "poller busy, try again later");
+    }
+
+    // Wait up to 5s for the poller to respond
+    match reply_rx.recv_timeout(std::time::Duration::from_secs(5)) {
+        Ok(snapshot) => {
+            // Also update latest_snapshot so subsequent stats show picks it up
+            {
+                let mut latest = state
+                    .latest_snapshot
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                *latest = Some(snapshot.clone());
+            }
+
+            let flow_rules = snapshot
+                .flow_rules
+                .iter()
+                .map(|frs| FlowRuleStatsData {
+                    name: frs.name.clone(),
+                    packets: frs.counters.packets,
+                    bytes: frs.counters.bytes,
+                    evictions: frs.counters.evictions,
+                    drops: frs.counters.drops,
+                    active_flows: frs.flows.len() as u64,
+                })
+                .collect();
+
+            Response::ok(ResponseData::StatsPull(StatsPullData {
+                tick_id: snapshot.tick_id,
+                wall_clock_ns: snapshot.wall_clock_ns,
+                flow_rules,
+            }))
+        }
+        Err(_) => Response::err(10, "pull timed out waiting for poller"),
+    }
 }

--- a/src/frontend/src/lifecycle.rs
+++ b/src/frontend/src/lifecycle.rs
@@ -147,25 +147,37 @@ impl Frontend {
             .iter()
             .map(|s| s.as_raw_sender().clone())
             .collect();
-        let poller_handle = poller::spawn(poller_config, raw_senders);
+
+        // Create pull channel for on-demand snapshot requests
+        let (pull_tx, pull_rx) = std::sync::mpsc::sync_channel(4);
+
+        let poller_handle = poller::spawn(poller_config, raw_senders, pull_rx);
 
         // Spawn control server for CLI RPCs
         let control_socket = PathBuf::from(&frontend_cfg.control_socket);
         #[cfg(feature = "vapi")]
         let control_state = {
-            match crate::vapi_control_client::VapiControlClient::connect("infmon-control") {
+            let mut state = match crate::vapi_control_client::VapiControlClient::connect(
+                "infmon-control",
+            ) {
                 Ok(client) => {
                     tracing::info!("VAPI control client connected — flow-rule CRUD will be forwarded to VPP backend");
-                    Arc::new(ControlState::with_vapi(config.flow_rules.clone(), client))
+                    ControlState::with_vapi(config.flow_rules.clone(), client)
                 }
                 Err(e) => {
                     tracing::warn!("VAPI control client failed to connect: {e} — flow-rule CRUD will be local-only");
-                    Arc::new(ControlState::new(config.flow_rules.clone()))
+                    ControlState::new(config.flow_rules.clone())
                 }
-            }
+            };
+            state.pull_tx = Some(pull_tx);
+            Arc::new(state)
         };
         #[cfg(not(feature = "vapi"))]
-        let control_state = Arc::new(ControlState::new(config.flow_rules.clone()));
+        let control_state = {
+            let mut state = ControlState::new(config.flow_rules.clone());
+            state.pull_tx = Some(pull_tx);
+            Arc::new(state)
+        };
         let control_handle = match control::spawn(&control_socket, control_state) {
             Ok(h) => {
                 tracing::info!("control server listening on {}", control_socket.display());

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -338,12 +338,15 @@ fn run_loop(
             }
         }
 
-        // Service any pending pull requests before sleeping.
-        // Each pull requester gets the same snapshot we just produced
-        // (or a fresh one if no tick happened this iteration).
+        // Drain all pending pull requests, then service them with a
+        // single snapshot so concurrent requesters see consistent
+        // counters (snapshot_and_clear resets VPP counters, so
+        // per-request snapshots would give near-zero to later ones).
+        let mut pull_waiters = Vec::new();
         while let Ok(reply_tx) = pull_rx.try_recv() {
-            // If we already have a snapshot from this tick, reuse it.
-            // Otherwise perform an ad-hoc snapshot.
+            pull_waiters.push(reply_tx);
+        }
+        if !pull_waiters.is_empty() {
             if let Some(c) = client.as_ref() {
                 match c.snapshot_and_clear() {
                     Ok(raw) => {
@@ -354,7 +357,9 @@ fn run_loop(
                         prev_mono = mono;
                         let snap = Arc::new(snapshot);
 
-                        // Fan out to exporters as well
+                        // Fan out to exporters — intentional: a pull
+                        // triggers an export cycle so dashboards stay
+                        // current even between regular polling ticks.
                         for (i, tx) in senders.iter().enumerate() {
                             if tx.try_send(snap.clone()).is_err() {
                                 tracing::warn!(
@@ -365,11 +370,16 @@ fn run_loop(
                             }
                         }
 
-                        let _ = reply_tx.send(snap);
+                        for waiter in &pull_waiters {
+                            let _ = waiter.send(snap.clone());
+                        }
                     }
                     Err(e) => {
-                        tracing::warn!("pull snapshot_and_clear failed: {e}");
-                        // Don't reply — the requester will time out
+                        tracing::warn!(
+                            "pull snapshot_and_clear failed: {e} — \
+                             {} pull requester(s) will time out",
+                            pull_waiters.len()
+                        );
                     }
                 }
             }

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -22,6 +22,14 @@ use crate::vapi_stats_client::VapiStatsClient;
 /// Sender half that exporter threads receive snapshots through.
 pub type SnapshotSender = std::sync::mpsc::SyncSender<Arc<FlowStatsSnapshot>>;
 
+/// A one-shot pull request: the control server sends this to the poller,
+/// which performs an immediate snapshot and sends the result back.
+pub type PullRequest = std::sync::mpsc::SyncSender<Arc<FlowStatsSnapshot>>;
+/// Receiver for pull requests (held by the poller thread).
+pub type PullReceiver = std::sync::mpsc::Receiver<PullRequest>;
+/// Sender for pull requests (held by ControlState).
+pub type PullSender = std::sync::mpsc::SyncSender<PullRequest>;
+
 /// Configuration for the poller thread.
 #[derive(Debug, Clone)]
 pub struct PollerConfig {
@@ -73,14 +81,18 @@ impl Drop for PollerHandle {
 /// `senders` are bounded channels to each registered exporter. The
 /// poller will try to send to every exporter; if a channel is full the
 /// snapshot is dropped for that exporter (backpressure, §7 of spec).
-pub fn spawn(config: PollerConfig, senders: Vec<SnapshotSender>) -> PollerHandle {
+pub fn spawn(
+    config: PollerConfig,
+    senders: Vec<SnapshotSender>,
+    pull_rx: PullReceiver,
+) -> PollerHandle {
     let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let stop2 = stop.clone();
 
     let join = thread::Builder::new()
         .name("poller".into())
         .spawn(move || {
-            run_loop(&config, &senders, &stop2);
+            run_loop(&config, &senders, &pull_rx, &stop2);
         })
         .expect("failed to spawn poller thread");
 
@@ -268,6 +280,7 @@ fn decode_snapshot(
 fn run_loop(
     config: &PollerConfig,
     senders: &[SnapshotSender],
+    pull_rx: &PullReceiver,
     stop: &std::sync::atomic::AtomicBool,
 ) {
     let mut client: Option<VapiStatsClient> = None;
@@ -325,6 +338,43 @@ fn run_loop(
             }
         }
 
+        // Service any pending pull requests before sleeping.
+        // Each pull requester gets the same snapshot we just produced
+        // (or a fresh one if no tick happened this iteration).
+        while let Ok(reply_tx) = pull_rx.try_recv() {
+            // If we already have a snapshot from this tick, reuse it.
+            // Otherwise perform an ad-hoc snapshot.
+            if let Some(c) = client.as_ref() {
+                match c.snapshot_and_clear() {
+                    Ok(raw) => {
+                        tick_id += 1;
+                        let wall = wall_clock_ns();
+                        let mono = monotonic_ns();
+                        let snapshot = decode_snapshot(raw, tick_id, wall, mono, prev_mono);
+                        prev_mono = mono;
+                        let snap = Arc::new(snapshot);
+
+                        // Fan out to exporters as well
+                        for (i, tx) in senders.iter().enumerate() {
+                            if tx.try_send(snap.clone()).is_err() {
+                                tracing::warn!(
+                                    "exporter {} channel full, dropping pull snapshot (tick {})",
+                                    i,
+                                    tick_id
+                                );
+                            }
+                        }
+
+                        let _ = reply_tx.send(snap);
+                    }
+                    Err(e) => {
+                        tracing::warn!("pull snapshot_and_clear failed: {e}");
+                        // Don't reply — the requester will time out
+                    }
+                }
+            }
+        }
+
         let elapsed = Duration::from_nanos(monotonic_ns().saturating_sub(tick_start));
         if let Some(remaining) = config.interval.checked_sub(elapsed) {
             sleep_interruptible(remaining, stop);
@@ -339,6 +389,7 @@ fn run_loop(
 fn run_loop(
     _config: &PollerConfig,
     _senders: &[SnapshotSender],
+    _pull_rx: &PullReceiver,
     stop: &std::sync::atomic::AtomicBool,
 ) {
     tracing::warn!("VAPI not available — poller will idle");

--- a/src/frontend/src/poller.rs
+++ b/src/frontend/src/poller.rs
@@ -382,6 +382,11 @@ fn run_loop(
                         );
                     }
                 }
+            } else {
+                tracing::warn!(
+                    "VAPI not connected — {} pull requester(s) will time out",
+                    pull_waiters.len()
+                );
             }
         }
 

--- a/src/frontend/src/poller_tests.rs
+++ b/src/frontend/src/poller_tests.rs
@@ -1,6 +1,11 @@
 use super::*;
 use std::sync::mpsc;
 
+fn dummy_pull_rx() -> super::PullReceiver {
+    let (_tx, rx) = std::sync::mpsc::sync_channel(1);
+    rx
+}
+
 #[test]
 fn decode_empty_raw_snapshot() {
     let raw = infmon_common::ipc::stats_client::RawSnapshot {
@@ -31,7 +36,7 @@ fn poller_stops_immediately() {
         interval: Duration::from_millis(100),
     };
     let (tx, _rx) = mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(2);
-    let handle = spawn(config, vec![tx]);
+    let handle = spawn(config, vec![tx], dummy_pull_rx());
 
     // Give it a moment to start, then stop.
     thread::sleep(Duration::from_millis(150));
@@ -53,7 +58,7 @@ fn poller_sends_snapshots_on_real_segment() {
         interval: Duration::from_millis(50),
     };
     let (tx, rx) = mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(8);
-    let handle = spawn(config, vec![tx]);
+    let handle = spawn(config, vec![tx], dummy_pull_rx());
 
     // Wait for a few ticks.
     thread::sleep(Duration::from_millis(200));
@@ -85,7 +90,7 @@ fn backpressure_drops_snapshots() {
         interval: Duration::from_millis(20),
     };
     let (tx, rx) = mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(1);
-    let handle = spawn(config, vec![tx]);
+    let handle = spawn(config, vec![tx], dummy_pull_rx());
 
     // Don't consume — let the channel fill up.
     thread::sleep(Duration::from_millis(200));
@@ -121,7 +126,7 @@ fn poller_handle_drop_stops_thread() {
     };
     let (tx, _rx) = mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(2);
     // Dropping handle should stop the thread cleanly
-    let handle = spawn(config, vec![tx]);
+    let handle = spawn(config, vec![tx], dummy_pull_rx());
     drop(handle);
 }
 
@@ -132,7 +137,7 @@ fn poller_with_no_senders() {
         stats_socket: PathBuf::from("/tmp/nonexistent-infmon-no-senders-test.sock"),
         interval: Duration::from_millis(100),
     };
-    let handle = spawn(config, vec![]);
+    let handle = spawn(config, vec![], dummy_pull_rx());
     thread::sleep(Duration::from_millis(150));
     handle.stop();
 }
@@ -146,7 +151,7 @@ fn poller_with_multiple_senders() {
     };
     let (tx1, _rx1) = mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(2);
     let (tx2, _rx2) = mpsc::sync_channel::<Arc<FlowStatsSnapshot>>(2);
-    let handle = spawn(config, vec![tx1, tx2]);
+    let handle = spawn(config, vec![tx1, tx2], dummy_pull_rx());
     thread::sleep(Duration::from_millis(150));
     handle.stop();
 }


### PR DESCRIPTION
## Summary

Add `infmonctl stats pull` command that triggers an immediate snapshot pull from the VPP backend, bypassing the regular 1Hz polling interval.

## Design

- **Protocol**: New `StatsPull` request/response variant in the IPC protocol, with `StatsPullData` containing `tick_id`, `wall_clock_ns`, and per-rule flow stats.
- **Poller**: Accepts `PullRequest` (a one-shot reply channel) via a bounded `sync_channel(4)`. On each tick iteration, drains pending requests and performs `snapshot_and_clear` for each, fanning out to exporters as well.
- **Control server**: `handle_stats_pull` sends the one-shot channel to the poller and blocks up to 5s for the reply. Also updates `latest_snapshot` so subsequent `stats show` reflects the pulled data.
- **CLI**: `infmonctl stats pull` with table and JSON output formats.

## Testing

- All existing tests pass (poller tests updated with `dummy_pull_rx()`).
- `cargo fmt` + `cargo clippy` clean.
