### PR TITLE
fix(e2e): use stats pull instead of stats show to get fresh counters

### DIFF
--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -64,8 +64,9 @@ def flow_rule_list() -> List[Dict[str, Any]]:
         parsed = _parse_json_output(result)
         if isinstance(parsed, list):
             return parsed
-    # Fallback: extract rule metadata from stats output
-    result = _run_infmonctl("stats", "show", "--json", check=False)
+    # Fallback: extract rule metadata from stats pull output (forces a
+    # fresh snapshot from VPP, avoiding the stale-cache / 0-counter issue).
+    result = _run_infmonctl("stats", "pull", "--json", check=False)
     if result.returncode != 0:
         return []
     parsed = _parse_json_output(result)
@@ -75,8 +76,12 @@ def flow_rule_list() -> List[Dict[str, Any]]:
 
 
 def get_flow_stats(rule_name: str) -> Optional[Dict[str, Any]]:
-    """Get flow statistics for a specific rule, returning parsed JSON."""
-    result = _run_infmonctl("stats", "show", "--json", check=False)
+    """Get flow statistics for a specific rule, returning parsed JSON.
+
+    Uses ``stats pull`` which forces a fresh snapshot from VPP, avoiding
+    the stale-cache / 0-counter issue that affects ``stats show``.
+    """
+    result = _run_infmonctl("stats", "pull", "--json", check=False)
     if result.returncode != 0:
         return None
     parsed = _parse_json_output(result)


### PR DESCRIPTION
## Summary

Switch e2e test helpers from `stats show` to `stats pull` to fix the 0-counter issue.

### Problem
The e2e tests used `infmonctl stats show` which reads from a cached snapshot that may not yet be populated after traffic replay, resulting in 0 flow counters and test failures.

### Fix
Replace `stats show` with `stats pull` in both `get_flow_stats()` and the `flow_rule_list()` fallback path. The `pull` command forces an immediate snapshot from VPP, ensuring fresh and accurate counter values.

### Changes
- `tests/e2e/helpers.py`: `get_flow_stats()` → use `stats pull --json`
- `tests/e2e/helpers.py`: `flow_rule_list()` fallback → use `stats pull --json`

Depends on: #167